### PR TITLE
Fix env vars values in CronJob to make sure it points to the correct Service name

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -36,12 +36,12 @@ spec:
 {{ toYaml .Values.kubecostChecks.resources | indent 14 }}
             env:
             - name: COST_ANALYZER_SERVER_ENDPOINT
-              value: {{ template "cost-analyzer.fullname" . }}.{{ .Release.Namespace  }}:9001
+              value: {{ template "cost-analyzer.serviceName" . }}.{{ .Release.Namespace  }}:9001
             - name: COST_ANALYZER_MODEL_ENDPOINT
               {{- if .Values.saml.enabled }}
-              value: {{ template "cost-analyzer.fullname" . }}.{{ .Release.Namespace  }}:9004
+              value: {{ template "cost-analyzer.serviceName" . }}.{{ .Release.Namespace  }}:9004
               {{- else }}
-              value: {{ template "cost-analyzer.fullname" . }}.{{ .Release.Namespace  }}:9003
+              value: {{ template "cost-analyzer.serviceName" . }}.{{ .Release.Namespace  }}:9003
               {{ end }}
             {{- if .Values.kubecostChecks }}
             {{- if .Values.kubecostChecks.debug }}


### PR DESCRIPTION
Found this problem in `cost-analyzer-checks-template.yaml`:
```
value: {{ template "cost-analyzer.fullname" . }}.{{ .Release.Namespace  }}:9003
```
which resulted in:
```
Error: getaddrinfo ENOTFOUND cost-analyzer.kubecost cost-analyzer.kubecost:9003
```
caused by `cost-analyzer-service-template.yaml` having a totally different name:
```
kind: Service
apiVersion: v1
metadata:
  name: {{ template "cost-analyzer.serviceName" . }}
```

Removed serviceName template and any references to it and replaced them with full name as it was expected in cost-analyzer-checks.
