### PR TITLE
add insecure support verify tls

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -267,6 +267,10 @@ spec:
                   name: {{ .Values.global.thanos.queryServiceBasicAuthSecretName }}
                   key: PASSWORD
             {{- end }}
+            {{- if .Values.global.prometheus.insecureSkipVerify }}
+            - name: INSECURE_SKIP_VERIFY
+              value: {{ (quote .Values.global.prometheus.insecureSkipVerify) }}
+            {{- end }}
             {{- if .Values.pricingCsv }}
             {{- if .Values.pricingCsv.enabled }}
             - name: USE_CSV_PROVIDER
@@ -470,6 +474,10 @@ spec:
             - name: HELM_VALUES
               value: {{ template "cost-analyzer.filterEnabled" .Values }}
             {{- end }}
+            {{- end }}
+            {{- if .Values.global.prometheus.insecureSkipVerify }}
+            - name: INSECURE_SKIP_VERIFY
+              value: {{ (quote .Values.global.prometheus.insecureSkipVerify) }}
             {{- end }}
             {{- /*
               If queryService is set, the cost-analyzer will always pass THANOS_ENABLED as true

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3,6 +3,7 @@ global:
   prometheus:
     enabled: true # If false, Prometheus will not be installed -- only actively supported on paid Kubecost plans
     fqdn: http://cost-analyzer-prometheus-server.default.svc #example fqdn. Ignored if enabled: true
+    insecureSkipVerify : true # If true, kubecost will not check the TLS cert of prometheus 
 
   # Durable storage option, product key required
   thanos:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3,7 +3,7 @@ global:
   prometheus:
     enabled: true # If false, Prometheus will not be installed -- only actively supported on paid Kubecost plans
     fqdn: http://cost-analyzer-prometheus-server.default.svc #example fqdn. Ignored if enabled: true
-    insecureSkipVerify : true # If true, kubecost will not check the TLS cert of prometheus 
+    # insecureSkipVerify : false # If true, kubecost will not check the TLS cert of prometheus 
 
   # Durable storage option, product key required
   thanos:


### PR DESCRIPTION
Testing: exec into pods and notice flag is set:

```atripathy@Ajays-MacBook-Pro cost-analyzer % kubectl exec -it kubecost-cost-analyzer-67b8689794-blgt7 -n kubecost -- /bin/sh
Defaulting container name to cost-model.
Use 'kubectl describe pod/kubecost-cost-analyzer-67b8689794-blgt7 -n kubecost' to see all of the containers in this pod.
/ $ printenv | grep INSECURE
INSECURE_SKIP_VERIFY=true
/ $ ^C
/ $ command terminated with exit code 130
atripathy@Ajays-MacBook-Pro cost-analyzer % kubectl exec -it kubecost-cost-analyzer-67b8689794-blgt7 -n kubecost -c cost-analyzer-server -- /bin/sh
/ $ printenv | grep INSECURE
INSECURE_SKIP_VERIFY=true
/ $ 
```