### PR TITLE
Update to Thanos v0.11.0

### DIFF
--- a/cost-analyzer/charts/thanos/Chart.yaml
+++ b/cost-analyzer/charts/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.10.1
+appVersion: 0.11.0
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: thanosio/thanos
-  tag: v0.10.1
+  tag: v0.11.0
   pullPolicy: IfNotPresent
 
 store:
@@ -320,9 +320,9 @@ compact:
   # How long to retain samples of resolution 2 (1 hour) in bucket. 0d - disables this retention
   retentionResolution1h: 1y
   # Number of goroutines to use when syncing block metadata from object storage.
-  compactConcurrency: 20
+  compactConcurrency: 1
   # Number of goroutines to use when compacting groups.
-  blockSyncConcurrency: 1
+  blockSyncConcurrency: 20
   # Log filtering level.
   logLevel: info
   # Compact service listening http port


### PR DESCRIPTION
Branch name is 0.12-upgrade, but we backtracked to 0.11.0

This includes a default value fix that appears to be a typo in the chart for thanos-compact.