### PR TITLE
rename configmap key to load db's into grafana properly

### DIFF
--- a/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
@@ -17,7 +17,7 @@ metadata:
     grafana_dashboard: "1"
     {{- end }}
 data:
-    pod-utilization.json: |-
+    prom-benchmark: |-
 {{ .Files.Get "prom-benchmark.json" | indent 8 }}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
@@ -17,7 +17,7 @@ metadata:
     grafana_dashboard: "1"
     {{- end }}
 data:
-    prom-benchmark: |-
+    prom-benchmark.json: |-
 {{ .Files.Get "prom-benchmark.json" | indent 8 }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Because configmaps are loaded in a random order, sometimes this dashboard would load and sometimes the pod-utilization dashboard would load, because the data key conflicted.

Testing done: Install grafana five or six times to make sure all dashboards load every time