### PR TITLE
support renaming container->container_name for compatibility with all…

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1075,6 +1075,10 @@ serverFiles:
           - source_labels: [ __name__ ]
             regex: (container_tasks_state|container_memory_failures_total|container_memory_swap|container_memory_cache|container_fs_reads_total|container_fs_writes_total|container_network_tcp_usage_total|container_spec_memory_limit_bytes|container_spec_memory_reservation_limit_bytes|container_spec_cpu_period|container_spec_memory_swap_limit_bytes|container_memory_max_usage_bytes|container_memory_mapped_file|container_last_seen|container_cpu_load_average_10s|container_memory_failcnt|container_memory_rss|container_start_time_seconds|container_network_udp_usage_total|container_spec_cpu_shares|container_cpu_schedstat_run_periods_total|container_cpu_schedstat_run_seconds_total|container_cpu_schedstat_runqueue_seconds_total|container_cpu_user_seconds_total|container_cpu_system_seconds_total|container_cpu_system_seconds_total|container_fs_reads_bytes_total|container_fs_read_seconds_total|container_fs_sector_writes_total|container_fs_sector_reads_total)
             action: drop
+          - source_labels: [ container ]
+            target_label: container_name
+            regex: (.+)
+            action: replace
 
       # Scrape config for service endpoints.
       #


### PR DESCRIPTION
… versions of cadvisor

Testing notes.
No effect on 1.14. No effect on 1.15. Note that in 1.15, both container and container_name exist for backwards compatibility. I don't have access to a 1.16+ cluster yet, so I set [ cluster ] to a different label that exists and noted that the replace was happening.