### PR TITLE
allow to specify tolerations&affinties for cost-analyzer pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ Parameter | Description | Default
 `prometheusRule.additionalLabels` | Additional labels that can be used so PrometheusRule will be discovered by Prometheus | `{}`
 `grafana.sidecar.datasources.defaultDatasourceEnabled` | Set this to `false` to disable creation of Prometheus datasource in Grafana | `true`
 `serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`
+`tolerations` | node taints to tolerate | `[]`
+`affinity` | pod affinity | `{}`

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -253,3 +253,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -105,6 +105,10 @@ ingress:
 
 nodeSelector: {}
 
+tolerations: []
+
+affinity: {}
+
 # If true, enable creation of NetworkPolicy resources.
 networkPolicy:
   enabled: false


### PR DESCRIPTION
Extended the cost-analyzer deployment with options for tolerations and affinities