### PR TITLE
Access-Control-Allow-Origin * to headers via nginx

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -41,6 +41,8 @@ data:
         add_header Cache-Control "max-age=300";
         add_header Cache-Control "must-revalidate";
         add_header ETag "{{ $.Chart.Version }}";
+        add_header 'Access-Control-Allow-Origin' * always;
+
         location /api/ {
             proxy_pass http://api/;
             proxy_redirect off;


### PR DESCRIPTION
This seems appropriate, and also adds to 400/500 responses. Does this conflict with SAML work?