### PR TITLE
Ajay tripathy use alternate label

### DIFF
--- a/cost-analyzer/templates/grafana-datasource-template.yaml
+++ b/cost-analyzer/templates/grafana-datasource-template.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- if $.Values.grafana.sidecar.datasources.label }}
     {{ $.Values.grafana.sidecar.datasources.label }}: "1"
     {{- else }}
-    grafana_datasource: "1"
+    kubecost_grafana_datasource: "1"
     {{- end }}
 data:
   datasource.yaml: |-

--- a/cost-analyzer/templates/grafana-datasource-template.yaml
+++ b/cost-analyzer/templates/grafana-datasource-template.yaml
@@ -15,7 +15,11 @@ metadata:
     {{- if $.Values.grafana.sidecar.datasources.label }}
     {{ $.Values.grafana.sidecar.datasources.label }}: "1"
     {{- else }}
+    {{- if .Values.global.grafana.enabled }}
     kubecost_grafana_datasource: "1"
+    {{- else }}
+    grafana_datasource: "1"
+    {{- end }}
     {{- end }}
 data:
   datasource.yaml: |-

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -82,9 +82,9 @@ kubecost:
 kubecostModel:
   image: "gcr.io/kubecost1/cost-model"
   imagePullPolicy: Always
-  warmCache: false
-  warmSavingsCache: false
-  etl: true
+  warmCache: true
+  warmSavingsCache: true
+  etl: false
   resources:
     requests:
       cpu: "200m"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -82,9 +82,9 @@ kubecost:
 kubecostModel:
   image: "gcr.io/kubecost1/cost-model"
   imagePullPolicy: Always
-  warmCache: true
-  warmSavingsCache: true
-  etl: false
+  warmCache: false
+  warmSavingsCache: false
+  etl: true
   resources:
     requests:
       cpu: "200m"
@@ -318,7 +318,7 @@ grafana:
       defaultDatasourceEnabled: true
       dataSourceName: Prometheus
       # label that the configmaps with datasources are marked with
-      label: grafana_datasource
+      label: kubecost_grafana_datasource
 #  For grafana to be accessible, add the path to root_url. For example, if you run kubecost at www.foo.com:9090/kubecost
 #  set root_url to "%(protocol)s://%(domain)s:%(http_port)s/kubecost/grafana". No change is necessary here if kubecost runs at a root URL
   grafana.ini:


### PR DESCRIPTION
Change from using the default data source label tag to make it less likely that users conflict on initial installs.