### PR TITLE
Ajay tripathy gcp key

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -67,6 +67,14 @@ spec:
               - key: nginx.conf
                 path: default.conf
         {{- if .Values.kubecostProductConfigs }}
+        {{- if .Values.kubecostProductConfigs.gcpSecretName }}
+        - name: gcp-key-secret
+          secret:
+            secretName: {{ .Values.kubecostProductConfigs.gcpSecretName }}
+            items:
+            - key: compute-viewer-kubecost-key.json
+              path: key.json
+        {{- end }}
         {{- if .Values.kubecostProductConfigs.serviceKeySecretName }}
         - name: service-key-secret
           secret:
@@ -193,6 +201,10 @@ spec:
             - name: persistent-configs
               mountPath: /var/configs
             {{- if .Values.kubecostProductConfigs }}
+            {{- if .Values.kubecostProductConfigs.gcpSecretName }}
+            - name: gcp-key-secret
+              mountPath: /models
+            {{- end }}
             {{- if .Values.kubecostProductConfigs.serviceKeySecretName }}
             - name: service-key-secret
               mountPath: /var/secrets

--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -94,8 +94,8 @@ data:
   {{- if .Values.kubecostProductConfigs.projectID }}
     projectID: "{{ .Values.kubecostProductConfigs.projectID }}"
   {{- end -}}
-  {{- if .Values.kubecostProductConfigs.biqQueryBillingDataDataset }}
-    billingDataDataset: "{{ .Values.kubecostProductConfigs.biqQueryBillingDataDataset }}"
+  {{- if .Values.kubecostProductConfigs.bigQueryBillingDataDataset }}
+    billingDataDataset: "{{ .Values.kubecostProductConfigs.bigQueryBillingDataDataset }}"
   {{- end -}}
   {{- if .Values.kubecostProductConfigs.athenaProjectID }}
     athenaProjectID: "{{ .Values.kubecostProductConfigs.athenaProjectID }}"

--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -94,6 +94,9 @@ data:
   {{- if .Values.kubecostProductConfigs.projectID }}
     projectID: "{{ .Values.kubecostProductConfigs.projectID }}"
   {{- end -}}
+  {{- if .Values.kubecostProductConfigs.biqQueryBillingDataDataset }}
+    billingDataDataset: "{{ .Values.kubecostProductConfigs.biqQueryBillingDataDataset }}"
+  {{- end -}}
   {{- if .Values.kubecostProductConfigs.athenaProjectID }}
     athenaProjectID: "{{ .Values.kubecostProductConfigs.athenaProjectID }}"
   {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -380,7 +380,7 @@ kubecostProductConfigs:
 #  athenaTable: "athena_test1"
 #  projectID: "123456789"
 #  gcpSecretName: gcp-secret # Name of a secret representing the gcp service key
-#  biqQueryBillingDataDataset: billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2
+#  bigQueryBillingDataDataset: billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2
 #  labelMappingConfigs:  # names of k8s labels used to designate different allocation concepts
 #    enabled: true
 #    owner_label: "owner"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -333,7 +333,7 @@ serviceAccount:
 # These configs can also be set from the Settings page in the Kubecost product UI
 # Values in this block override config changes in the Settings UI on pod restart
 #
-# kubecostProductConfigs:
+kubecostProductConfigs:
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.
 # Ref: https://github.com/kubecost/docs/blob/master/multi-cluster.md
@@ -379,6 +379,8 @@ serviceAccount:
 #  athenaDatabase: athenacurcfn_athena_test1
 #  athenaTable: "athena_test1"
 #  projectID: "123456789"
+#  gcpSecretName: gcp-secret # Name of a secret representing the gcp service key
+#  biqQueryBillingDataDataset: billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2
 #  labelMappingConfigs:  # names of k8s labels used to designate different allocation concepts
 #    enabled: true
 #    owner_label: "owner"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -333,7 +333,7 @@ serviceAccount:
 # These configs can also be set from the Settings page in the Kubecost product UI
 # Values in this block override config changes in the Settings UI on pod restart
 #
-kubecostProductConfigs:
+# kubecostProductConfigs:
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.
 # Ref: https://github.com/kubecost/docs/blob/master/multi-cluster.md


### PR DESCRIPTION
Fixes #498 

Add a secret to the same name as kubecost like this:

kubectl create secret generic gcp-secret --from-file compute-viewer-kubecost-key.json -n kubecost

the secret has form 

```
{
  "type": "service_account",
  "project_id": "",
  "private_key_id": "07ea38ce0e4969ec8be4883d9ffe6941c478165c",
  "private_key": "-----BEGIN PRIVATE KEY-----foo-----END PRIVATE KEY-----\n",
  "client_email": "compute-viewer-kubecost@guestbook-227502.iam.gserviceaccount.com",
  "client_id": "103549887095203286466",
  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
  "token_uri": "https://oauth2.googleapis.com/token",
  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/compute-viewer-kubecost%40guestbook-227502.iam.gserviceaccount.com"
}
```

and can be created via the following steps:

```
export PROJECT_ID=$(gcloud config get-value project)
gcloud iam service-accounts create compute-viewer-kubecost --display-name "Compute Read Only Account Created For Kubecost" --format json
gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com --role roles/compute.viewer
gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com --role roles/bigquery.user
gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com --role roles/bigquery.dataViewer
gcloud iam service-accounts keys create ./compute-viewer-kubecost-key.json --iam-account compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com
```

Tested by adding a secret and checking it is placed in the correct filepath.