### PR TITLE
Add imagepullsecrets to containers missing them

### DIFF
--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/deployment.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.imagePullSecrets | indent 2 }}
+{{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       serviceAccountName: {{ template "kube-state-metrics.serviceAccountName" . }}
       {{- if .Values.securityContext.enabled }}

--- a/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+       {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }}
       containers:
       - name: thanos-bucket
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
@@ -37,6 +37,10 @@ spec:
         prometheus.io/port: "{{ .Values.compact.http.port }}"
       {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+       {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }}
       containers:
       - name: thanos-compact
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/charts/thanos/templates/query-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-deployment.yaml
@@ -39,6 +39,10 @@ spec:
         prometheus.io/port: "{{ .Values.query.http.port }}"
       {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+       {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }}
       containers:
       - name: thanos-query
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
@@ -39,6 +39,10 @@ spec:
         prometheus.io/port: "{{ .Values.queryFrontend.http.port }}"
       {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+       {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }}
       containers:
       - name: thanos-query-frontend
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/charts/thanos/templates/store-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-deployment.yaml
@@ -37,6 +37,10 @@ spec:
       prometheus.io/port: "{{ .Values.store.http.port }}"
       {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+       {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }}
       containers:
       - name: thanos-store
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -24,6 +24,10 @@ spec:
         {{ toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
         {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }}
       hostNetwork: true
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
Testing done:
 helm template cost-analyzer-helm-chart/cost-analyzer -f cost-analyzer-helm-chart/cost-analyzer/values.yaml > out.yaml

Uncomment values.yaml imagepullsecrets block, note this appears in all templates when above command run.