### PR TITLE
Neal/spa nginx config

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -192,8 +192,8 @@ data:
             proxy_pass http://model/isAdminAuthenticated;
         }
     {{- end }}
-        location ~ ^/beta(/|/overview)?(/.*)?$ {
+        location /beta {
             root /var/www;
-            try_files $2 /new_index.html;
+            try_files $uri $uri/ /new_index.html;
         }
     }

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -192,4 +192,8 @@ data:
             proxy_pass http://model/isAdminAuthenticated;
         }
     {{- end }}
+        location ~ ^/beta(/|/overview)?(/.*)?$ {
+            root /var/www;
+            try_files $2 /new_index.html;
+        }
     }


### PR DESCRIPTION
Establishes a `/beta` set of routes in NGINX to manage routing to the new SPA until it is ready to live at `/`.

This approach requires a change to the frontend repo, which will be explained on a PR there.