### PR TITLE
Group -> allocationFilter mapping

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-group-filters-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-group-filters-template.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.groupFilters }}
+{{- if .Values.groupFilters.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: group-filters
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data: '{{ toJson .Values.groupFilters }}'
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-group-filters-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-group-filters-template.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.groupFilters }}
-{{- if .Values.groupFilters.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,5 +8,4 @@ metadata:
 data:
   allocationFilters: '{{ toJson .Values.groupFilters.allocationFilters }}'
   assetFilters: '{{ toJson .Values.groupFilters.assetFilters }}'
-{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-group-filters-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-group-filters-template.yaml
@@ -6,6 +6,8 @@ metadata:
   name: group-filters
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-data: '{{ toJson .Values.groupFilters }}'
+data:
+  allocationFilters: '{{ toJson .Values.groupFilters.allocationFilters }}'
+  assetFilters: '{{ toJson .Values.groupFilters.assetFilters }}'
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -144,6 +144,14 @@ saml:
         assertionvalues:
           - "readonly"
 
+# Define global data filters for specific user groups
+# No filters defined by default
+# BETA: This implementation is to collect user feedback and may change dramatically.
+# Do not rely on this configuration format remaining consistent.
+groupFilters:
+  allocationFilters: {} # allocation data filters per-group
+  assetFilters: {} # asset data filters per-group
+
 # Adds an httpProxy as an environment variable. systemProxy.enabled must be `true`to have any effect.
 # Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml
 systemProxy:
@@ -545,13 +553,6 @@ serviceAccount:
   create: true # Set this to false if you're bringing your own service account.
   annotations: {}
   # name: kc-test
-
-# Define global data filters for specific user groups
-# Disabled by default
-groupFilters:
-  enabled: false
-  allocationFilters: {} # allocation data filters per-group
-  assetFilters: {} # asset data filters per-group
 
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -121,7 +121,7 @@ pricingCsv:
 
 # SAML integration for user management and RBAC, enterprise key required
 # Ref: https://github.com/kubecost/docs/blob/master/user-management.md
-saml: 
+saml:
   enabled: false
   secretName: "kubecost-authzero"
   #metadataSecretName: "kubecost-authzero-metadata" # One of metadataSecretName or idpMetadataURL must be set. defaults to metadataURL if set
@@ -412,9 +412,9 @@ networkCosts:
   imagePullPolicy: Always
   # For existing Prometheus Installs, create a Service which generates Endpoints for each of the network-costs pods.
   # This Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.
-  # NOTE: Setting this option to true and leaving the above extraScrapeConfig "job_name: kubecost-networking" configured will cause the 
-  # NOTE: pods to be scraped twice. 
-  prometheusScrape: false 
+  # NOTE: Setting this option to true and leaving the above extraScrapeConfig "job_name: kubecost-networking" configured will cause the
+  # NOTE: pods to be scraped twice.
+  prometheusScrape: false
   # Traffic Logging will enable logging the top 5 destinations for each source
   # every 30 minutes.
   trafficLogging: true
@@ -481,7 +481,7 @@ networkCosts:
   additionalLabels: {}
   nodeSelector: {}
   annotations: {}
-  
+
 # Kubecost Deployment Configuration
 # Used for HA mode in Business & Enterprise tier
 kubecostDeployment:
@@ -546,6 +546,12 @@ serviceAccount:
   annotations: {}
   # name: kc-test
 
+# Define global data filters for specific user groups
+# Disabled by default
+groupFilters:
+  enabled: false
+  allocationFilters: {} # allocation data filters per-group
+  assetFilters: {} # asset data filters per-group
 
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request
 


### PR DESCRIPTION
Maybe the template should only run if SAML is enabled as well? This PR represents it as a standalone config setting.

### Testing done

Installed the chart as-is

App behavior: normal as expected

Then uninstalled, edited `values.yaml` to include

```
groupFilters:
  enabled: true
  allocationFilters:
    admin:
      namespace:
        - kubecost
  assetFilters: {}
```

and reinstalled.

App behavior: still normal as expected

Then edited the `auth.go` `Groups()` function to return `[]string{admin}` (short circuit to always get admin group). Built and deployed this image to the cluster.

App behavior: Now the Allocations view aggregated by namespace only shows the `kubecost` namespace + `__idle__` !


Have yet to do end-to-end testing with an actual SAML-based identity provider.