### PR TITLE
Standardize UIDs for grafana charts

### DIFF
--- a/cost-analyzer/grafana-dashboards/cluster-metrics.json
+++ b/cost-analyzer/grafana-dashboards/cluster-metrics.json
@@ -1657,7 +1657,7 @@
     ]
   },
   "timezone": "",
-  "title": "Kubecost cluster metrics",
-  "uid": "JOUdHGZZz",
+  "title": "Kubecost Cluster Metrics",
+  "uid": "kubecost-cluster-metrics",
   "version": 20
 }

--- a/cost-analyzer/grafana-dashboards/cluster-utilization.json
+++ b/cost-analyzer/grafana-dashboards/cluster-utilization.json
@@ -3467,7 +3467,7 @@
         ]
     },
     "timezone":"browser",
-    "title":"Cluster cost & utilization metrics",
-    "uid":"cluster-costs",
+    "title": "Kubecost Cluster Cost & Utilization Metrics",
+    "uid": "kubecost-cluster-utilization",
     "version":1
 }

--- a/cost-analyzer/grafana-dashboards/deployment-utilization.json
+++ b/cost-analyzer/grafana-dashboards/deployment-utilization.json
@@ -1360,7 +1360,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Deployment/Statefulset/Daemonset utilization metrics",
-  "uid": "deployment-metrics",
+  "title": "Kubecost Deployment/Statefulset/Daemonset Utilization Metrics",
+  "uid": "kubecost-deployment-utilization",
   "version": 1
 }

--- a/cost-analyzer/grafana-dashboards/label-cost-utilization.json
+++ b/cost-analyzer/grafana-dashboards/label-cost-utilization.json
@@ -1187,7 +1187,7 @@
     ]
   },
   "timezone": "",
-  "title": "Label costs & utilization",
-  "uid": "lWMhIA-ik",
+  "title": "Kubecost Label Cost & Utilization Metrics",
+  "uid": "kubecost-label-cost-utilization",
   "version": 2
 }

--- a/cost-analyzer/grafana-dashboards/namespace-utilization.json
+++ b/cost-analyzer/grafana-dashboards/namespace-utilization.json
@@ -1150,7 +1150,7 @@
 		]
 	},
 	"timezone":"browser",
-	"title":"Namespace utilization metrics",
-	"uid":"at-cost-analysis-namespace2",
+	"title": "Kubecost Namespace Utilization Metrics",
+	"uid": "kubecost-namespace-utilization",
 	"version":1
 }

--- a/cost-analyzer/grafana-dashboards/node-utilization.json
+++ b/cost-analyzer/grafana-dashboards/node-utilization.json
@@ -1364,7 +1364,7 @@
 		]
 	},
 	"timezone":"",
-	"title":"Node utilization metrics",
-	"uid":"NUQW37Lmk",
+	"title": "Kubecost Node Utilization Metrics",
+	"uid": "kubecost-node-utilization",
 	"version":1
 }

--- a/cost-analyzer/grafana-dashboards/pod-utilization.json
+++ b/cost-analyzer/grafana-dashboards/pod-utilization.json
@@ -792,7 +792,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Pod cost & utilization metrics",
-  "uid": "at-cost-analysis-pod",
+  "title": "Kubecost Pod Cost & Utilization Metrics",
+  "uid": "kubecost-pod-utilization",
   "version": 1
 }

--- a/cost-analyzer/grafana-dashboards/prom-benchmark.json
+++ b/cost-analyzer/grafana-dashboards/prom-benchmark.json
@@ -5664,7 +5664,7 @@
     ]
   },
   "timezone": "utc",
-  "title": "Prometheus Benchmark - 2.17.x",
-  "uid": "L0HBvojWz",
+  "title": "Kubecost Prometheus Benchmark - 2.17.x",
+  "uid": "kubecost-prometheus-benchmark",
   "version": 4
 }

--- a/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 data:
     cluster-metrics.json: |-
-{{ .Files.Get "cluster-metrics.json" | indent 8 }}
+{{ .Files.Get "grafana-dashboards/cluster-metrics.json" | indent 8 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 data:
     cluster-utilization.json: |-
-{{ .Files.Get "cluster-utilization.json" | indent 8 }}
+{{ .Files.Get "grafana-dashboards/cluster-utilization.json" | indent 8 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 data:
     deployment-utilization.json: |-
-{{ .Files.Get "deployment-utilization.json" | indent 8 }}
+{{ .Files.Get "grafana-dashboards/deployment-utilization.json" | indent 8 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 data:
     label-cost-utilization.json: |-
-{{ .Files.Get "label-cost-utilization.json" | indent 8 }}
+{{ .Files.Get "grafana-dashboards/label-cost-utilization.json" | indent 8 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 data:
     namespace-utilization.json: |-
-{{ .Files.Get "namespace-utilization.json" | indent 8 }}
+{{ .Files.Get "grafana-dashboards/namespace-utilization.json" | indent 8 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 data:
     node-utilization.json: |-
-{{ .Files.Get "node-utilization.json" | indent 8 }}
+{{ .Files.Get "grafana-dashboards/node-utilization.json" | indent 8 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 data:
     pod-utilization.json: |-
-{{ .Files.Get "pod-utilization.json" | indent 8 }}
+{{ .Files.Get "grafana-dashboards/pod-utilization.json" | indent 8 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
@@ -17,8 +17,8 @@ metadata:
     grafana_dashboard: "1"
     {{- end }}
 data:
-    pod-utilization.json: |-
-{{ .Files.Get "prom-benchmark.json" | indent 8 }}
+    prom-benchmark.json: |-
+{{ .Files.Get "grafana-dashboards/prom-benchmark.json" | indent 8 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
* standardize UIDs for grafana dashboards in a form **kubecost-<json-file-name>**, for example **kubecost-cluster-metrics**
* move all grafana dashboards to a separate folder named **grafana-dashboards**
* fix **cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml**, duplicate name in the config file