### PR TITLE
Bump thanos to 0.19

### DIFF
--- a/cost-analyzer/charts/thanos/Chart.yaml
+++ b/cost-analyzer/charts/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.15.0
+appVersion: 0.19.0
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.15.0
+version: 0.19.0
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: thanosio/thanos
-  tag: v0.15.0
+  tag: v0.19.0
   pullPolicy: IfNotPresent
 
 store:


### PR DESCRIPTION
Tested on scaled out cluster. No more duplicate labels series matches as in 0.18!


http://35.232.95.104:9090/diagnostics.html

There are a few timeouts I've been investigating, but on rebuild they disappear/go green.