### PR TITLE
pod annotations added

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -15,6 +15,11 @@ spec:
     metadata:
       labels:
         app: cost-analyzer
+{{- if .Values.podAnnotations}}
+       annotations:
+{{- with .Values.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       restartPolicy: Always
       serviceAccountName: {{ template "cost-analyzer.fullname" . }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: cost-analyzer
 {{- if .Values.podAnnotations}}
-       annotations:
+      annotations:
 {{- with .Values.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -15,10 +15,11 @@ spec:
     metadata:
       labels:
         app: cost-analyzer
-{{- if .Values.podAnnotations}}
+{{- if .Values.global.podAnnotations}}
       annotations:
-{{- with .Values.podAnnotations }}
+{{- with .Values.global.podAnnotations }}
 {{ toYaml . | indent 8 }}
+{{- end }}
 {{- end }}
     spec:
       restartPolicy: Always

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -12,3 +12,6 @@ global:
     alertmanager: # Supply an alertmanager FQDN to receive notifications from the app.
       enabled: false # Allow kubecost to write to your alertmanager
       fqdn: http://cost-analyzer-prometheus-server.default.svc.cluster.local #example fqdn. Ignored if prometheus.enabled: true
+  podAnnotations: {
+    #  iam.amazonaws.com/role: role-arn
+  }

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -12,6 +12,5 @@ global:
     alertmanager: # Supply an alertmanager FQDN to receive notifications from the app.
       enabled: false # Allow kubecost to write to your alertmanager
       fqdn: http://cost-analyzer-prometheus-server.default.svc.cluster.local #example fqdn. Ignored if prometheus.enabled: true
-  podAnnotations: {
-    #  iam.amazonaws.com/role: role-arn
-  }
+  podAnnotations: {}
+    # iam.amazonaws.com/role: role-arn


### PR DESCRIPTION
## what
* add support for pod annotations added

## why
* pod annotations are used for specifying extra metadata needed by other controllers, like `kiam`