### PR TITLE
support SAML NameIDFormat config

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -470,6 +470,10 @@ spec:
             - name: AUDIENCE_URI
               value: {{ .Values.saml.audienceURI }}
             {{- end }}
+            {{- if .Values.saml.nameIDFormat }}
+            - name: NAME_ID_FORMAT
+              value: {{ .Values.saml.nameIDFormat }}
+            {{- end}}
             {{- if .Values.saml.rbac.enabled }}
             - name: SAML_RBAC_ENABLED
               value: "true"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -120,6 +120,7 @@ saml: # enterprise key required to use
   idpMetadataURL: "https://dev-elu2z98r.auth0.com/samlp/metadata/c6nY4M37rBP0qSO1IYIqBPPyIPxLS8v2"
   appRootURL: "http://localhost:9090" # sample URL
   # audienceURI: "http://localhost:9090" # by convention, the same as the appRootURL, but any string uniquely identifying kubecost to your samp IDP. Optional if you follow the convention
+  # nameIDFormat: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" If your SAML provider requires a specific nameid format
   rbac:
     enabled: false
     groups:


### PR DESCRIPTION
Testing done: run helm template and note the env variable is set, to be consumed by cost-analyzer pod
helm template ./cost-analyzer > out.txt
cat out.txt
```       ...
            - name: UTC_OFFSET
              value: "+00:00"
            - name: SAML_ENABLED
              value: "true"
            - name: IDP_URL
              value: https://dev-elu2z98r.auth0.com/samlp/metadata/c6nY4M37rBP0qSO1IYIqBPPyIPxLS8v2
            - name: SP_HOST
              value: http://localhost:9090
            - name: NAME_ID_FORMAT
              value: urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
            - name: CLUSTER_ID
              value: cluster-one
            - name: SQL_ADDRESS
            ...
```

This env variable is consumed by kubecost when it is acting as a Service Provider to set the NameIdFormat.