### PR TITLE
add check for pushgateway enabled in pushgateway-pvc template yaml

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/pushgateway-pvc.yaml
+++ b/cost-analyzer/charts/prometheus/templates/pushgateway-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pushgateway.enabled -}}
 {{- if .Values.pushgateway.persistentVolume.enabled -}}
 {{- if not .Values.pushgateway.persistentVolume.existingClaim -}}
 apiVersion: v1
@@ -26,5 +27,6 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.pushgateway.persistentVolume.size }}"
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Issue: https://github.com/kubecost/cost-analyzer-helm-chart/issues/706
Description: check that pushgateway is enabled before creating PVC deployment yaml for said pushgateway
Testing: helm template with pushgateway disabled