### PR TITLE
bump ksm version

### DIFF
--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -25,7 +25,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 7.5.4
+  tag: 7.5.6
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.
@@ -255,7 +255,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:1.11.1
+  image: kiwigrid/k8s-sidecar:1.12.0
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/values.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/values.yaml
@@ -2,7 +2,7 @@
 prometheusScrape: true
 image:
   repository: quay.io/coreos/kube-state-metrics
-  tag: v1.9.5
+  tag: v1.9.8
   pullPolicy: IfNotPresent
 
 # If set to true, this will deploy kube-state-metrics as a StatefulSet and the data


### PR DESCRIPTION
Bumps KSM to v1.98 in the default installation. Many users are already using ksm v1.9.8 on their BYO-prometheus installations.

Tested on integration test clusters.