### PR TITLE
Disable checks cronjob by default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -157,7 +157,7 @@ systemProxy:
 
 # Manages Kubecost alerts
 kubecostChecks:
-  enabled: true
+  enabled: false
   image: "quay.io/kubecost1/checks"
   resources:
     requests:


### PR DESCRIPTION
The checks cronjob is being deprecated in favor of moving our alerting system within the cost-model pod.