### PR TITLE
set etlToDisk off for now

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -100,7 +100,7 @@ kubecostModel:
   warmCache: true
   warmSavingsCache: true
   etl: true
-  etlToDisk: true
+  etlToDisk: false
   # The total number of days the ETL storage will build
   etlStoreDurationDays: 120
   maxQueryConcurrency: 5


### PR DESCRIPTION
On multi-zone clusters, we're having an issue with multiple attachments of PVs. We're disabling ETLToDisk on it for now-- future PRs to use the attached disk if none is available.