### PR TITLE
Set proper gcp key mounted filepath

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,3 @@
+matches-ignore:
+  - name:
+    matches: AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -305,7 +305,7 @@ spec:
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
             - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /var/configs/key.json
+              value: /models/key.json
             - name: CONFIG_PATH
               value: /var/configs/
             - name: DB_PATH
@@ -606,6 +606,10 @@ spec:
           volumeMounts:
             - name: persistent-configs
               mountPath: /var/configs
+            {{- if .Values.kubecostProductConfigs.gcpSecretName }}
+            - name: gcp-key-secret
+              mountPath: /models
+            {{- end }}
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
               valueFrom:
@@ -691,7 +695,7 @@ spec:
             - name: KUBECOST_NAMESPACE
               value: {{ .Release.Namespace }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /var/configs/key.json
+              value: /models/key.json
             - name: KUBECOST_TOKEN
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Hi, this is a modification to set the proper key.json filepath (gcp sa creds) used to query bigquery.
Useful when you have preprovisioned the bigquery config.

Thx.