### PR TITLE
Service Account Annotations

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-service-account-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-account-template.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ template "cost-analyzer.fullname" . }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -283,6 +283,7 @@ grafana:
 
 serviceAccount:
   create: true
+  annotations: {}
 
 # These configs can also be set from the Settings page in the Kubecost product UI
 # Values in this block override config changes in the Settings UI on pod restart


### PR DESCRIPTION
Adds the ability to pass custom annotations to the ServiceAccount creation.

https://github.com/kubecost/cost-analyzer-helm-chart/issues/362
