### PR TITLE
fix network costs pod

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -16,7 +16,9 @@ spec:
     metadata:
       labels:
         app: {{ template "cost-analyzer.networkCostsName" . }}
-        {{ toYaml .Values.networkCosts.additionalLabels | indent 8 }}
+        {{- if .Values.networkCosts.additionalLabels }}
+        {{ toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
+        {{- end }}
     spec:
       hostNetwork: true
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}


### PR DESCRIPTION
Tested by setting networkCosts.enabled: true, with 
1. networkCosts.additionalLabels: {} 
2.  additionalLabels.foo: bar

1.  pods install as expected
``` kubectl get pods -n kubecost
NAME                                                READY   STATUS      RESTARTS   AGE
cost-analyzer-checks-1614183000-x4vxk               0/1     Completed   0          25m
cost-analyzer-checks-1614183600-tdrn6               0/1     Completed   0          15m
cost-analyzer-checks-1614184200-pd5rv               0/1     Completed   0          5m47s
kubecost-cost-analyzer-5fd9b487d5-m8fs6             3/3     Running     0          9m17s
kubecost-grafana-6df5cc66b6-6t4sg                   3/3     Running     0          11h
kubecost-kube-state-metrics-57d4dfc748-klkmk        1/1     Running     0          11h
kubecost-network-costs-942d6                        1/1     Running     0          8m57s
kubecost-network-costs-kcpk8                        1/1     Running     0          9m13s
kubecost-network-costs-n29j5                        1/1     Running     0          9m15s
kubecost-network-costs-n2bp4                        1/1     Running     0          8m54s
kubecost-network-costs-pf8fq                        1/1     Running     0          9m3s
kubecost-network-costs-xc62p 
```
2.  pods have expected labels:
```
 kubectl get pods -n kubecost kubecost-network-costs-942d6  -o yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2021-02-24T16:26:51Z"
  generateName: kubecost-network-costs-
  labels:
    app: kubecost-network-costs
    controller-revision-hash: 6d875795c7
    foo: bar
```