### PR TITLE
add http proxy environment variable

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -403,6 +403,13 @@ spec:
             - name: ETL_STORE_DURATION_DAYS
               value: {{ (quote .Values.kubecostModel.etlStoreDurationDays) | default (quote 120) }}
             {{- end }}
+            {{- if and .Values.systemProxy.enabled (not .Values.systemProxy.useHttps) }}
+            - name: HTTP_PROXY
+              value: "{{ required "missing proxy IP" .Values.systemProxy.proxyIP }}:{{ required "missing proxy port" .Values.systemProxy.proxyPort}}"
+            {{- else if and .Values.systemProxy.enabled .Values.systemProxy.useHttps }}
+            - name: HTTPS_PROXY
+              value: "{{ required "missing proxy IP" .Values.systemProxy.proxyIP }}:{{ required "missing proxy port" .Values.systemProxy.proxyPort}}"
+            {{- end }}
             - name: PV_ENABLED
               value: {{ (quote .Values.persistentVolume.enabled) | default (quote true) }}
             - name: MAX_QUERY_CONCURRENCY

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -131,8 +131,8 @@ saml: # enterprise key required to use
           - "readonly"
 
 systemProxy:
-  enabled: true
-  useHttps: true
+  enabled: false
+  useHttps: false
   proxyIP: "127.0.0.1"
   proxyPort: "8888"
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -130,6 +130,12 @@ saml: # enterprise key required to use
         assertionvalues:
           - "readonly"
 
+systemProxy:
+  enabled: true
+  useHttps: true
+  proxyIP: "127.0.0.1"
+  proxyPort: "8888"
+
 # imagePullSecrets:
 # - name: "image-pull-secret"
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -130,6 +130,8 @@ saml: # enterprise key required to use
         assertionvalues:
           - "readonly"
 
+# Adds an httpProxy as an environment variable. systemProxy.enabled must be `true` for `useHttps` to have any effect.
+# Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml
 systemProxy:
   enabled: false
   useHttps: false


### PR DESCRIPTION
Issue: https://github.com/kubecost/cost-analyzer-helm-chart/issues/696
Description: Support HTTP and HTTPS proxy environment variables.

Testing: helm template for correct generation, ssh into pod and check that the environment variable is correctly set