### PR TITLE
Add back podSecurityPolicy.enabled checks

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-psp.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp.template.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.podSecurityPolicy }}
+{{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ include "cost-analyzer.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
@@ -14,3 +16,5 @@ spec:
         rule: RunAsAny
     volumes:
         - '*'
+{{- end }}
+{{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -5,7 +5,7 @@ global:
     fqdn: http://cost-analyzer-prometheus-server.default.svc #example fqdn. Ignored if enabled: true
     # insecureSkipVerify : false # If true, kubecost will not check the TLS cert of prometheus
     # queryServiceBasicAuthSecretName: dbsecret # kubectl create secret generic dbsecret -n kubecost --from-file=USERNAME --from-file=PASSWORD
-    # queryServiceBearerTokenSecretName: dbsecret  # kubectl create secret generic mcdbsecret -n kubecost --from-file=TOKEN 
+    # queryServiceBearerTokenSecretName: dbsecret  # kubectl create secret generic mcdbsecret -n kubecost --from-file=TOKEN
 
   # Durable storage option, product key required
   thanos:
@@ -66,7 +66,7 @@ global:
           baselineWindow: 30d       # previous window, offset by window
           aggregation: namespace
           filter: kubecost, default # accepts csv
-            
+
     alertmanager: # Supply an alertmanager FQDN to receive notifications from the app.
       enabled: false # If true, allow kubecost to write to your alertmanager
       fqdn: http://cost-analyzer-prometheus-server.default.svc #example fqdn. Ignored if prometheus.enabled: true
@@ -110,7 +110,7 @@ pricingCsv:
   enabled: false
   location:
     provider: "AWS"
-    region: "us-east-1" 
+    region: "us-east-1"
     URI: s3://kc-csv-test/pricing_schema.csv # a valid file URI
     csvAccessCredentials: pricing-schema-access-secret
 
@@ -243,7 +243,7 @@ networkPolicy:
   enabled: false
 
 podSecurityPolicy:
-  enabled: false
+  enabled: true
 
 # Define persistence volume for cost-analyzer, more information at https://github.com/kubecost/docs/blob/master/storage.md
 persistentVolume:
@@ -301,7 +301,7 @@ prometheus:
     # This overrides the cluster_id set in prometheus.server.global.external_labels.
     # NOTE: This does not affect the external_labels set in prometheus config.
     # clusterIDConfigmap: cluster-id-configmap
-    
+
     resources: {}
     # limits:
     #   cpu: 500m
@@ -336,7 +336,7 @@ prometheus:
     enabled: false
     persistentVolume:
       enabled: true
-  serverFiles: 
+  serverFiles:
   #  prometheus.yml: # Sample block -- enable if using an in cluster durable store.
   #      remote_write:
   #        - url: "http://pgprometheus-adapter:9201/write"
@@ -400,9 +400,9 @@ networkCosts:
   image: gcr.io/kubecost1/kubecost-network-costs:v14.1
   imagePullPolicy: Always
   # Traffic Logging will enable logging the top 5 destinations for each source
-  # every 30 minutes. 
+  # every 30 minutes.
   trafficLogging: true
-  # Port will set both the containerPort and hostPort to this value. 
+  # Port will set both the containerPort and hostPort to this value.
   # These must be identical due to network-costs being run on hostNetwork
   port: 3001
   resources: {}
@@ -410,12 +410,12 @@ networkCosts:
     #  cpu: "50m"
     #  memory: "20Mi"
   config:
-    # Configuration for traffic destinations, including specific classification 
+    # Configuration for traffic destinations, including specific classification
     # for IPs and CIDR blocks. This configuration will act as an override to the
     # automatic classification provided by network-costs.
     destinations:
       # In Zone contains a list of address/range that will be
-      # classified as in zone. 
+      # classified as in zone.
       in-zone:
         # Loopback
         - "127.0.0.1"
@@ -425,15 +425,15 @@ networkCosts:
         - "10.0.0.0/8"
         - "172.16.0.0/12"
         - "192.168.0.0/16"
-        
+
       # In Region contains a list of address/range that will be
-      # classified as in region. This is synonymous with cross 
-      # zone traffic, where the regions between source and destinations 
+      # classified as in region. This is synonymous with cross
+      # zone traffic, where the regions between source and destinations
       # are the same, but the zone is different.
       in-region: []
-        
+
       # Cross Region contains a list of address/range that will be
-      # classified as non-internet egress from one region to another. 
+      # classified as non-internet egress from one region to another.
       cross-region: []
 
       # Direct Classification specifically maps an ip address or range
@@ -442,7 +442,7 @@ networkCosts:
       direct-classification: []
       # - region: "us-east1"
       #   zone: "us-east1-c"
-      #   ips: 
+      #   ips:
       #     - "10.0.0.0/24"
 
   ## Node tolerations for server scheduling to nodes with taints
@@ -478,7 +478,7 @@ reporting:
   # Kubecost bug report feature: Logs access/collection limited to .Release.Namespace
   # Ref: http://docs.kubecost.com/bug-report
   logCollection: true
-  # Basic frontend analytics 
+  # Basic frontend analytics
   productAnalytics: true
   # Report Javascript errors
   errorReporting: true
@@ -566,7 +566,7 @@ serviceAccount:
 #    enabled: true
 #  # The cluster profile represents a predefined set of parameters to use when calculating savings.
 #  # Possible values are: [ development, production, high-availability ]
-#  clusterProfile: production 
+#  clusterProfile: production
 #  customPricesEnabled: false # This makes the default view custom prices-- generally used for on-premises clusters
 #  spotLabel: lifecycle
 #  spotLabelValue: Ec2Spot
@@ -616,7 +616,7 @@ serviceAccount:
 #  discount: "" # percentage discount applied to compute
 #  negotiatedDiscount: "" # custom negotiated cloud provider discount
 #  defaultIdle: false
-#  serviceKeySecretName: "" # Use an existing AWS or Azure secret with format as in aws-service-key-secret.yaml or azure-service-key-secret.yaml. Leave blank if using createServiceKeySecret 
+#  serviceKeySecretName: "" # Use an existing AWS or Azure secret with format as in aws-service-key-secret.yaml or azure-service-key-secret.yaml. Leave blank if using createServiceKeySecret
 #  createServiceKeySecret: true # Creates a secret representing your cloud service key based on data in values.yaml. If you are storing unencrypted values, add a secret manually
 #  sharedNamespaces: "" # namespaces with shared workloads, example value: "kube-system\,ingress-nginx\,kubecost\,monitoring"
 #  productKey: # apply business or enterprise product license


### PR DESCRIPTION
This was removed in https://github.com/kubecost/cost-analyzer-helm-chart/pull/733. With the removal of the checks, the PSP is now always deployed where in the past it was defaulted to false. This has broken our build after upgrading to 1.73.0; in cases where two instances of kubecost are deployed on a cluster, there is a collision of the PSP name - perhaps a fix can be to generate unique names using `{{ template "cost-analyzer.fullname" . }}`, happy to add that in this pr or another if that makes sense.

I've added the checks back in to use the value, I'm not sure if this was intentionally removed or not. Let me know if the value should be defaulted to `true` accompanying this change if the intention was to always deploy it.