### PR TITLE
Template PSP names 

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kubecost-cost-analyzer-psp
+  name: {{ template "cost-analyzer.fullname" . }}-psp
   annotations:
 {{- if .Values.podSecurityPolicy.annotations }}
 {{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
@@ -13,6 +13,6 @@ rules:
   resources: ['podsecuritypolicies']
   verbs: ['use']
   resourceNames:
-  - kubecost-cost-analyzer-psp
+  - {{ template "cost-analyzer.fullname" . }}-psp
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-psp-rolebinding.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp-rolebinding.template.yaml
@@ -3,11 +3,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-    name: kubecost-cost-analyzer-psp
+    name: {{ template "cost-analyzer.fullname" . }}-psp
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
-    name: kubecost-cost-analyzer-psp
+    name: {{ template "cost-analyzer.fullname" . }}-psp
 subjects:
 - kind: ServiceAccount
   name: {{ template "cost-analyzer.serviceAccountName" . }}

--- a/cost-analyzer/templates/cost-analyzer-psp.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp.template.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "cost-analyzer.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
-    name: kubecost-cost-analyzer-psp
+    name: {{ template "cost-analyzer.fullname" . }}-psp
 spec:
     privileged: false
     seLinux:


### PR DESCRIPTION
Followup to https://github.com/kubecost/cost-analyzer-helm-chart/pull/765
To prevent name collisions if multiple instances of kubecost may be running in a cluster, template out the name so that they can be unique across multiple charts.