### PR TITLE
Enabled Helm Values Reporting

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -270,6 +270,8 @@ spec:
               value: {{ (quote .Values.reporting.productAnalytics ) | default (quote true) }}
             - name: ERROR_REPORTING_ENABLED
               value: {{ (quote .Values.reporting.errorReprting ) | default (quote true) }}
+            - name: VALUES_REPORTING_ENABLED
+              value: {{ (quote .Values.reporting.valuesReporting) | default (quote true) }}
             {{- if .Values.reporting.errorReporting }}
             - name: SENTRY_DSN
               value: "https://71964476292e4087af8d5072afe43abd@o394722.ingest.sentry.io/5245431"
@@ -423,6 +425,12 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: prometheus-server-endpoint
+            {{- if .Values.reporting }}
+            {{- if .Values.reporting.valuesReporting }}
+            - name: HELM_VALUES
+              value: {{ template "cost-analyzer.filterEnabled" .Values }}
+            {{- end }}
+            {{- end }}
             {{- /*
               If queryService is set, the cost-analyzer will always pass THANOS_ENABLED as true
               to ensure that the custom query service target is used. The global.thanos.enabled

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -316,6 +316,7 @@ reporting:
   logCollection: true 
   productAnalytics: true 
   errorReporting: true
+  valuesReporting: true
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
Uses some helm templating wizardry to filter out any `.Values` leaf nodes that are set to `enabled: false`

This:
```yaml
foo:
  enabled: true
  bar: 123
  inner:
    value: 123
    innerInner:
      enabled: false
      anotherThing: 123
    thing: true
```

Is filtered to this:
```yaml
foo:
  enabled: true
  bar: 123
  inner:
    value: 123
    thing: true
```

There is also now a single flag under `reporting`, namely `reporting.valuesReporting` which controls whether or not this template is used. Any users who have issues can simply disable it via `--set reporting.valuesReporting=false`