### PR TITLE
Thanos Query Service Override

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -167,6 +167,11 @@ spec:
             - name: REMOTE_WRITE_ENABLED
               value: "true"
             {{- end }}
+            {{- /* 
+              If queryService is set, the cost-analyzer will always pass THANOS_ENABLED as true
+              to ensure that the custom query service target is used. The global.thanos.enabled
+              flag does not have any affect on this behavior.
+            */}}
             {{- if .Values.global.thanos.queryService }}
             - name: THANOS_ENABLED
               value: "true"
@@ -266,6 +271,11 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: prometheus-server-endpoint
+            {{- /* 
+              If queryService is set, the cost-analyzer will always pass THANOS_ENABLED as true
+              to ensure that the custom query service target is used. The global.thanos.enabled
+              flag does not have any affect on this behavior.
+            */}}
             {{- if .Values.global.thanos.queryService }}
             - name: THANOS_ENABLED
               value: "true"

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -167,16 +167,21 @@ spec:
             - name: REMOTE_WRITE_ENABLED
               value: "true"
             {{- end }}
-            {{- if .Values.thanos }}
+            {{- if .Values.global.thanos.queryService }}
+            - name: THANOS_ENABLED
+              value: "true"
+            - name: THANOS_QUERY_URL
+              value: {{ .Values.global.thanos.queryService }}    
+            {{- else if .Values.thanos }}
             {{- if .Values.thanos.query }}
             {{- if .Values.thanos.query.enabled }}
             - name: THANOS_ENABLED
               value: "true"
             - name: THANOS_QUERY_URL
               value: http://{{ .Release.Name }}-thanos-query-http.{{ .Release.Namespace }}:{{ .Values.thanos.query.http.port }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
+            {{- end }} 
+            {{- end }} 
+            {{- end }} 
             {{- if .Values.saml }}
             {{- if .Values.saml.enabled }}
             - name: SAML_ENABLED
@@ -261,16 +266,21 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: prometheus-server-endpoint
-            {{- if .Values.thanos }}
+            {{- if .Values.global.thanos.queryService }}
+            - name: THANOS_ENABLED
+              value: "true"
+            - name: THANOS_QUERY_URL
+              value: {{ .Values.global.thanos.queryService }}    
+            {{- else if .Values.thanos }}
             {{- if .Values.thanos.query }}
             {{- if .Values.thanos.query.enabled }}
             - name: THANOS_ENABLED
               value: "true"
             - name: THANOS_QUERY_URL
               value: http://{{ .Release.Name }}-thanos-query-http.{{ .Release.Namespace }}:{{ .Values.thanos.query.http.port }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
+            {{- end }} 
+            {{- end }} 
+            {{- end }} 
             - name: KUBECOST_NAMESPACE
               value: {{ .Release.Namespace }}
             - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
Update cost-analyzer deployment to allow a thanos query service override without enabling thanos