### PR TITLE
Ajay tripathy checks quay

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -60,7 +60,7 @@ saml: # enterprise key required to use
 
 kubecostChecks:
   enabled: true
-  image: "gcr.io/kubecost1/checks"
+  image: "quay.io/kubecost1/checks"
   resources:
     requests:
       cpu: "20m"


### PR DESCRIPTION
Reasoning: These are imagepullpolicy: Always and run ever 10minutes we're getting charged a decent amount for container egress on GKE. I propose we start by migrating checks to quay by default.

Tested by manually pushing, looking at cronjob file:

...
              valueFrom:
                configMapKeyRef:
                  key: prometheus-alertmanager-endpoint
                  name: kubecost-cost-analyzer
            image: quay.io/kubecost1/checks:prod-1.64.0
            imagePullPolicy: Always
            name: cost-analyzer-checks
            resources:
              limits:
                cpu: 100m
                memory: 200Mi
....

And noting:

cost-analyzer-checks-1598904600-qplvx               0/1     Completed   0          5m13s
