### PR TITLE
add protocol header to port names for istio support

### DIFF
--- a/cost-analyzer/charts/grafana/templates/service.yaml
+++ b/cost-analyzer/charts/grafana/templates/service.yaml
@@ -37,7 +37,7 @@ spec:
 {{ toYaml .Values.service.externalIPs | indent 4 }}
 {{- end }}
   ports:
-    - name: service
+    - name: tcp-service
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: 3000

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -26,13 +26,13 @@ spec:
   type: ClusterIP
 {{- end }}
   ports:
-    - name: server
+    - name: tcp-server
       port: 9001
       targetPort: 9001
-    - name: model
+    - name: tcp-model
       port: 9003
       targetPort: 9003
-    - name: frontend
+    - name: tcp-frontend
       {{- if .Values.kubecostFrontend.tls }}
       {{- if .Values.kubecostFrontend.tls.enabled }}
       port: 443


### PR DESCRIPTION
When kubecost was deployed on an istio-enabled cluster/namespace, kubecost was not functioning ... frontend would not connect to api. 

Per istio documenation, service ports should be named protocol-name. I did a test on one of my cluster using the changes I made in this PR and it work. I also kept the new port names and tested it successfully on a non-istio enabled cluster/namespace. My testing was minimal, we should definitely test more on the nightly builds.