### PR TITLE
Grafana DataSource Name via Values

### DIFF
--- a/cost-analyzer/templates/grafana-datasource-template.yaml
+++ b/cost-analyzer/templates/grafana-datasource-template.yaml
@@ -17,7 +17,7 @@ data:
     datasources:
     - access: proxy
       isDefault: true
-      name: Prometheus
+      name: {{ default "Prometheus" .Values.grafana.sidecar.datasources.dataSourceName }}
       type: prometheus
 {{- if .Values.global.prometheus.enabled }}
       url: http://{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace  }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -258,6 +258,7 @@ grafana:
     datasources:
       enabled: true
       defaultDatasourceEnabled: true
+      dataSourceName: Prometheus
 
 serviceAccount:
   create: true


### PR DESCRIPTION
Add a `dataSourceName` to allow overriding the default Prometheus data source name.

Fix for https://github.com/kubecost/cost-analyzer-helm-chart/issues/266
