### PR TITLE
Fix for breaking changes in kubernetes API v1.16

### DIFF
--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -12766,7 +12766,7 @@ spec:
             path: /sys
 ---
 # Source: cost-analyzer/charts/grafana/templates/deployment.yaml
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubecost-grafana


### PR DESCRIPTION
see https://kubernetes.io/blog/2019/09/18/kubernetes-1-16-release-announcement/

"in 1.16 if you submit a Deployment to the API server and specify extensions/v1beta1 as the API group it will be rejected with:
error: unable to recognize "deployment": no matches for kind "Deployment" in version "extensions/v1beta1"