### PR TITLE
parametrise resources

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.40.0"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer
-version: 1.40.0
+version: 1.41.0

--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -21,7 +21,7 @@ spec:
             - node
             - ./node/cron.js
             resources:
-{{ toYaml .Values.kubecostFrontend.resources | indent 14 }}
+{{ toYaml .Values.kubecostChecks.resources | indent 14 }}
             env:
             - name: COST_ANALYZER_SERVER_ENDPOINT
               value: {{ template "cost-analyzer.fullname" . }}.{{ .Release.Namespace  }}.svc.cluster.local:9001

--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -21,12 +21,7 @@ spec:
             - node
             - ./node/cron.js
             resources:
-              requests:
-                cpu: "20m"
-                memory: "100Mi"
-              limits:
-                cpu: "100m"
-                memory: "200Mi"
+{{ toYaml .Values.kubecostFrontend.resources | indent 14 }}
             env:
             - name: COST_ANALYZER_SERVER_ENDPOINT
               value: {{ template "cost-analyzer.fullname" . }}.{{ .Release.Namespace  }}.svc.cluster.local:9001

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -84,16 +84,7 @@ spec:
             - name: nginx-conf
               mountPath: /etc/nginx/conf.d/
           resources:
-            requests:
-              cpu: "10m"
-              memory: "55Mi"
-            {{- if .Values.kubecostFrontend }}
-            {{- if .Values.kubecostFrontend.limits }}
-            limits:
-              cpu: {{ .Values.kubecostFrontend.limits.cpu }}
-              memory: {{ .Values.kubecostFrontend.limits.memory }}
-            {{ end }}
-            {{ end }}
+{{ toYaml .Values.kubecostFrontend.resources | indent 12 }}
           imagePullPolicy: Always
           readinessProbe:
             httpGet:
@@ -108,16 +99,7 @@ spec:
         - image: ajaytripathy/kubecost:prod-{{ $.Chart.AppVersion }}
         {{ end }}
           resources:
-            requests:
-              cpu: "100m"
-              memory: "55Mi"
-            {{- if .Values.kubecost }}
-            {{- if .Values.kubecost.limits }}
-            limits:
-              cpu: {{ .Values.kubecost.limits.cpu }}
-              memory: {{ .Values.kubecost.limits.memory }}
-            {{ end }}
-            {{ end }}
+{{ toYaml .Values.kubecost.resources | indent 12 }}
           name: cost-analyzer-server
           readinessProbe:
             httpGet:
@@ -157,16 +139,7 @@ spec:
           name: cost-model
           imagePullPolicy: Always
           resources:
-            requests:
-              cpu: "200m"
-              memory: "55Mi"
-            {{- if .Values.kubecostModel }}
-            {{- if .Values.kubecostModel.limits }}
-            limits:
-              cpu: {{ .Values.kubecostModel.limits.cpu }}
-              memory: {{ .Values.kubecostModel.limits.memory }}
-            {{ end }}
-            {{ end }}
+{{ toYaml .Values.kubecostModel.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -23,24 +23,43 @@ global:
 
 kubecostChecks:
   image: "ajaytripathy/kubecost-checks"
+  resources:
+    requests:
+      cpu: "20m"
+      memory: "100Mi"
+    limits:
+      cpu: "100m"
+      memory: "200Mi"
 
 kubecostFrontend:
   image: "ajaytripathy/kubecost-frontend"
-  #limits:
-  #  cpu: "100m"
-  #  memory: "256Mi"
+  resources:
+    requests:
+      cpu: "10m"
+      memory: "55Mi"
+    #limits:
+    #  cpu: "100m"
+    #  memory: "256Mi"
 
 kubecost:
   image: "ajaytripathy/kubecost"
-  #limits:
-  #  cpu: "100m"
-  #  memory: "256Mi"
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "55Mi"
+    #limits:
+    #  cpu: "100m"
+    #  memory: "256Mi"
 
 kubecostModel:
   image: "ajaytripathy/kubecost-cost-model"
-  #limits:
-  #  cpu: "800m"
-  #  memory: "256Mi"
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "55Mi"
+    #limits:
+    #  cpu: "800m"
+    #  memory: "256Mi"
 
 kubecostInit:
   image: "ajaytripathy/kubecost-init"


### PR DESCRIPTION
In our case, if not limited, kubecost has CPU usage very high. We would like to reserve such CPU usage for the application, but at the moment it's impossible as it's hardcoded