### PR TITLE
Add matchLabels option to thanos services

### DIFF
--- a/cost-analyzer/charts/thanos/templates/bucket-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/bucket-service.yaml
@@ -24,4 +24,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: bucket
+{{ with .Values.bucket.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 {{ end }}

--- a/cost-analyzer/charts/thanos/templates/compact-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-service.yaml
@@ -24,4 +24,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: compact
+{{ with .Values.compact.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 {{ end}}

--- a/cost-analyzer/charts/thanos/templates/query-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-service.yaml
@@ -26,6 +26,7 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: query
+{{ with .Values.query.grpc.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 
 ---
 
@@ -58,4 +59,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: query
+{{ with .Values.query.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 {{- end -}}

--- a/cost-analyzer/charts/thanos/templates/sidecar-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/sidecar-service.yaml
@@ -24,6 +24,7 @@ spec:
       name: grpc
   selector:
     app: prometheus
+{{ with .Values.sidecar.grpc.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 
 ---
 
@@ -54,4 +55,5 @@ spec:
       name: http
   selector:
     app: prometheus
+{{ with .Values.sidecar.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 {{- end }}

--- a/cost-analyzer/charts/thanos/templates/store-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-service.yaml
@@ -26,6 +26,7 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: store
+{{ with .Values.store.grpc.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 
 ---
 
@@ -58,4 +59,5 @@ spec:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: store
+{{ with .Values.store.http.service.matchLabels }}{{ toYaml . | indent 4 }}{{ end }}
 {{- end -}}

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -67,6 +67,7 @@ store:
       annotations: {}
       # Labels to query grpc service
       labels: {}
+      matchLabels: {}
     # Set up ingress for the grpc service
     ingress:
       enabled: false
@@ -93,6 +94,7 @@ store:
       annotations: {}
       # Labels to query http service
       labels: {}
+      matchLabels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false
@@ -209,6 +211,7 @@ query:
       annotations: {}
       # labels to query grpc service
       labels: {}
+      matchLabels: {}
     # Set up ingress for the grpc service
     ingress:
       enabled: false
@@ -236,6 +239,7 @@ query:
       annotations: {}
       # Labels to query http service
       labels: {}
+      matchLabels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false
@@ -422,6 +426,7 @@ bucket:
       annotations: {}
       # Labels to query http service
       labels: {}
+      matchLabels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false
@@ -515,6 +520,7 @@ sidecar:
       annotations: {}
       # Labels to query grpc service
       labels: {}
+      matchLabels: {}
     # Set up ingress for the grpc service
     ingress:
       enabled: false
@@ -541,6 +547,7 @@ sidecar:
       annotations: {}
       # Labels to query http service
       labels: {}
+      matchLabels: {}
     # Set up ingress for the http service
     ingress:
       enabled: false


### PR DESCRIPTION
I will [upstream](https://github.com/banzaicloud/banzai-charts/pull/1086) this as well. Added `matchLabels` option to all the thanos services to be able to configure extra selectors. This is necessary for our use case because we have multiples of the same thanos components running in a namespace.