### PR TITLE
Disable savings cache with flag

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -218,6 +218,8 @@ spec:
             {{- end }}
             - name: CACHE_WARMING_ENABLED
               value: {{ (quote .Values.kubecostModel.warmCache) | default (quote true) }}
+            - name: SAVINGS_CACHE_WARMING_ENABLED
+              value: {{ (quote .Values.kubecostModel.warmSavingsCache) | default (quote true) }}
             {{- /*
               If queryService is set, the cost-analyzer will always pass THANOS_ENABLED as true
               to ensure that the custom query service target is used. The global.thanos.enabled


### PR DESCRIPTION
Depends on https://github.com/kubecost/kubecost-cost-model/pull/121

## Changes

Set `.Values.kubecostModel.warmSavingsCache` to false to disable savings cache only

## Testing

Changed values and saw the following difference in logs:

### Before
```
$ kubectl logs kubecost-cost-analyzer-5d9ff687d4-f9zph cost-model -f | grep "cache warming"
I0428 17:34:19.273973       1 log.go:19] [Info] AggregateCostModel cache warming enabled
I0428 17:34:19.273994       1 log.go:19] [Info] Savings cache warming enabled
```

### After
```
$ kubectl logs kubecost-cost-analyzer-59fc975b85-xg9tt cost-model -f | grep "cache warming"
I0428 17:35:38.508258       1 log.go:19] [Info] AggregateCostModel cache warming enabled
```