### PR TITLE
Move configmap_key_ref option out of external_labels block

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -233,15 +233,15 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.global.external_labels.configmap_key_ref) }}
+            {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.global.clusterIDConfigmap) }}
             - name: CLUSTER_ID
               value: {{ .Values.prometheus.server.global.external_labels.cluster_id }}
             {{- end }}
-            {{- if .Values.prometheus.server.global.external_labels.configmap_key_ref }}
+            {{- if .Values.prometheus.server.global.clusterIDConfigmap }}
             - name: CLUSTER_ID
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Values.prometheus.server.global.external_labels.configmap_key_ref }}
+                  name: {{ .Values.prometheus.server.global.clusterIDConfigmap }}
                   key: CLUSTER_ID
             {{- end }}
             {{- if .Values.remoteWrite.postgres.installLocal }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -170,11 +170,13 @@ prometheus:
       scrape_interval: 1m
       scrape_timeout: 10s
       evaluation_interval: 1m
+      # If clusterIDConfigmap is defined, instead use user-generated configmap with key CLUSTER_ID
+      # to use as unique cluster ID in kubecost cost-analyzer deployment.
+      # This overrides the cluster_id set in prometheus.server.global.external_labels.
+      # NOTE: This does not affect the external_labels set in prometheus config.
+      # clusterIDConfigmap: cluster-id-configmap
       external_labels:
         cluster_id: cluster-one # Each cluster should have a unique ID
-        # If configmap_key_ref is defined, instead use user-generated configmap with key CLUSTER_ID to use as unique cluster ID.
-        # This overrides the above cluster_id.
-        # configmap_key_ref: cluster-id-configmap
     persistentVolume:
       size: 32Gi
       enabled: true
@@ -286,7 +288,7 @@ serviceAccount:
 
 # These configs can also be set from the Settings page in the Kubecost product UI
 # Values in this block override config changes in the Settings UI on pod restart
-# 
+#
 # kubecostProductConfigs:
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.
@@ -315,7 +317,7 @@ serviceAccount:
 #  awsSpotDataBucket: spot-data-feed-s3-bucket
 #  awsSpotDataPrefix: dev
 #  projectID: "123456789"
-#  labelMappingConfigs:  # names of k8s labels used to designate different allocation concepts 
+#  labelMappingConfigs:  # names of k8s labels used to designate different allocation concepts
 #    owner_label: "owner"
 #    team_label: "team"
 #    department_label: "dept"
@@ -333,6 +335,6 @@ serviceAccount:
 #  defaultIdle: false
 #  serviceKeySecretName: ""
 #  sharedNamespaces: ""
-#  productKey: # apply business or enterprise product license 
+#  productKey: # apply business or enterprise product license
 #    key: ""
 #    enabled: false


### PR DESCRIPTION
Moving the option up a level to `.Values.prometheus.server.global.clusterIDConfigmap` (with a rename - feel free to tweak the name if not clear enough) to avoid setting `configmap_key_ref` as an external label in prometheus config. 