### PR TITLE
Disable Alertmanager by default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -327,7 +327,7 @@ prometheus:
     #    value: "value"
     #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
   alertmanager:
-    # enabled: false
+      enabled: false
     persistentVolume:
       enabled: true
   nodeExporter:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -327,7 +327,7 @@ prometheus:
     #    value: "value"
     #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
   alertmanager:
-      enabled: false
+    enabled: false
     persistentVolume:
       enabled: true
   nodeExporter:


### PR DESCRIPTION
The majority of users are not leveraging Alertmanager and are instead using our in-product alerts. This proposal is to disable it by default.