### PR TITLE
Network Costs Configuration

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.networkCosts -}}
+{{- if .Values.networkCosts.enabled -}}
+{{- if .Values.networkCosts.config -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-costs-config
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  config.yaml: |
+{{- toYaml .Values.networkCosts.config | nindent 4 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -41,6 +41,10 @@ spec:
           name: nf-conntrack
         - mountPath: /netfilter
           name: netfilter
+        {{- if .Values.networkCosts.config }}
+        - mountPath: /network-costs/config
+          name: network-costs-config
+        {{- end }}
         securityContext:
           privileged: true
         ports:
@@ -48,6 +52,11 @@ spec:
           containerPort: 3001
           hostPort: 3001
       volumes:
+      {{- if .Values.networkCosts.config }}
+      - name: network-costs-config
+        configMap:
+          name: network-costs-config
+      {{- end }}
       - name: nf-conntrack
         hostPath: 
           path: /proc/net

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -176,12 +176,23 @@ prometheus:
 
 networkCosts:
   enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v6
+  image: gcr.io/kubecost1/kubecost-network-costs:v7
   imagePullPolicy: Always
   resources:
     #requests:
     #  cpu: "50m"
     #  memory: "20Mi"
+  config:
+    # White Listed from Egress Reporting
+    # Accepts both static IPs and CIDR block
+    whiteList:
+      - "127.0.0.1"
+      # IPv4 Link Local Address Space
+      - "169.254.0.0/16"
+      # Private Address Ranges in RFC-1918
+      - "10.0.0.0/8"
+      - "172.16.0.0/12"
+      - "192.168.0.0/16"
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
Upgrading to v7 with or without a config:
- It is still possible to update to network-costs v7 without using a config. The network-costs app will supply a default configuration should a config not exist. 