### PR TITLE
Thanos Optimizations

### DIFF
--- a/cost-analyzer/charts/thanos/templates/query-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-deployment.yaml
@@ -47,6 +47,8 @@ spec:
         - "--log.level={{ .Values.query.logLevel }}"
         - "--grpc-address=0.0.0.0:{{ .Values.query.grpc.port }}"
         - "--http-address=0.0.0.0:{{ .Values.query.http.port }}"
+        - "--query.timeout={{ .Values.query.timeout }}"
+        - "--query.max-concurrent={{ .Values.query.maxConcurrent }}"
         {{- if .Values.query.replicaLabel }}
         - "--query.replica-label={{ .Values.query.replicaLabel }}"
         {{- end }}

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -156,6 +156,11 @@ query:
   # can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the
   # stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path
   webPrefixHeader: ""
+  # Maximum time to process query by query node.
+  timeout: 2m
+  # Maximum number of queries processed
+  # concurrently by query node.
+  maxConcurrent: 20
   # https://github.com/improbable-eng/thanos/issues/1015
   storeDNSResolver: miekgdns
   # Enable DNS discovery for stores

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -51,11 +51,15 @@ prometheus:
 thanos:
   store:
     enabled: true
+    grpcSeriesMaxConcurrency: 1
+    blockSyncConcurrency: 1
     resources: 
       requests:
-        memory: "2Gi"
+        memory: "2.5Gi"
   query: 
     enabled: true
+    timeout: 3m
+    maxConcurrent: 10
   # Thanos Sidecar Service Discovery
   sidecar:
     enabled: true


### PR DESCRIPTION
Based on observations of memory spiking occurring on `thanos-store`, we decided to test reducing concurrency to `1` in order to force each query to be processed serially in the hopes that would honor memory configuration values. Based on multiple concurrent requests through the cost-model product, we were able to show that using higher concurrency values (ie: 20) yielded much higher spikes in memory (well beyond configured values), while a single threaded approach sat well below the configured limits. 

Additionally, given the nature of cost-model queries containing many time series, we reduced the number of concurrent requests allowed to be made from `thanos-query`. This can be tuned depending on datasets, but prevents memory bloat from aggregating in `thanos-query`.

* Expose thanos-query maxConcurrent and timeout configuration options
* Increase memory requests to be inline with default thanos-store cache-pool-size + index-cache-size 
* Reduce block sync concurrency and grpc series concurrency to prevent bloating memory usage from well exceeding the configured limitations.