### PR TITLE
feat(network-costs): add affinity

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -84,6 +84,10 @@ spec:
       tolerations:
 {{ toYaml .Values.networkCosts.tolerations | indent 8 }}
     {{- end }}
+      {{- with .Values.networkCosts.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if .Values.networkCosts.config }}
       - name: network-costs-config

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -470,6 +470,8 @@ networkCosts:
   #    value: "value"
   #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+  affinity: {}
+
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   priorityClassName: []


### PR DESCRIPTION
This PR allows configuring affinity for the network-costs pods. This can be useful for creating anti-affinity rules for certain nodes, for  example EKS Fargate.