### PR TITLE
remove commonlabels

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -18,9 +18,6 @@ spec:
         {{ include "cost-analyzer.commonLabels" . | nindent 8 }}
     spec:
       template:
-        metadata:
-          labels:
-            {{ include "cost-analyzer.commonLabels" . | nindent 12 }}
         spec:
           containers:
           - name: cost-analyzer-checks


### PR DESCRIPTION
These need to be removed temporarily as they conflict with service selector labels. We should change the service selector labels then revert this.