### PR TITLE
Ajay tripathy saml fix

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.59.1"
+appVersion: "1.59.2"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer
-version: 1.59.1
+version: 1.59.2

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -148,7 +148,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-{{- if .Values.global.grafana.proxy }}
+    {{- if .Values.global.grafana.proxy }}
         location /grafana/ {
         {{- if .Values.saml.enabled }}
             auth_request /auth;
@@ -160,7 +160,7 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-{{ end }}
+    {{ end }}
     {{- if .Values.saml.enabled }}
         location /auth {
             proxy_pass http://model/isAuthenticated;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -160,8 +160,8 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-
-        {{- if .Values.saml.enabled }}
+{{ end }}
+    {{- if .Values.saml.enabled }}
         location /auth {
             proxy_pass http://model/isAuthenticated;
         }
@@ -171,5 +171,4 @@ data:
             proxy_pass http://model/isAdminAuthenticated;
         }
         {{- end }}
-{{ end }}
     }

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -170,5 +170,5 @@ data:
         location /authrbac {
             proxy_pass http://model/isAdminAuthenticated;
         }
-        {{- end }}
+    {{- end }}
     }


### PR DESCRIPTION
So-- if you do not use the grafana frontend proxy, ie have byo-grafana, this fails because this was dumped in that block. It does not fail right away because nginx needs to restart to pick up new configmap changes.

Testing as follows:
set global.grafana.proxy = false
helm upgrade
note that things still work
restart the cost-analyzer-pod
note that /api is now unreachable
Apply the fix
helm upgrade
/api still unreachable
restart the cost-analyzer-pod
/api now reachable.