### PR TITLE
networkcosts - add ability to have tolerations on the ds

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.50.2"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer
-version: 1.50.2
+version: 1.50.3

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -51,6 +51,9 @@ spec:
         - name: http-server
           containerPort: 3001
           hostPort: 3001
+{{- if .Values.networkCosts.priorityClassName }}
+      priorityClassName: "{{ .Values.networkCosts.priorityClassName }}"
+{{- end }}
 {{- if .Values.networkCosts.tolerations }}
       tolerations:
 {{ toYaml .Values.networkCosts.tolerations | indent 8 }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -53,7 +53,7 @@ spec:
           hostPort: 3001
 {{- if .Values.networkCosts.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.networkCosts.tolerations | indent 8 }}
     {{- end }}
       volumes:
       {{- if .Values.networkCosts.config }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -51,6 +51,10 @@ spec:
         - name: http-server
           containerPort: 3001
           hostPort: 3001
+{{- if .Values.networkCosts.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
       volumes:
       {{- if .Values.networkCosts.config }}
       - name: network-costs-config
@@ -58,7 +62,7 @@ spec:
           name: network-costs-config
       {{- end }}
       - name: nf-conntrack
-        hostPath: 
+        hostPath:
           path: /proc/net
       - name: netfilter
         hostPath:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1,12 +1,12 @@
 global:
   # zone: cluster.local (use only if your DNS server doesn't live in the same zone as kubecost)
   prometheus:
-    enabled: true # If false, Prometheus will not be installed -- only actively supported on paid Kubecost plans 
+    enabled: true # If false, Prometheus will not be installed -- only actively supported on paid Kubecost plans
     fqdn: http://cost-analyzer-prometheus-server.default.svc.cluster.local #example fqdn. Ignored if enabled: true
 
   thanos:
     enabled: false
-  
+
   grafana:
     enabled: true # If false, Grafana will not be installed
     domainName: cost-analyzer-grafana.default.svc.cluster.local #example grafana domain Ignored if enabled: true
@@ -200,6 +200,15 @@ networkCosts:
       - "10.0.0.0/8"
       - "172.16.0.0/12"
       - "192.168.0.0/16"
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
 
 serviceMonitor:
   enabled: false
@@ -224,7 +233,7 @@ serviceAccount:
 
 # These configs are settable from either the /settings.html page or values.yaml
 # This block overrides configs set on /settings.html on pod restart
-#kubecostProductConfigs: 
+#kubecostProductConfigs:
 #  defaultModelPricing: # default (monthly) model prices are used predominately for on-prem clusters
 #    CPU: 28.0
 #    spotCPU: 4.86

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -185,7 +185,7 @@ networkCosts:
   enabled: false
   image: gcr.io/kubecost1/kubecost-network-costs:v10
   imagePullPolicy: Always
-  resources:
+  resources: {}
     #requests:
     #  cpu: "50m"
     #  memory: "20Mi"
@@ -209,6 +209,9 @@ networkCosts:
   #    value: "value"
   #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+  ## PriorityClassName
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  priorityClassName: []
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
allows the ability to add a toleration so the daemonset pods can be deployed to nodes that are tainted