### PR TITLE
Node-Exporter: Bind to all IPs on Port 

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
@@ -41,7 +41,7 @@ spec:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
             {{- if .Values.nodeExporter.hostNetwork }}
-            - --web.listen-address=localhost:{{ .Values.nodeExporter.service.hostPort }}
+            - --web.listen-address=:{{ .Values.nodeExporter.service.hostPort }}
             {{- end }}
           {{- range $key, $value := .Values.nodeExporter.extraArgs }}
           {{- if $value }}


### PR DESCRIPTION
Fix for a bug that was causing node-exporter not to be accessible via service.