### PR TITLE
Thanos Memory Knobs

### DIFF
--- a/cost-analyzer/charts/thanos/templates/query-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-deployment.yaml
@@ -50,6 +50,9 @@ spec:
         - "--http-address=0.0.0.0:{{ .Values.query.http.port }}"
         - "--query.timeout={{ .Values.query.timeout }}"
         - "--query.max-concurrent={{ .Values.query.maxConcurrent }}"
+        {{- if .Values.query.autoDownsampling }}
+        - "--query.auto-downsampling"
+        {{- end }}
         {{- if .Values.query.replicaLabel }}
         - "--query.replica-label={{ .Values.query.replicaLabel }}"
         {{- end }}

--- a/cost-analyzer/charts/thanos/templates/query-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-deployment.yaml
@@ -99,6 +99,8 @@ spec:
           containerPort: {{ .Values.query.grpc.port }}
         resources:
           {{ toYaml .Values.query.resources | nindent 10 }}
+        env:
+          {{- toYaml .Values.query.extraEnv | nindent 10 }}
         volumeMounts:
         {{- range .Values.query.serviceDiscoveryFileConfigMaps }}
         - mountPath: /etc/query/{{ . }}

--- a/cost-analyzer/charts/thanos/templates/store-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-deployment.yaml
@@ -74,6 +74,8 @@ spec:
           containerPort: {{ .Values.store.http.port }}
         - name: grpc
           containerPort: {{ .Values.store.grpc.port }}
+        env:
+          {{- toYaml .Values.store.extraEnv | nindent 10 }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/config

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -166,6 +166,9 @@ query:
   # Maximum number of queries processed
   # concurrently by query node.
   maxConcurrent: 20
+  # Enable automatic adjustment (step / 5) to what source of data should be used in store gateways 
+  # if no max_source_resolution param is specified.
+  autoDownsampling: false                                        
   # https://github.com/improbable-eng/thanos/issues/1015
   storeDNSResolver: miekgdns
   # Enable DNS discovery for stores

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -60,6 +60,7 @@ thanos:
     enabled: true
     timeout: 3m
     maxConcurrent: 10
+    autoDownsampling: true
   # Thanos Sidecar Service Discovery
   sidecar:
     enabled: true

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -55,18 +55,21 @@ thanos:
     blockSyncConcurrency: 20
     extraEnv:
       - name: GOGC
-        value: "40"
+        value: "100"
     resources: 
       requests:
         memory: "2.5Gi"
   query: 
     enabled: true
     timeout: 3m
-    maxConcurrent: 10
+    maxConcurrent: 1
+    resources:
+      requests:
+        memory: "2.5Gi"
     autoDownsampling: false
     extraEnv:
       - name: GOGC
-        value: "40"
+        value: "100"
   # Thanos Sidecar Service Discovery
   sidecar:
     enabled: true

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -53,6 +53,9 @@ thanos:
     enabled: true
     grpcSeriesMaxConcurrency: 20
     blockSyncConcurrency: 20
+    extraEnv:
+      - name: GOGC
+        value: "40"
     resources: 
       requests:
         memory: "2.5Gi"
@@ -60,7 +63,10 @@ thanos:
     enabled: true
     timeout: 3m
     maxConcurrent: 10
-    autoDownsampling: true
+    autoDownsampling: false
+    extraEnv:
+      - name: GOGC
+        value: "40"
   # Thanos Sidecar Service Discovery
   sidecar:
     enabled: true


### PR DESCRIPTION
* Push `--query.auto-downsampling` through helm chart for thanos. 
* Fixed an issue in Thanos Charts that didn't propagate `extraEnv` to the deployments for store or query.
* Added some test values for GOGC=40 to store and query to see if we can more aggressively clean up after larger queries.