### PR TITLE
fix datasource default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -327,8 +327,8 @@ grafana:
       label: grafana_dashboard
     datasources:
       enabled: true
-      defaultDatasourceEnabled: true
-      dataSourceName: Prometheus
+      defaultDatasourceEnabled: false
+      dataSourceName: default-kubecost
       # label that the configmaps with datasources are marked with
       label: kubecost_grafana_datasource
 #  For grafana to be accessible, add the path to root_url. For example, if you run kubecost at www.foo.com:9090/kubecost


### PR DESCRIPTION
If you have multiple default datasources, behavior on which datasource is actually added to grafana is undefined. We actually supply a default datasource elsewhere if this is set to true, so it is sometimes causing grafana to break.