### PR TITLE
Disable push gateway by default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -198,7 +198,7 @@ prometheus:
     persistentVolume:
       enabled: true
   pushgateway:
-    # enabled: false
+    enabled: false
     persistentVolume:
       enabled: true
   serverFiles: 


### PR DESCRIPTION
The majority of users are not actively leveraging this component. Let's disable by default.