### PR TITLE
Add a "hidden" value option to specify full image names

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -24,7 +24,11 @@ spec:
           containers:
           - name: cost-analyzer-checks
           {{- if .Values.kubecostChecks }}
+          {{- if .Values.kubecostChecks.fullImageName }}
+            image: {{ .Values.kubecostChecks.fullImageName }}
+          {{- else }}
             image: {{ .Values.kubecostChecks.image }}:prod-{{ $.Chart.AppVersion }}
+          {{ end }}
           {{- else }}
             image: gcr.io/kubecost1/checks:prod-{{ $.Chart.AppVersion }}
           {{ end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -584,7 +584,9 @@ spec:
             periodSeconds: 10
             failureThreshold: 200
         {{- if .Values.kubecost }}
-        {{- if .Values.imageVersion}}
+        {{- if .Values.kubecost.fullImageName }}
+        - image: {{ .Values.kubecost.fullImageName }}
+        {{- else if .Values.imageVersion}}
         - image: {{ .Values.kubecost.image }}:{{ .Values.imageVersion }}
         {{- else }}
         - image: {{ .Values.kubecost.image }}:prod-{{ $.Chart.AppVersion }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -539,7 +539,9 @@ spec:
             - name: CUSTOM_ALERTS_ENABLED
               value: {{ (quote .Values.global.notifications.alertConfigs.enabled) | default (quote false) }}
         {{- if .Values.kubecostFrontend }}
-        {{- if .Values.imageVersion}}
+        {{- if .Values.kubecostFrontend.fullImageName }}
+        - image: {{ .Values.kubecostFrontend.fullImageName }}
+        {{- else if .Values.imageVersion }}
         - image: {{ .Values.kubecostFrontend.image }}:{{ .Values.imageVersion }}
         {{- else }}
         - image: {{ .Values.kubecostFrontend.image }}:prod-{{ $.Chart.AppVersion }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -213,7 +213,9 @@ spec:
 {{ end }}
       containers:
         {{- if .Values.kubecostModel }}
-        {{- if .Values.imageVersion}}
+        {{- if .Values.kubecostModel.fullImageName }}
+        - image: {{ .Values.kubecostModel.fullImageName }}
+        {{- else if .Values.imageVersion }}
         - image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
         {{- else }}
         - image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}


### PR DESCRIPTION
For the checks, cost-model, frontend, and server images.

This change supports the nightly build/test effort in https://github.com/kubecost/integration-ci-cd. It is intended as a private, unstable pattern for Kubecost internal automated integration testing.


#### Testing

Verified by using this branch in the Actions jobs. Inspecting the container images running in the cluster show that they are running the appropriate nightly images.