### PR TITLE
Use custom grafana dashboard sidecar label

### DIFF
--- a/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
@@ -8,7 +8,9 @@ metadata:
   name: cluster-metrics-dashboard
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    grafana_dashboard: "1"
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
 data:
     cluster-metrics.json: |-
 {{ .Files.Get "cluster-metrics.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
@@ -8,7 +8,9 @@ metadata:
   name: cluster-utilization-dashboard
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    grafana_dashboard: "1"
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
 data:
     cluster-utilization.json: |-
 {{ .Files.Get "cluster-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
@@ -8,7 +8,9 @@ metadata:
   name: deployment-utilization-dashboard
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    grafana_dashboard: "1"
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
 data:
     deployment-utilization.json: |-
 {{ .Files.Get "deployment-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
@@ -8,7 +8,9 @@ metadata:
   name: label-cost-dashboard
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    grafana_dashboard: "1"
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
 data:
     label-cost-utilization.json: |-
 {{ .Files.Get "label-cost-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
@@ -8,7 +8,9 @@ metadata:
   name: namespace-utilization-dashboard
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    grafana_dashboard: "1"
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
 data:
     namespace-utilization.json: |-
 {{ .Files.Get "namespace-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
@@ -8,7 +8,9 @@ metadata:
   name: node-utilization-dashboard
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    grafana_dashboard: "1"
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
 data:
     node-utilization.json: |-
 {{ .Files.Get "node-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
@@ -8,7 +8,9 @@ metadata:
   name: pod-utilization-dashboard
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    grafana_dashboard: "1"
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
 data:
     pod-utilization.json: |-
 {{ .Files.Get "pod-utilization.json" | indent 8 }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -259,6 +259,8 @@ grafana:
       enabled: true
       defaultDatasourceEnabled: true
       dataSourceName: Prometheus
+      # label that the configmaps with dashboards are marked with
+      label: grafana_dashboard
 
 serviceAccount:
   create: true
@@ -267,7 +269,7 @@ serviceAccount:
 # This block overrides configs set on /settings.html on pod restart
 # kubecostProductConfigs:
 # An optional list of cluster definitions that can be added for frontend access. The local
-# cluster is *always* included by default, so this list is for non-local clusters. 
+# cluster is *always* included by default, so this list is for non-local clusters.
 #  clusters:
 #    - name: "Cluster A"
 #      address: http://cluster-a.kubecost.com:9090


### PR DESCRIPTION
Using the `grafana.sidecar.dashboards.label` config field to set the label on dashboard configmaps so one can customize that label.

For our use case, we have another Grafana instance pulling in cms with the default `grafana_dashboard` label, so the Kubecost Grafana instance ended up pulling in all of those dashboards but we'd like to keep them separate.