### PR TITLE
Allow users to create the service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Kubecost helm chart
 Helm chart for the Kubecost project, which is created to monitor and manage Kubernetes resource spend. Please contact team@kubecost.com or visit [kubecost.com](http://kubecost.com) for more info.
 
-While Helm is the [recommended install path](http://kubecost.com/install), these resources can also be deployed with the following command:<a name="manifest"></a> 
-  
+While Helm is the [recommended install path](http://kubecost.com/install), these resources can also be deployed with the following command:<a name="manifest"></a>
+
 `kubectl apply -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/master/kubecost.yaml --namespace kubecost`
 
 <a name="config-options"></a><br/>
@@ -33,3 +33,4 @@ Parameter | Description | Default
 `prometheusRule.enabled` | Set this to `true` to create PrometheusRule for Prometheus operator | `false`
 `prometheusRule.additionalLabels` | Additional labels that can be used so PrometheusRule will be discovered by Prometheus | `{}`
 `grafana.sidecar.datasources.defaultDatasourceEnabled` | Set this to `false` to disable creation of Prometheus datasource in Grafana | `true`
+`serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`

--- a/cost-analyzer/templates/cost-analyzer-service-account-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-account-template.yaml
@@ -1,6 +1,8 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -99,7 +99,7 @@ service:
   type: ClusterIP
 
 remoteWrite:
-  postgres: 
+  postgres:
     enabled: false
     initImage: "ajaytripathy/kubecost-sql-init"
     initImagePullPolicy: Always
@@ -211,3 +211,6 @@ grafana:
     datasources:
       enabled: true
       defaultDatasourceEnabled: true
+
+serviceAccount:
+  create: true


### PR DESCRIPTION
Allowing the users to create the service account on their own helps to use EKS feature to map the [IAM roles with service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)