### PR TITLE
Stop warming the legacy cache

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -195,7 +195,7 @@ kubecostModel:
   # kubecost_cloud_expense_total metrics
   outOfClusterPromMetricsEnabled: false
   # Build local cost allocation cache
-  warmCache: true
+  warmCache: false
   # Build local savings cache
   warmSavingsCache: true
   # Run allocation ETL pipelines


### PR DESCRIPTION
Stops warming the legacy cache, which made the default view on the legacy cost-allocation page load quickly. That page has been deprecated, though it is still available by navigating directly to /details.html

This will dramatically decrease prometheus resource utilization.