### PR TITLE
Add ETL resolution configurations

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -199,7 +199,7 @@ spec:
         {{- end }}
           resources:
 {{ toYaml .Values.initChownData.resources | indent 12 }}
-          {{- if and (.Values.kubecostModel.etlToDisk | default true) .Values.persistentVolume.dbPVEnabled }}          
+          {{- if and (.Values.kubecostModel.etlToDisk | default true) .Values.persistentVolume.dbPVEnabled }}
           command: ["sh", "-c", "/bin/chmod -R 777 /var/configs && /bin/chmod -R 777 /var/db"]
           {{- else }}
           command: ["sh", "-c", "/bin/chmod -R 777 /var/configs"]
@@ -349,7 +349,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.prometheus.queryServiceBasicAuthSecretName }}
                   key: PASSWORD
-            {{- end }}              
+            {{- end }}
             {{- if .Values.global.prometheus.queryServiceBearerTokenSecretName }}
             - name: DB_BEARER_TOKEN
               valueFrom:
@@ -436,6 +436,10 @@ spec:
             - name: ETL_STORE_DURATION_DAYS
               value: {{ (quote .Values.kubecostModel.etlStoreDurationDays) | default (quote 120) }}
             {{- end }}
+            - name: ETL_RESOLUTION_SECONDS
+              value: {{ (quote .Values.kubecostModel.etlResolutionSeconds) | default (quote 60) }}
+            - name: ETL_MAX_BATCH_HOURS
+              value: {{ (quote .Values.kubecostModel.etlMaxBatchHours) | default (quote 6) }}
             {{- if .Values.systemProxy.enabled }}
             - name: HTTP_PROXY
               value: {{ .Values.systemProxy.httpProxyUrl }}
@@ -707,7 +711,7 @@ spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}
-    {{- end }} 
+    {{- end }}
       {{- if .Values.priority }}
       {{- if .Values.priority.enabled }}
       priorityClassName: {{ template "cost-analyzer.fullname" . }}-priority


### PR DESCRIPTION
Supports https://github.com/kubecost/cost-model/pull/719 and https://github.com/kubecost/kubecost-cost-model/pull/347

## Changes
- `kubecostModel.etlResolutionSeconds` (i.e. `ETL_RESOLUTION_SECONDS`) determines how high of a resolution ETL should use. Defaults to `60` (i.e. 1m) but should be set to `300` (i.e. 5m) or even `600` (i.e. 10m) for big clients.
- `kubecostModel.etlMaxBatchHours` (i.e. `ETL_MAX_BATCH_HOURS`) limits the window duration of expensive ETL queries, batching them out so that any one query will not time out. Defaults to `6` (i.e. 6h) but might need to be set to `3` (i.e. 3h) for big clients who want to keep high resolution.

## Testing
- Will do a clean install today with helm values set and report back