### PR TITLE
remove imagepullsecrets, no one is using it today

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -111,5 +111,3 @@ spec:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: kubecost-token
           imagePullPolicy: Always
-      imagePullSecrets:
-        - name: regcred


### PR DESCRIPTION
Fix #26 . Just remove imagepullsecrets, as I believe no one is using them today.