### PR TITLE
Release patch

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.79.0"
+appVersion: "1.79.1"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer


### PR DESCRIPTION
One liner helm chart change to support servicemonitor. Tested by quickly running through http://35.192.75.47:9090/settings.html