### PR TITLE
Ajay tripathy allow configurable grafana fname

### DIFF
--- a/cost-analyzer/templates/grafana-datasource-template.yaml
+++ b/cost-analyzer/templates/grafana-datasource-template.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- end }}
     {{- end }}
 data:
-  datasource.yaml: |-
+  {{ default "datasource.yaml" .Values.grafana.sidecar.datasources.dataSourceFilename }}: |-
     apiVersion: 1
     datasources:
     - access: proxy

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -406,6 +406,7 @@ grafana:
       # label that the configmaps with dashboards are marked with
       label: grafana_dashboard
     datasources:
+      # dataSourceFilename: foo.yml # If you need to change the name of the datasource file
       enabled: true
       defaultDatasourceEnabled: false
       dataSourceName: default-kubecost


### PR DESCRIPTION
See #622 for motivation

testing:
helm template kubecost ./cost-analyzer -n kubecost > out.txt generates this when the value is set:

```---
# Source: cost-analyzer/templates/grafana-datasource-template.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: grafana-datasource
  labels:

    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.67.1
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
    kubecost_grafana_datasource: "1"
data:
  foo.yml: |-
    apiVersion: 1
    datasources:
    - access: proxy
      name: "default-kubecost"
      isDefault: false
      type: prometheus
      url: http://kubecost-prometheus-server.kubecost```


