### PR TITLE
Templatize prom server/alertmanager service names

### DIFF
--- a/cost-analyzer/charts/grafana/templates/configmap.yaml
+++ b/cost-analyzer/charts/grafana/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
       isDefault: true
       name: Prometheus
       type: prometheus
-      url: http://{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace  }}.svc
+      url: http://{{ template "cost-analyzer.prometheus.server.name" }}.{{ .Release.Namespace }}.svc
 {{ else }}
     - access: proxy
       isDefault: true

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -24,6 +24,28 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create the fully qualified name for Prometheus server service.
+*/}}
+{{- define "cost-analyzer.prometheus.server.name" -}}
+{{- if .Values.prometheus.server.fullnameOverride -}}
+{{- .Values.prometheus.server.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-prometheus-server" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the fully qualified name for Prometheus alertmanager service.
+*/}}
+{{- define "cost-analyzer.prometheus.alertmanager.name" -}}
+{{- if .Values.prometheus.alertmanager.fullnameOverride -}}
+{{- .Values.prometheus.alertmanager.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-prometheus-alertmanager" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "cost-analyzer.serviceName" -}}
 {{- printf "%s-%s" .Release.Name "cost-analyzer" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
@@ -7,18 +7,18 @@ metadata:
 data:
   {{- if .Values.global.prometheus.enabled }}
   {{- if .Values.global.zone }}
-    prometheus-alertmanager-endpoint: http://{{ .Release.Name }}-prometheus-alertmanager.{{ .Release.Namespace  }}.svc.{{ .Values.global.zone }}
+    prometheus-alertmanager-endpoint: http://{{ template "cost-analyzer.prometheus.alertmanager.name" }}.{{ .Release.Namespace  }}.svc.{{ .Values.global.zone }}
   {{ else }}
-    prometheus-alertmanager-endpoint: http://{{ .Release.Name }}-prometheus-alertmanager.{{ .Release.Namespace  }}
+    prometheus-alertmanager-endpoint: http://{{ template "cost-analyzer.prometheus.alertmanager.name" }}.{{ .Release.Namespace  }}
   {{- end -}}
   {{ else }}
     prometheus-alertmanager-endpoint: {{ .Values.global.notifications.alertmanager.fqdn }}
   {{- end -}}
   {{- if .Values.global.prometheus.enabled }}
   {{- if .Values.global.zone }}
-    prometheus-server-endpoint: http://{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace  }}.svc.{{ .Values.global.zone }}
+    prometheus-server-endpoint: http://{{ template "cost-analyzer.prometheus.server.name" }}.{{ .Release.Namespace  }}.svc.{{ .Values.global.zone }}
   {{ else }}
-    prometheus-server-endpoint: http://{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace  }}
+    prometheus-server-endpoint: http://{{ template "cost-analyzer.prometheus.server.name" }}.{{ .Release.Namespace  }}
   {{- end -}}
   {{ else }}
     prometheus-server-endpoint: {{ .Values.global.prometheus.fqdn }}

--- a/cost-analyzer/templates/grafana-datasource-template.yaml
+++ b/cost-analyzer/templates/grafana-datasource-template.yaml
@@ -24,7 +24,7 @@ data:
       name: {{ default "Prometheus" .Values.grafana.sidecar.datasources.dataSourceName }}
       type: prometheus
 {{- if .Values.global.prometheus.enabled }}
-      url: http://{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace  }}
+      url: http://{{ template "cost-analyzer.prometheus.server.name" }}.{{ .Release.Namespace  }}
 {{ else }}
       url: {{ .Values.global.prometheus.fqdn }}
 {{- end -}}


### PR DESCRIPTION
And use `fullnameOverride` if supplied in config

`{{ .Release.Name }}-prometheus-server` needs to be truncated if it is >63 characters