### PR TITLE
Pass the AppVersion to CostModel

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -273,6 +273,8 @@ spec:
               value: /var/configs/
             - name: DB_PATH
               value: /var/db/
+            - name: APP_VERSION
+              value: "{{ $.Chart.AppVersion }}"
             - name: CLUSTER_PROFILE
             {{- if .Values.kubecostProductConfigs }}
               value: {{ .Values.kubecostProductConfigs.clusterProfile | default "production" }}


### PR DESCRIPTION
Adding `APP_VERSION` env var to pass into cost-model so we can link to error reporting. 