### PR TITLE
fix psp role name

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kubecost-network-costs
+  name: kubecost-cost-analyzer-psp
   annotations:
-{{- if .Values.networkCosts.podSecurityPolicy.annotations }}
-{{ toYaml .Values.networkCosts.podSecurityPolicy.annotations | indent 4 }}
+{{- if .Values.podSecurityPolicy.annotations }}
+{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
 {{- end }}
 rules:
 - apiGroups: ['extensions']


### PR DESCRIPTION
Testing Done:

```
 kubectl get role -n kubecost
NAME                         AGE
kubecost-cost-analyzer       7d4h
kubecost-cost-analyzer-psp   4m22s
kubecost-grafana             7d4h
kubecost-grafana-test        88d
kubecost-network-costs       4m22s

(venv) Ajays-MacBook-Pro-2:cost-analyzer atripathy$ kubectl get role -n kubecost kubecost-cost-analyzer-psp -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  creationTimestamp: "2020-06-09T00:20:03Z"
  name: kubecost-cost-analyzer-psp
  namespace: kubecost
  resourceVersion: "107595087"
  selfLink: /apis/rbac.authorization.k8s.io/v1/namespaces/kubecost/roles/kubecost-cost-analyzer-psp
  uid: f69ece79-a9e6-11ea-810c-42010a80013c
rules:
- apiGroups:
  - extensions
  resourceNames:
  - kubecost-cost-analyzer-psp
  resources:
  - podsecuritypolicies
  verbs:
  - use
```
