### PR TITLE
Use custom grafana datasources sidecar label

### DIFF
--- a/cost-analyzer/templates/grafana-datasource-template.yaml
+++ b/cost-analyzer/templates/grafana-datasource-template.yaml
@@ -9,7 +9,11 @@ metadata:
   name: grafana-datasource
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- if $.Values.grafana.sidecar.datasources.label }}
+    {{ $.Values.grafana.sidecar.datasources.label }}: "1"
+    {{- else }}
     grafana_datasource: "1"
+    {{- end }}
 data:
   datasource.yaml: |-
     # config file version

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -266,6 +266,8 @@ grafana:
       enabled: true
       defaultDatasourceEnabled: true
       dataSourceName: Prometheus
+      # label that the configmaps with datasources are marked with
+      label: grafana_datasource
 
 serviceAccount:
   create: true

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -260,12 +260,12 @@ grafana:
   sidecar:
     dashboards:
       enabled: true
+      # label that the configmaps with dashboards are marked with
+      label: grafana_dashboard
     datasources:
       enabled: true
       defaultDatasourceEnabled: true
       dataSourceName: Prometheus
-      # label that the configmaps with dashboards are marked with
-      label: grafana_dashboard
 
 serviceAccount:
   create: true


### PR DESCRIPTION
Similar to https://github.com/kubecost/cost-analyzer-helm-chart/pull/321 - doing the same for the grafana datasources sidecar. Also while adding this, noticed that I accidentally added the dashboard label under the datasources section, woops! Made that fix here as well