### PR TITLE
Add other network policy options

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-policy.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-policy.yaml
@@ -2,18 +2,49 @@
 {{- if .Values.networkPolicy.enabled -}}
 apiVersion: {{ include "cost-analyzer.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
+{{- if .Values.networkPolicy.denyEgress }}
 metadata:
   name: deny-egress
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      {{ include "cost-analyzer.selectorLabels" . | nindent 6 }}
+      {{- include "cost-analyzer.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Egress
   egress:
   - to:
     - namespaceSelector: {}
+{{- else }}
+{{- if .Values.networkPolicy.sameNamespace}}
+metadata:
+  name: shared-namespace
+  namespace: {{ default "kubecost" .Values.networkPolicy.namespace}}
+spec:
+  podSelector:
+    matchLabels:
+      app: prometheus
+      component: server
+{{- else }}
+metadata:
+  name: closed-traffic
+  namespace: {{ default "kubecost" .Values.networkPolicy.namespace}}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cost-analyzer
+{{- end  }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cost-analyzer
+    - namespaceSelector:
+        matchLabels:
+          name: k8s-kubecost
+{{- end  }}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -242,6 +242,9 @@ priority:
 # If true, enable creation of NetworkPolicy resources.
 networkPolicy:
   enabled: false
+  denyEgress: true # create a network policy that denies egress from kubecost
+  sameNamespace: true # Set to true if cost analyser and prometheus are on the same namespace
+#  namespace: kubecost # Namespace where prometheus is installed
 
 podSecurityPolicy:
   enabled: true


### PR DESCRIPTION
Tested flags with helm template
networkPolicy:
  enabled: true
  denyEgress: true
---
# Source: cost-analyzer/templates/cost-analyzer-network-policy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: deny-egress
  labels:
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.75.1
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/name: cost-analyzer
      app.kubernetes.io/instance: RELEASE-NAME
      app: cost-analyzer
  policyTypes:
  - Egress
  egress:
  - to:
    - namespaceSelector: {}
---

networkPolicy:
  enabled: true
  denyEgress: false
  sameNamespace: true
---
# Source: cost-analyzer/templates/cost-analyzer-network-policy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: shared-namespace
  namespace: kubecost
spec:
  podSelector:
    matchLabels:
      app: prometheus
      component: server
  policyTypes:
  - Ingress
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: cost-analyzer
    - namespaceSelector:
        matchLabels:
          name: k8s-kubecost
---

networkPolicy:
  enabled: true
  denyEgress: false
  sameNamespace: false
  namespace: test

---
# Source: cost-analyzer/templates/cost-analyzer-network-policy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: closed-traffic
  namespace: test
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/name: cost-analyzer
  policyTypes:
  - Ingress
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: cost-analyzer
    - namespaceSelector:
        matchLabels:
          name: k8s-kubecost
---