### PR TITLE
Disable priorityclass by default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -137,7 +137,7 @@ affinity: {}
 
 # If true, creates a PriorityClass to be used by the cost-analyzer pod
 priority:
-  enabled: true
+  enabled: false
   # value: 1000000
 
 # If true, enable creation of NetworkPolicy resources.


### PR DESCRIPTION
Helm does not handle this API version change properly + PriorityClass is less relevant without Prometheus init block.