### PR TITLE
Add namespace option for grafana dashboard cms

### DIFF
--- a/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
@@ -6,6 +6,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cluster-metrics-dashboard
+  {{- if $.Values.grafana.namespace_dashboards }}
+  namespace: {{ $.Values.grafana.namespace_dashboards }}
+  {{- end }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}

--- a/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
@@ -6,6 +6,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cluster-utilization-dashboard
+  {{- if $.Values.grafana.namespace_dashboards }}
+  namespace: {{ $.Values.grafana.namespace_dashboards }}
+  {{- end }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}

--- a/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
@@ -6,6 +6,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: deployment-utilization-dashboard
+  {{- if $.Values.grafana.namespace_dashboards }}
+  namespace: {{ $.Values.grafana.namespace_dashboards }}
+  {{- end }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}

--- a/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
@@ -6,6 +6,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: label-cost-dashboard
+  {{- if $.Values.grafana.namespace_dashboards }}
+  namespace: {{ $.Values.grafana.namespace_dashboards }}
+  {{- end }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}

--- a/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
@@ -6,6 +6,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: namespace-utilization-dashboard
+  {{- if $.Values.grafana.namespace_dashboards }}
+  namespace: {{ $.Values.grafana.namespace_dashboards }}
+  {{- end }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}

--- a/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
@@ -6,6 +6,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: node-utilization-dashboard
+  {{- if $.Values.grafana.namespace_dashboards }}
+  namespace: {{ $.Values.grafana.namespace_dashboards }}
+  {{- end }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}

--- a/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
@@ -6,6 +6,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pod-utilization-dashboard
+  {{- if $.Values.grafana.namespace_dashboards }}
+  namespace: {{ $.Values.grafana.namespace_dashboards }}
+  {{- end }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -257,6 +257,7 @@ prometheusRule:
 supportNFS: true
 
 grafana:
+  namespace_dashboards: kubecost
   sidecar:
     dashboards:
       enabled: true


### PR DESCRIPTION
Adds an option to set a namespace for grafana dashboard configmaps.

For our specific use case, we are using a separate grafana instance that is running in a different ns than kubecost. The grafana that we are running is also run as part of the prometheus-operator helm chart, which is unfortunately a bit more limited than the standalone grafana chart - the dashboards sidecar is unable to scan the entire cluster for dashboards, just the same ns that it is running in. This means that we would need the option to deploy the kubecost grafana dashboards into a different ns.