### PR TITLE
[Feature] Add service annotations and expose HTTP port for cost-analyzer

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -49,3 +49,10 @@ spec:
       targetPort: 9004
     {{- end }}
     {{- end }}
+    {{- if .Values.kubecostFrontend.http }}
+    {{- if .Values.kubecostFrontend.http.enabled }}
+    - name: frontend-http
+      port: 80
+      targetPort: 9090
+    {{- end }}
+    {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -4,6 +4,12 @@ metadata:
   name: {{ template "cost-analyzer.serviceName" . }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{- if .Values.service -}}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- end }}
 spec:
   selector:
     {{ include "cost-analyzer.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
At Rakuten Viki, we use service annotations to generate [Network Endpoint Groups](https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg) as backend to our Load Balancer. We'd like to have the same setup instead of using Ingress by k8s.

This PR adds `annotations` section to `cost-analyzer` service template and an option to expose HTTP port 80 for the service.