### PR TITLE
fix: the service name should be based on the release name

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -24,6 +24,10 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{- define "cost-analyzer.serviceName" -}}
+{{- printf "%s-%s" .Release.Name "cost-analyzer" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1,3 +1,4 @@
+{{- $serviceName := include "cost-analyzer.serviceName" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,11 +10,11 @@ data:
     gzip_static  on;
 
     upstream api {
-        server kubecost-cost-analyzer.{{ .Release.Namespace }}:9001;
+        server {{ $serviceName }}.{{ .Release.Namespace }}:9001;
     }
 
     upstream model {
-        server kubecost-cost-analyzer.{{ .Release.Namespace }}:9003;
+        server {{ $serviceName }}.{{ .Release.Namespace }}:9003;
     }
 
 {{- if .Values.global.grafana.proxy }}
@@ -41,7 +42,7 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location /model/ {       	
+        location /model/ {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;

--- a/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cost-analyzer.fullname" . -}}
+{{- $serviceName := include "cost-analyzer.serviceName" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -31,7 +32,7 @@ spec:
 	{{- range $ingressPaths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: {{ $serviceName }}
               servicePort: frontend
 	{{- end }}
   {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: kubecost-cost-analyzer
+  name: {{ template "cost-analyzer.serviceName" . }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -9,7 +9,7 @@ global:
     domainName: cost-analyzer-grafana.default.svc.cluster.local #example grafana domain Ignored if enabled: true
     scheme: "http" # http or https, for the domain name above.
     proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
-    
+
   notifications:
     slack: # Write to a webhook.
       enabled: false # Allow kubecost to write to your slackbot.
@@ -47,7 +47,7 @@ kubecostInit:
 
 ingress:
   enabled: false
-  annotations: 
+  annotations:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   paths: ["/"] # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing
@@ -80,7 +80,7 @@ prometheus:
       scheme: http
       dns_sd_configs:
       - names:
-        - kubecost-cost-analyzer
+        - {{ template "cost-analyzer.serviceName" . }}
         type: 'A'
         port: 9003
   server:
@@ -116,7 +116,7 @@ supportNFS: true
 grafana:
   sidecar:
     dashboards:
-      enabled: true 
+      enabled: true
     datasources:
       enabled: true
       defaultDatasourceEnabled: true


### PR DESCRIPTION
In order to generate the scrape config for prometheus, we need to have a
well-known service name, however there's a limitation on Helm where you can't
access variables from the parent context, so we cannot know what the actual
chart name is.

Prefixing a hard-coded service name with the release name is a middle-ground
compromise which should still allow for multiple kubecost installations if
desired.

Fixes #83