### PR TITLE
fix service key upload

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -307,7 +307,11 @@ spec:
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
             - name: GOOGLE_APPLICATION_CREDENTIALS
+            {{- if .Values.kubecostProductConfigs.gcpSecretName }}
+              value: /models/key.json
+            {{- else }}
               value: /var/configs/key.json
+            {{- end }}
             - name: CONFIG_PATH
               value: /var/configs/
             - name: DB_PATH


### PR DESCRIPTION
Looks like the directory for the GOOGLE_APPLICATION_CREDENTIALS was wrong for certain cases where the secret was applied. We changed some secret stores and didn't swap this variable, causing a regression that went unnoticed for many users because the key had been saved to the correct directory on a PV during migration.
<img width="1792" alt="Screen Shot 2021-03-18 at 11 24 53 PM" src="https://user-images.githubusercontent.com/453512/111740685-6776f380-8842-11eb-9f43-0cf128fc62b2.png">
 Tested this with both a secret and a manual key upload.

