### PR TITLE
Support for Prometheus operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ Parameter | Description | Default
 `ingress.hosts` | Ingress hostnames | `[cost-analyzer.local]`
 `ingress.tls` | Ingress TLS configuration (YAML) | `[]`
 `networkPolicy.enabled` | If true, create a NetworkPolicy to deny egress  | `false`
+`serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
+`serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
+`prometheusRule.enabled` | Set this to `true` to create PrometheusRule for Prometheus operator | `false`
+`prometheusRule.additionalLabels` | Additional labels that can be used so PrometheusRule will be discovered by Prometheus | `{}`
+`grafana.sidecar.datasources.defaultDatasourceEnabled` | Set this to `false` to disable creation of Prometheus datasource in Grafana | `true`

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -51,3 +51,11 @@ helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Create the selector labels.
+*/}}
+{{- define "cost-analyzer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cost-analyzer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -50,6 +50,7 @@ app.kubernetes.io/name: {{ include "cost-analyzer.name" . }}
 helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app: cost-analyzer
 {{- end -}}
 
 {{/*

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        app: cost-analyzer
+        {{ include "cost-analyzer.selectorLabels" . | nindent 8 }}
 {{- if .Values.global.podAnnotations}}
       annotations:
 {{- with .Values.global.podAnnotations }}

--- a/cost-analyzer/templates/cost-analyzer-network-policy.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-policy.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: cost-analyzer
+      {{ include "cost-analyzer.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Egress
   egress:

--- a/cost-analyzer/templates/cost-analyzer-prometheusrule-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-prometheusrule-template.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.prometheus }}
+{{- if .Values.prometheus.serverFiles }}
+{{- if .Values.prometheus.serverFiles.rules }}
+{{- if .Values.prometheusRule }}
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "cost-analyzer.fullname" . }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- if .Values.prometheusRule.additionalLabels }}
+    {{ toYaml .Values.prometheusRule.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  {{ toYaml .Values.prometheus.serverFiles.rules | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   selector:
-    app: cost-analyzer
+    {{ include "cost-analyzer.selectorLabels" . | nindent 4 }}
 {{- if .Values.service -}}
 {{- if .Values.service.type }}
   type: "{{ .Values.service.type }}"

--- a/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.serviceMonitor }}
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cost-analyzer.fullname" . }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{ toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: model
+      honorLabels: true
+      interval: 1m
+      scrapeTimeout: 10s
+      path: /metrics
+      scheme: http
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{ include "cost-analyzer.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/grafana-datasource-template.yaml
+++ b/cost-analyzer/templates/grafana-datasource-template.yaml
@@ -2,12 +2,14 @@
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.datasources -}}
 {{- if .Values.grafana.sidecar.datasources.enabled -}}
+{{- if .Values.grafana.sidecar.datasources.defaultDatasourceEnabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-datasource
   labels:
-     grafana_datasource: "1"
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    grafana_datasource: "1"
 data:
   datasource.yaml: |-
     # config file version
@@ -21,6 +23,7 @@ data:
       url: http://{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace  }}.svc.cluster.local
 {{ else }}
       url: {{ .Values.global.prometheus.fqdn }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -94,9 +94,19 @@ prometheus:
               record: cluster:cpu_usage:rate5m
             - expr: rate(container_cpu_usage_seconds_total{container_name!=""}[5m])
               record: cluster:cpu_usage_nosum:rate5m
+
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+
+prometheusRule:
+  enabled: false
+  additionalLabels: {}
+
 grafana:
   sidecar:
     dashboards:
       enabled: true 
     datasources:
       enabled: true
+      defaultDatasourceEnabled: true


### PR DESCRIPTION
Fix #48 

I add a way to disable the creation of the Prometheus datasource in Grafana because it's yet done by the Prometheus Operator helm chart.

I also add an helper for the labels used in selectors in different resources.

I tried to reuse the things defined in values.yaml. It works fine for rules as i can reuse  `.Values.prometheus.serverFiles.rules` but it's not possible to do the same thing for the scraping part as `.Values.prometheus.extraScrapeConfigs` is a string and not structured data and i can not see a way to convert that string to a Go structure