### PR TITLE
stop using hostnetwork by default

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -397,7 +397,7 @@ nodeExporter:
 
   ## If true, node-exporter pods share the host network namespace
   ##
-  hostNetwork: true
+  hostNetwork: false
 
   ## If true, node-exporter pods share the host PID namespace
   ##


### PR DESCRIPTION
Using hostnetwork by default here is undesirable as certain k8s flavors don't allow it.