### PR TITLE
support custom cron schedule

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   {{- if .Values.kubecostChecks.debug }}
   schedule: "*/1 * * * *"
+  {{- else if .Values.kubecostChecks.schedule }}
+  schedule: {{ .Values.kubecostChecks.schedule | quote }}
   {{- else }}
   schedule: "*/10 * * * *"
   {{- end }}


### PR DESCRIPTION
This makes the cronjob schedule configurable. However, note that if it isn't running around UTC midnight servertime on Sunday, the weekly update email will not be sent.