### PR TITLE
support imagePullSecrets on kubecost images

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -54,6 +54,10 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: prometheus-alertmanager-endpoint
+        {{- if .Values.imagePullSecrets }}
+          imagePullSecrets:
+          {{ toYaml .Values.imagePullSecrets | indent 2 }}
+        {{- end }}
           restartPolicy: OnFailure
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -649,6 +649,10 @@ spec:
                   name: external-grafana-config-map
                   key: grafanaURL
             {{- end }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }} 
       {{- if .Values.priority }}
       {{- if .Values.priority.enabled }}
       priorityClassName: {{ template "cost-analyzer.fullname" . }}-priority

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -62,7 +62,7 @@ saml: # enterprise key required to use
         assertionvalues:
           - "readonly"
 
-imagePullSecrets:
+# imagePullSecrets:
 # - name: "image-pull-secret"
 
 kubecostChecks:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -62,6 +62,9 @@ saml: # enterprise key required to use
         assertionvalues:
           - "readonly"
 
+imagePullSecrets:
+- name: "image-pull-secret"
+
 kubecostChecks:
   enabled: true
   image: "quay.io/kubecost1/checks"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -63,7 +63,7 @@ saml: # enterprise key required to use
           - "readonly"
 
 imagePullSecrets:
-- name: "image-pull-secret"
+# - name: "image-pull-secret"
 
 kubecostChecks:
   enabled: true


### PR DESCRIPTION
Issue: https://github.com/kubecost/cost-analyzer-helm-chart/issues/668
Description: Add imagePullSecrets field to cost-analyzer helm chart `values.yaml`
Testing: ran `helm template ./cost-analyzer -n kubecost > test.yaml` and verified that the `imagePullSecrets` field is below the `containers` field at the same indentation

Sample outputs: See [comment](https://github.com/kubecost/cost-analyzer-helm-chart/pull/685#issuecomment-732459373) below.