### PR TITLE
nginx: cache static files for maximum duration

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -148,11 +148,11 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-{{- if .Values.global.grafana.proxy }}
+    {{- if .Values.global.grafana.proxy }}
         location /grafana/ {
-{{- if .Values.saml.enabled }}
+        {{- if .Values.saml.enabled }}
             auth_request /auth;
-{{- end }}
+        {{- end }}
             proxy_pass http://grafana/;
             proxy_redirect off;
             proxy_http_version 1.1;
@@ -160,17 +160,17 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-{{ end }}
-{{- if .Values.saml.enabled }}
+    {{ end }}
+    {{- if .Values.saml.enabled }}
         location /auth {
             proxy_pass http://model/isAuthenticated;
         }
-{{- end }}
-{{- if .Values.saml.rbac.enabled }}
+        {{- end }}
+        {{- if .Values.saml.rbac.enabled }}
         location /authrbac {
             proxy_pass http://model/isAdminAuthenticated;
         }
-{{- end }}
+    {{- end }}
         location / {
             expires max;
             try_files $uri $uri/ =404;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -53,7 +53,6 @@ data:
         server_name _;
         root /var/www;
         index index.html;
-        add_header Cache-Control "max-age=300";
         add_header Cache-Control "must-revalidate";
 {{- if .Values.imageVersion }}
         add_header ETag "{{ $.Values.imageVersion }}";
@@ -71,7 +70,9 @@ data:
 {{- else }}
         listen {{ $nginxPort }};
 {{- end }}
+
         location /api/ {
+            expires 5m;
             {{- if .Values.saml.enabled }}
             auth_request /auth;
             {{- end }}
@@ -83,6 +84,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location /model/ {
+            expires 5m;
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
@@ -93,9 +95,8 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        
         location ~ ^/(turndown|cluster)/ {
-
+            expires 5m;
             add_header 'Access-Control-Allow-Origin' '*' always;
 {{- if .Values.clusterController }}
 {{- if .Values.clusterController.enabled }}
@@ -147,12 +148,11 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-
-    {{- if .Values.global.grafana.proxy }}
+{{- if .Values.global.grafana.proxy }}
         location /grafana/ {
-        {{- if .Values.saml.enabled }}
+{{- if .Values.saml.enabled }}
             auth_request /auth;
-        {{- end }}
+{{- end }}
             proxy_pass http://grafana/;
             proxy_redirect off;
             proxy_http_version 1.1;
@@ -160,15 +160,19 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-    {{ end }}
-    {{- if .Values.saml.enabled }}
+{{ end }}
+{{- if .Values.saml.enabled }}
         location /auth {
             proxy_pass http://model/isAuthenticated;
         }
-        {{- end }}
-        {{- if .Values.saml.rbac.enabled }}
+{{- end }}
+{{- if .Values.saml.rbac.enabled }}
         location /authrbac {
             proxy_pass http://model/isAdminAuthenticated;
         }
-    {{- end }}
+{{- end }}
+        location / {
+            expires max;
+            try_files $uri $uri/ =404;
+        }
     }

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -327,8 +327,8 @@ grafana:
       label: grafana_dashboard
     datasources:
       enabled: true
-      defaultDatasourceEnabled: true
-      dataSourceName: Prometheus
+      defaultDatasourceEnabled: false
+      dataSourceName: default-kubecost
       # label that the configmaps with datasources are marked with
       label: kubecost_grafana_datasource
 #  For grafana to be accessible, add the path to root_url. For example, if you run kubecost at www.foo.com:9090/kubecost


### PR DESCRIPTION
## Changes
- Remove global max-age header
- Add expires (equivalent header with nicer syntax) to individual server blocks
- Add catch-all file server location block to the end of the server block with `expire max`

## Testing
### Do we get the right headers?
Yes, static file caching is maximized
![Screenshot from 2020-07-10 14-19-25](https://user-images.githubusercontent.com/8070055/87185945-a074c680-c2b8-11ea-8dcb-d4f9887f4d9e.png)

Yes, /model/ and /api/ responses are still 5m
![Screenshot from 2020-07-10 14-22-20](https://user-images.githubusercontent.com/8070055/87186100-e2057180-c2b8-11ea-93e8-25c339079bd4.png)

### Does Grafana work?
Yes
![Screenshot from 2020-07-10 14-18-40](https://user-images.githubusercontent.com/8070055/87185960-a5d21100-c2b8-11ea-81b0-f0ff037fba97.png)

### Does ETag bust the cache?
Need to check