### PR TITLE
fix additional labels"

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cost-analyzer-checks
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    {{- if .Values.global.podAnnotations}}
+    {{- if .Values.kubecostChecks.additionalLabels }}
     {{ toYaml .Values.kubecostChecks.additionalLabels | nindent 4 }}
     {{- end }}
 spec:

--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -6,7 +6,9 @@ metadata:
   name: cost-analyzer-checks
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- if .Values.global.podAnnotations}}
     {{ toYaml .Values.kubecostChecks.additionalLabels | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.kubecostChecks.debug }}
   schedule: "*/1 * * * *"

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -26,7 +26,9 @@ spec:
     metadata:
       labels:
         {{ include "cost-analyzer.selectorLabels" . | nindent 8 }}
+        {{- if .Values.global.additionalLabels }}
         {{ toYaml .Values.global.additionalLabels | nindent 8 }}
+        {{- end }}
 {{- if .Values.kubecostDeployment }}
 {{- with .Values.kubecostDeployment.labels }}
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
Fixes a bug that occurs when .Values.kubecostChecks.additionalLabels  and .Values.global.additionalLabels were left unset:

Error: YAML parse error on cost-analyzer/templates/cost-analyzer-checks-template.yaml: error converting YAML to JSON: yaml: line 12: did not find expected key
Use --debug flag to render out invalid YAML
