### PR TITLE
Remove * 100 from 2 grafana queries

### DIFF
--- a/cost-analyzer/namespace-utilization.json
+++ b/cost-analyzer/namespace-utilization.json
@@ -521,7 +521,7 @@
 			"steppedLine":true,
 			"targets":[
 				{
-					"expr":"sum (rate (container_cpu_usage_seconds_total{namespace=\"$namespace\"}[10m])) by (namespace) * 100\n",
+					"expr":"sum (rate (container_cpu_usage_seconds_total{namespace=\"$namespace\"}[10m])) by (namespace)\n",
 					"format":"time_series",
 					"hide":false,
 					"instant":false,
@@ -635,7 +635,7 @@
 			"steppedLine":true,
 			"targets":[
 				{
-					"expr":"sum (container_memory_working_set_bytes{namespace=\"$namespace\"})\n/\nsum(node_memory_MemTotal_bytes) * 100",
+					"expr":"sum (container_memory_working_set_bytes{namespace=\"$namespace\"})\n/\nsum(node_memory_MemTotal_bytes)",
 					"format":"time_series",
 					"instant":false,
 					"intervalFactor":1,


### PR DESCRIPTION
In the bundled Grafana dashboard `Namespace utilization metrics`  the panels  `Overall CPU Utilization
` and `Overall RAM Utilization` seem to not work unless the `* 100` is not there.

Can you please check if this makes sense and merge if it's useful?