### PR TITLE
Correct ServiceMonitor endpoint object

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.79.0"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer
-version: 1.79.0
+version: 1.79.1
 annotations:
   "artifacthub.io/links": |
     - name: Homepage

--- a/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: model
+    - port: cost-model
       honorLabels: true
       interval: 1m
       scrapeTimeout: 10s

--- a/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: cost-model
+    - port: tcp-model
       honorLabels: true
       interval: 1m
       scrapeTimeout: 10s


### PR DESCRIPTION
# Bug fix
The endpoint of the cost-analyzer `ServiceMonitor` points to a non-existing port in the `service` object.
This PR fixes the mismatch between the ServiceMonitor endpoint port, and the service ports names