### PR TITLE
Push additional labels down to pod in cronjob

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-checks-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-checks-template.yaml
@@ -24,8 +24,17 @@ spec:
     metadata:
       labels:
         {{ include "cost-analyzer.commonLabels" . | nindent 8 }}
+        {{- if .Values.kubecostChecks.additionalLabels }}
+        {{ toYaml .Values.kubecostChecks.additionalLabels | nindent 8 }}
+        {{- end }}
     spec:
       template:
+        metadata:
+          labels:
+          {{ include "cost-analyzer.commonLabels" . | nindent 14 }}
+          {{- if .Values.kubecostChecks.additionalLabels }}
+          {{ toYaml .Values.kubecostChecks.additionalLabels | nindent 14 }}
+          {{- end }}
         spec:
           containers:
           - name: cost-analyzer-checks


### PR DESCRIPTION
tested by adding additional labels:

```
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2021-03-22T04:50:03Z"
  generateName: cost-analyzer-checks-1616388600-
  labels:
    app: cost-analyzer
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cost-analyzer
    controller-uid: 74eb4718-d6bd-4209-b72a-9a9ae0fe87c8
    foo: bar
    helm.sh/chart: cost-analyzer-1.76.0
    job-name: cost-analyzer-checks-1616388600
  name: cost-analyzer-checks-1616388600-6jmzj
```
