### PR TITLE
Network Costs Pod HOST_PROC Support

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -32,15 +32,24 @@ spec:
 {{ toYaml .Values.networkCosts.resources | indent 10 }}
 {{- end }}
         env:
+        {{- if .Values.networkCosts.hostProc }}
+        - name: HOST_PROC
+          value: {{ .Values.networkCosts.hostProc.mountPath }}
+        {{- end }}
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         volumeMounts:
+        {{- if .Values.networkCosts.hostProc }}
+        - mountPath: {{ .Values.networkCosts.hostProc.mountPath }}
+          name: host-proc
+        {{- else }}
         - mountPath: /net
           name: nf-conntrack
         - mountPath: /netfilter
           name: netfilter
+        {{- end }}
         {{- if .Values.networkCosts.config }}
         - mountPath: /network-costs/config
           name: network-costs-config
@@ -64,11 +73,17 @@ spec:
         configMap:
           name: network-costs-config
       {{- end }}
+      {{- if .Values.networkCosts.hostProc }}
+      - name: host-proc
+        hostPath:
+          path: {{ default "/proc" .Values.networkCosts.hostProc.hostPath }}
+      {{- else }}
       - name: nf-conntrack
         hostPath:
           path: /proc/net
       - name: netfilter
         hostPath:
           path: /proc/sys/net/netfilter
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -215,7 +215,7 @@ prometheus:
 
 networkCosts:
   enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v11
+  image: gcr.io/kubecost1/kubecost-network-costs:v12
   imagePullPolicy: Always
   resources: {}
     #requests:


### PR DESCRIPTION
supports the following additions to values.yaml networkCosts:

```yaml
networkCosts:
  hostProc:
    hostPath: /proc
    mountPath: /host-proc
```

Where `hostPath` is the location of `/proc` (default) and `mountPath` is the mount path on the network-costs pod. 