### PR TITLE
Increase query.max-samples value

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -206,6 +206,7 @@ prometheus:
       enabled: true
     extraArgs:
       query.max-concurrency: 1
+      query.max-samples: 100000000
   alertmanager:
     # enabled: false
     persistentVolume:


### PR DESCRIPTION
We've seen a number of users hit this threshold. Increasing should not have a major impact on max memory usage, given our query concurrency. 

This PR still needs to be tested.