### PR TITLE
bump version

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: "1.77.0"
+appVersion: "1.77.1"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer
-version: 1.77.0
+version: 1.77.1
 annotations:
   "artifacthub.io/links": |
     - name: Homepage


### PR DESCRIPTION
Bump version to 1.77.1 for patch release.

This contains a fix where a NULL value in the AWS Athena data was causing panics. 