### PR TITLE
use datasource dropdown in one more spot

### DIFF
--- a/cost-analyzer/namespace-utilization.json
+++ b/cost-analyzer/namespace-utilization.json
@@ -29,7 +29,7 @@
 					"value":"avg"
 				}
 			],
-			"datasource":"default-kubecost",
+			"datasource":"${datasource}",
 			"fontSize":"100%",
 			"gridPos":{
 				"h":9,


### PR DESCRIPTION
It looks like one "default-kubecost" datasource was missed in https://github.com/kubecost/cost-analyzer-helm-chart/pull/807