### PR TITLE
Net Costs 14.1 and Disable Thanos Sidecar Discoverability by Default

### DIFF
--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -117,8 +117,10 @@ thanos:
         memory: "1.5Gi"
 
   # Thanos Sidecar Service Discovery
+  # Disabling removes the prometheus sidecar from querier store discovery. This ensures
+  # that all clusters read from the same data in remote store. 
   sidecar:
-    enabled: true
+    enabled: false
   bucket:
     enabled: false
   compact:

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -120,7 +120,7 @@ thanos:
   # Disabling removes the prometheus sidecar from querier store discovery. This ensures
   # that all clusters read from the same data in remote store. 
   sidecar:
-    enabled: false
+    enabled: true
   bucket:
     enabled: false
   compact:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -388,7 +388,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v14.0
+  image: gcr.io/kubecost1/kubecost-network-costs:v14.1
   imagePullPolicy: Always
   # Traffic Logging will enable logging the top 5 destinations for each source
   # every 30 minutes. 


### PR DESCRIPTION
Update network-costs to 14.1, disable sidecar discovery from thanos querier.