### PR TITLE
#836 Ingress api fix

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -149,6 +149,17 @@ Return the appropriate apiVersion for networkpolicy.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for Ingress.
+*/}}
+{{- define "cost-analyzer.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for podsecuritypolicy.
 */}}
 {{- define "cost-analyzer.podSecurityPolicy.apiVersion" -}}

--- a/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
@@ -3,7 +3,7 @@
 {{- $fullName := include "cost-analyzer.fullname" . -}}
 {{- $serviceName := include "cost-analyzer.serviceName" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "cost-analyzer.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Fixes #836 

API "extensions/v1beta1" is deprecated since Kubernetes 1.14. Pull request will fix the issue. #836 