### PR TITLE
Add labels to job

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -13,15 +13,21 @@ spec:
   schedule: "*/10 * * * *"
   {{- end }}
   jobTemplate:
+    metadata:
+      labels:
+        {{ include "cost-analyzer.commonLabels" . | nindent 8 }}
     spec:
       template:
+        metada:
+          labels:
+            {{ include "cost-analyzer.commonLabels" . | nindent 12 }}
         spec:
           containers:
           - name: cost-analyzer-checks
           {{- if .Values.kubecostChecks }}
             image: {{ .Values.kubecostChecks.image }}:prod-{{ $.Chart.AppVersion }}
           {{- else }}
-            image: ajaytripathy/kubecost-checks:prod-{{ $.Chart.AppVersion }}
+            image: gcr.io/kubecost1/checks:prod-{{ $.Chart.AppVersion }}
           {{ end }}
             imagePullPolicy: Always
             args:


### PR DESCRIPTION
Kubecost jobs show up like this:
`kubecost      cost-analyzer-checks-1582047000-txzzm                 0/1     Completed   0          25m`

This PR is to add labels to those jobs so that they don't show up in the `__unallocated__` bucket.