### PR TITLE
Ajay tripathy fix customname

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -9,11 +9,11 @@ data:
     gzip_static  on;
 
     upstream api {
-        server {{ template "cost-analyzer.fullname" . }}.{{ .Release.Namespace }}:9001;
+        server kubecost-cost-analyzer.{{ .Release.Namespace }}:9001;
     }
 
     upstream model {
-        server {{ template "cost-analyzer.fullname" . }}.{{ .Release.Namespace }}:9003;
+        server kubecost-cost-analyzer.{{ .Release.Namespace }}:9003;
     }
 
 {{- if .Values.global.grafana.proxy }}

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ template "cost-analyzer.fullname" . }}
+  name: kubecost-cost-analyzer
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2,7 +2,7 @@ global:
 
   prometheus:
     enabled: true # If false, Prometheus will not be installed
-    fqdn: http://byo-prometheus-server.monitoring.svc.cluster.local #example fqdn. Ignored if enabled: true
+    fqdn: http://cost-analyzer-prometheus-server.default.svc.cluster.local #example fqdn. Ignored if enabled: true
 
   grafana:
     enabled: true # If false, Grafana will not be installed

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2,7 +2,7 @@ global:
 
   prometheus:
     enabled: true # If false, Prometheus will not be installed
-    fqdn: http://cost-analyzer-prometheus-server.default.svc.cluster.local #example fqdn. Ignored if enabled: true
+    fqdn: http://byo-prometheus-server.monitoring.svc.cluster.local #example fqdn. Ignored if enabled: true
 
   grafana:
     enabled: true # If false, Grafana will not be installed


### PR DESCRIPTION
changing the --name parameter from 'kubecost' to something else was previously broken because of the way we do service discovery of our prometheus. This should fix that.