### PR TITLE
Replaced old request metrics with the new metrics

### DIFF
--- a/cost-analyzer/cluster-metrics.json
+++ b/cost-analyzer/cluster-metrics.json
@@ -544,7 +544,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "SUM(kube_pod_container_resource_requests{resource="cpu", unit="core"}) / SUM(kube_node_status_allocatable_cpu_cores) * 100",
+          "expr": "SUM(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"}) / SUM(kube_node_status_allocatable_cpu_cores) * 100",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -727,7 +727,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"})\n /\n sum(kube_node_status_allocatable_memory_bytes)\n) * 100",
+          "expr": "(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"})\n /\n sum(kube_node_status_allocatable_memory_bytes)\n) * 100",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/cost-analyzer/cluster-metrics.json
+++ b/cost-analyzer/cluster-metrics.json
@@ -544,7 +544,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "SUM(kube_pod_container_resource_requests_cpu_cores) / SUM(kube_node_status_allocatable_cpu_cores) * 100",
+          "expr": "SUM(kube_pod_container_resource_requests{resource="cpu", unit="core"}) / SUM(kube_node_status_allocatable_cpu_cores) * 100",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -727,7 +727,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(\n sum(kube_pod_container_resource_requests_memory_bytes{namespace!=\"\"})\n /\n sum(kube_node_status_allocatable_memory_bytes)\n) * 100",
+          "expr": "(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"})\n /\n sum(kube_node_status_allocatable_memory_bytes)\n) * 100",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/cost-analyzer/cluster-utilization.json
+++ b/cost-analyzer/cluster-utilization.json
@@ -557,7 +557,7 @@
             "tableColumn":"",
             "targets":[
                 {
-                    "expr":"SUM(kube_pod_container_resource_requests{resource="cpu", unit="core"}) / SUM(kube_node_status_allocatable_cpu_cores) * 100",
+                    "expr":"SUM(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"}) / SUM(kube_node_status_allocatable_cpu_cores) * 100",
                     "format":"time_series",
                     "interval":"",
                     "intervalFactor":1,
@@ -744,7 +744,7 @@
             "tableColumn":"",
             "targets":[
                 {
-                    "expr":"(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"})\n /\n sum(kube_node_status_allocatable_memory_bytes)\n) * 100",
+                    "expr":"(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"})\n /\n sum(kube_node_status_allocatable_memory_bytes)\n) * 100",
                     "format":"time_series",
                     "interval":"",
                     "intervalFactor":1,
@@ -1317,7 +1317,7 @@
             ],
             "targets":[
                 {
-                    "expr":"(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
+                    "expr":"(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
                     "format":"table",
                     "hide":false,
                     "instant":true,
@@ -1327,7 +1327,7 @@
                     "refId":"A"
                 },
                 {
-                    "expr":"(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
+                    "expr":"(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
                     "format":"table",
                     "instant":true,
                     "intervalFactor":1,
@@ -1343,7 +1343,7 @@
                     "refId":"C"
                 },
                 {
-                    "expr":"# CPU \n(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n#END CPU \n# Memory \n\n(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n# PV storage\n\n(\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageSSD \n\nor\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageStandard \n)",
+                    "expr":"# CPU \n(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n#END CPU \n# Memory \n\n(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n# PV storage\n\n(\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageSSD \n\nor\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageStandard \n)",
                     "format":"table",
                     "instant":true,
                     "intervalFactor":1,
@@ -1425,7 +1425,7 @@
                     "refId":"A"
                 },
                 {
-                    "expr":"SUM(kube_pod_container_resource_requests{resource="cpu", unit="core"})",
+                    "expr":"SUM(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"})",
                     "format":"time_series",
                     "intervalFactor":1,
                     "legendFormat":"requests",
@@ -1729,7 +1729,7 @@
             ],
             "targets":[
                 {
-                    "expr":"sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\"}) by (namespace) ",
+                    "expr":"sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\"}) by (namespace) ",
                     "format":"table",
                     "hide":false,
                     "instant":true,
@@ -1886,7 +1886,7 @@
                     "refId":"B"
                 },
                 {
-                    "expr":"sum(kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (node) / sum(kube_node_status_capacity_cpu_cores) by (node)",
+                    "expr":"sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"}) by (node) / sum(kube_node_status_capacity_cpu_cores) by (node)",
                     "format":"table",
                     "instant":true,
                     "intervalFactor":1,
@@ -1965,7 +1965,7 @@
                     "refId":"A"
                 },
                 {
-                    "expr":"SUM(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"} / 1024 / 1024 / 1024)",
+                    "expr":"SUM(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"} / 1024 / 1024 / 1024)",
                     "format":"time_series",
                     "intervalFactor":1,
                     "legendFormat":"requests",
@@ -2269,7 +2269,7 @@
             ],
             "targets":[
                 {
-                    "expr":"sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"} / 1024 / 1024 / 1024) by (namespace) ",
+                    "expr":"sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"} / 1024 / 1024 / 1024) by (namespace) ",
                     "format":"table",
                     "hide":false,
                     "instant":true,
@@ -2426,7 +2426,7 @@
                     "refId":"B"
                 },
                 {
-                    "expr":"sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"}) by (node) / SUM(kube_node_status_capacity_memory_bytes) by (node)",
+                    "expr":"sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"}) by (node) / SUM(kube_node_status_capacity_memory_bytes) by (node)",
                     "format":"table",
                     "instant":true,
                     "intervalFactor":1,

--- a/cost-analyzer/cluster-utilization.json
+++ b/cost-analyzer/cluster-utilization.json
@@ -557,7 +557,7 @@
             "tableColumn":"",
             "targets":[
                 {
-                    "expr":"SUM(kube_pod_container_resource_requests_cpu_cores) / SUM(kube_node_status_allocatable_cpu_cores) * 100",
+                    "expr":"SUM(kube_pod_container_resource_requests{resource="cpu", unit="core"}) / SUM(kube_node_status_allocatable_cpu_cores) * 100",
                     "format":"time_series",
                     "interval":"",
                     "intervalFactor":1,
@@ -744,7 +744,7 @@
             "tableColumn":"",
             "targets":[
                 {
-                    "expr":"(\n sum(kube_pod_container_resource_requests_memory_bytes{namespace!=\"\"})\n /\n sum(kube_node_status_allocatable_memory_bytes)\n) * 100",
+                    "expr":"(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"})\n /\n sum(kube_node_status_allocatable_memory_bytes)\n) * 100",
                     "format":"time_series",
                     "interval":"",
                     "intervalFactor":1,
@@ -1317,7 +1317,7 @@
             ],
             "targets":[
                 {
-                    "expr":"(\n sum(kube_pod_container_resource_requests_cpu_cores{namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests_cpu_cores{namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
+                    "expr":"(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
                     "format":"table",
                     "hide":false,
                     "instant":true,
@@ -1327,7 +1327,7 @@
                     "refId":"A"
                 },
                 {
-                    "expr":"(\n sum(kube_pod_container_resource_requests_memory_bytes{namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests_memory_bytes{namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
+                    "expr":"(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
                     "format":"table",
                     "instant":true,
                     "intervalFactor":1,
@@ -1343,7 +1343,7 @@
                     "refId":"C"
                 },
                 {
-                    "expr":"# CPU \n(\n sum(kube_pod_container_resource_requests_cpu_cores{namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests_cpu_cores{namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n#END CPU \n# Memory \n\n(\n sum(kube_pod_container_resource_requests_memory_bytes{namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests_memory_bytes{namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n# PV storage\n\n(\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageSSD \n\nor\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageStandard \n)",
+                    "expr":"# CPU \n(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n#END CPU \n# Memory \n\n(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n# PV storage\n\n(\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageSSD \n\nor\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageStandard \n)",
                     "format":"table",
                     "instant":true,
                     "intervalFactor":1,
@@ -1425,7 +1425,7 @@
                     "refId":"A"
                 },
                 {
-                    "expr":"SUM(kube_pod_container_resource_requests_cpu_cores)",
+                    "expr":"SUM(kube_pod_container_resource_requests{resource="cpu", unit="core"})",
                     "format":"time_series",
                     "intervalFactor":1,
                     "legendFormat":"requests",
@@ -1729,7 +1729,7 @@
             ],
             "targets":[
                 {
-                    "expr":"sum(kube_pod_container_resource_requests_cpu_cores{namespace!=\"\"}) by (namespace) ",
+                    "expr":"sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!=\"\"}) by (namespace) ",
                     "format":"table",
                     "hide":false,
                     "instant":true,
@@ -1886,7 +1886,7 @@
                     "refId":"B"
                 },
                 {
-                    "expr":"sum(kube_pod_container_resource_requests_cpu_cores) by (node) / sum(kube_node_status_capacity_cpu_cores) by (node)",
+                    "expr":"sum(kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (node) / sum(kube_node_status_capacity_cpu_cores) by (node)",
                     "format":"table",
                     "instant":true,
                     "intervalFactor":1,
@@ -1965,7 +1965,7 @@
                     "refId":"A"
                 },
                 {
-                    "expr":"SUM(kube_pod_container_resource_requests_memory_bytes{namespace!=\"\"} / 1024 / 1024 / 1024)",
+                    "expr":"SUM(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"} / 1024 / 1024 / 1024)",
                     "format":"time_series",
                     "intervalFactor":1,
                     "legendFormat":"requests",
@@ -2269,7 +2269,7 @@
             ],
             "targets":[
                 {
-                    "expr":"sum(kube_pod_container_resource_requests_memory_bytes{namespace!=\"\"} / 1024 / 1024 / 1024) by (namespace) ",
+                    "expr":"sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"} / 1024 / 1024 / 1024) by (namespace) ",
                     "format":"table",
                     "hide":false,
                     "instant":true,
@@ -2426,7 +2426,7 @@
                     "refId":"B"
                 },
                 {
-                    "expr":"sum(kube_pod_container_resource_requests_memory_bytes{namespace!=\"\"}) by (node) / SUM(kube_node_status_capacity_memory_bytes) by (node)",
+                    "expr":"sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!=\"\"}) by (node) / SUM(kube_node_status_capacity_memory_bytes) by (node)",
                     "format":"table",
                     "instant":true,
                     "intervalFactor":1,

--- a/cost-analyzer/deployment-utilization.json
+++ b/cost-analyzer/deployment-utilization.json
@@ -845,7 +845,7 @@
           "step": 60
         },
         {
-          "expr": "sum (kube_pod_container_resource_requests{resource="cpu", unit="core", pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"}) by (pod,node)",
+          "expr": "sum (kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"}) by (pod,node)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -966,7 +966,7 @@
           "step": 60
         },
         {
-          "expr": "sum ((kube_pod_container_resource_requests{resource="memory", unit="byte", pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"})) by (pod,node)",
+          "expr": "sum ((kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"})) by (pod,node)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "rqst: {{ node }} | {{ pod }}",

--- a/cost-analyzer/deployment-utilization.json
+++ b/cost-analyzer/deployment-utilization.json
@@ -845,7 +845,7 @@
           "step": 60
         },
         {
-          "expr": "sum (kube_pod_container_resource_requests_cpu_cores{pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"}) by (pod,node)",
+          "expr": "sum (kube_pod_container_resource_requests{resource="cpu", unit="core", pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"}) by (pod,node)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -966,7 +966,7 @@
           "step": 60
         },
         {
-          "expr": "sum ((kube_pod_container_resource_requests_memory_bytes{pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"})) by (pod,node)",
+          "expr": "sum ((kube_pod_container_resource_requests{resource="memory", unit="byte", pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"})) by (pod,node)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "rqst: {{ node }} | {{ pod }}",

--- a/cost-analyzer/label-cost-utilization.json
+++ b/cost-analyzer/label-cost-utilization.json
@@ -432,7 +432,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(\n sum (kube_pod_container_resource_requests_cpu_cores) by (pod)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod)\n or up * 0\n) ",
+          "expr": "sum(\n sum (kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (pod)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod)\n or up * 0\n) ",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -594,7 +594,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(\n sum (kube_pod_container_resource_requests_memory_bytes) by (pod)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod)\n or up * 0\n) ",
+          "expr": "sum(\n sum (kube_pod_container_resource_requests{resource="memory", unit="byte"}) by (pod)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod)\n or up * 0\n) ",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -820,7 +820,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(\n label_replace(\n sum (kube_pod_container_resource_requests_cpu_cores) by (pod, container)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container),\n \"container_name\",\n \"$1\", \n \"container\", \n \"(.+)\"\n )\n) \n",
+          "expr": "sum(\n label_replace(\n sum (kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (pod, container)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container),\n \"container_name\",\n \"$1\", \n \"container\", \n \"(.+)\"\n )\n) \n",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "request",
@@ -918,7 +918,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(\n label_replace(\n sum (kube_pod_container_resource_requests_memory_bytes) by (pod, container)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container),\n \"container_name\",\n \"$1\", \n \"container\", \n \"(.+)\"\n )\n) \n",
+          "expr": "sum(\n label_replace(\n sum (kube_pod_container_resource_requests{resource="memory", unit="byte"}) by (pod, container)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container),\n \"container_name\",\n \"$1\", \n \"container\", \n \"(.+)\"\n )\n) \n",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "request",

--- a/cost-analyzer/namespace-utilization.json
+++ b/cost-analyzer/namespace-utilization.json
@@ -412,7 +412,7 @@
 			"steppedLine":false,
 			"targets":[
 				{
-					"expr":"topk(10,\n label_replace(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace=\"$namespace\"}) by (pod),\n \"pod_name\", \n \"$1\", \n \"pod\", \n \"(.+)\"\n ) \n/ on (pod_name) sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",pod_name=~\".+\"}[1h])) by (pod_name))",
+					"expr":"topk(10,\n label_replace(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace=\"$namespace\"}) by (pod),\n \"pod_name\", \n \"$1\", \n \"pod\", \n \"(.+)\"\n ) \n/ on (pod_name) sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",pod_name=~\".+\"}[1h])) by (pod_name))",
 					"format":"time_series",
 					"intervalFactor":1,
 					"refId":"A"

--- a/cost-analyzer/namespace-utilization.json
+++ b/cost-analyzer/namespace-utilization.json
@@ -412,7 +412,7 @@
 			"steppedLine":false,
 			"targets":[
 				{
-					"expr":"topk(10,\n label_replace(\n sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\"}) by (pod),\n \"pod_name\", \n \"$1\", \n \"pod\", \n \"(.+)\"\n ) \n/ on (pod_name) sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",pod_name=~\".+\"}[1h])) by (pod_name))",
+					"expr":"topk(10,\n label_replace(\n sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace=\"$namespace\"}) by (pod),\n \"pod_name\", \n \"$1\", \n \"pod\", \n \"(.+)\"\n ) \n/ on (pod_name) sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",pod_name=~\".+\"}[1h])) by (pod_name))",
 					"format":"time_series",
 					"intervalFactor":1,
 					"refId":"A"

--- a/cost-analyzer/node-utilization.json
+++ b/cost-analyzer/node-utilization.json
@@ -454,7 +454,7 @@
 					"refId":"C"
 				},
 				{
-					"expr":"sum(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests_cpu_cores{container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod), \n\"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)",
+					"expr":"sum(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests{resource="cpu", unit="core", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod), \n\"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)",
 					"format":"table",
 					"instant":true,
 					"intervalFactor":1,
@@ -468,7 +468,7 @@
 					"refId":"D"
 				},
 				{
-					"expr":"sum(label_replace(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests_memory_bytes{container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod),\n\"container_name\",\"$1\",\"container\",\"(.+)\"), \"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)\n",
+					"expr":"sum(label_replace(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests{resource="memory", unit="byte", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod),\n\"container_name\",\"$1\",\"container\",\"(.+)\"), \"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)\n",
 					"format":"table",
 					"instant":true,
 					"intervalFactor":1,
@@ -546,7 +546,7 @@
 			"tableColumn":"",
 			"targets":[
 				{
-					"expr":"sum(\n count(avg_over_time(kube_pod_container_resource_requests_cpu_cores{container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod)\n * on (pod) group_right()\n sum(kube_pod_container_status_running) by (pod)\n)",
+					"expr":"sum(\n count(avg_over_time(kube_pod_container_resource_requests{resource="cpu", unit="core", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod)\n * on (pod) group_right()\n sum(kube_pod_container_status_running) by (pod)\n)",
 					"format":"time_series",
 					"instant":true,
 					"intervalFactor":1,

--- a/cost-analyzer/node-utilization.json
+++ b/cost-analyzer/node-utilization.json
@@ -454,7 +454,7 @@
 					"refId":"C"
 				},
 				{
-					"expr":"sum(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests{resource="cpu", unit="core", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod), \n\"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)",
+					"expr":"sum(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod), \n\"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)",
 					"format":"table",
 					"instant":true,
 					"intervalFactor":1,
@@ -468,7 +468,7 @@
 					"refId":"D"
 				},
 				{
-					"expr":"sum(label_replace(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests{resource="memory", unit="byte", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod),\n\"container_name\",\"$1\",\"container\",\"(.+)\"), \"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)\n",
+					"expr":"sum(label_replace(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod),\n\"container_name\",\"$1\",\"container\",\"(.+)\"), \"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)\n",
 					"format":"table",
 					"instant":true,
 					"intervalFactor":1,
@@ -546,7 +546,7 @@
 			"tableColumn":"",
 			"targets":[
 				{
-					"expr":"sum(\n count(avg_over_time(kube_pod_container_resource_requests{resource="cpu", unit="core", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod)\n * on (pod) group_right()\n sum(kube_pod_container_status_running) by (pod)\n)",
+					"expr":"sum(\n count(avg_over_time(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod)\n * on (pod) group_right()\n sum(kube_pod_container_status_running) by (pod)\n)",
 					"format":"time_series",
 					"instant":true,
 					"intervalFactor":1,

--- a/cost-analyzer/pod-utilization.json
+++ b/cost-analyzer/pod-utilization.json
@@ -123,7 +123,7 @@
         },
         {
           "exemplar": true,
-          "expr": "avg(kube_pod_container_resource_requests_cpu_cores{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"}) by (container)",
+          "expr": "avg(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"}) by (container)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -284,7 +284,7 @@
         },
         {
           "exemplar": true,
-          "expr": "avg(kube_pod_container_resource_requests_memory_bytes{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"}) by (container)",
+          "expr": "avg(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"}) by (container)",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/cost-analyzer/pod-utilization.json
+++ b/cost-analyzer/pod-utilization.json
@@ -123,7 +123,7 @@
         },
         {
           "exemplar": true,
-          "expr": "avg(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"}) by (container)",
+          "expr": "avg(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"}) by (container)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -284,7 +284,7 @@
         },
         {
           "exemplar": true,
-          "expr": "avg(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"}) by (container)",
+          "expr": "avg(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"}) by (container)",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -358,7 +358,7 @@ prometheus:
   #        - url: "http://pgprometheus-adapter:9201/write"
   #          write_relabel_configs:
   #            - source_labels: [__name__]
-  #              regex: 'container_.*_allocation|container_.*_allocation_bytes|.*_hourly_cost|kube_pod_container_resource_requests_memory_bytes|container_memory_working_set_bytes|kube_pod_container_resource_requests_cpu_cores|kube_pod_container_resource_requests|pod_pvc_allocation|kube_namespace_labels|kube_pod_labels'
+  #              regex: 'container_.*_allocation|container_.*_allocation_bytes|.*_hourly_cost|kube_pod_container_resource_requests{resource="memory", unit="byte"}|container_memory_working_set_bytes|kube_pod_container_resource_requests{resource="cpu", unit="core"}|kube_pod_container_resource_requests|pod_pvc_allocation|kube_namespace_labels|kube_pod_labels'
   #              action: keep
   #          queue_config:
   #            max_samples_per_send: 1000
@@ -402,9 +402,9 @@ prometheus:
               record: kubecost_savings_container_cpu_usage_seconds
             - expr: sum(container_memory_working_set_bytes{container_name!="",container_name!="POD",instance!=""}) by (namespace, pod_name, container_name, instance)
               record: kubecost_savings_container_memory_usage_bytes
-            - expr: avg(sum(kube_pod_container_resource_requests_cpu_cores{namespace!="kube-system"}) by (pod, namespace, instance)) by (pod, namespace)
+            - expr: avg(sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!="kube-system"}) by (pod, namespace, instance)) by (pod, namespace)
               record: kubecost_savings_pod_requests_cpu_cores
-            - expr: avg(sum(kube_pod_container_resource_requests_memory_bytes{namespace!="kube-system"}) by (pod, namespace, instance)) by (pod, namespace)
+            - expr: avg(sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!="kube-system"}) by (pod, namespace, instance)) by (pod, namespace)
               record: kubecost_savings_pod_requests_memory_bytes
 
 ## Module for measuring network costs


### PR DESCRIPTION
Replaced `kube_pod_container_resource_requests_cpu_cores`
and `kube_pod_container_resource_requests_memory_bytes`
with `kube_pod_container_resource_requests{resource="cpu", unit="core"}`
and `kube_pod_container_resource_requests{resource="memory", unit="byte"}`
respectively.

Necessary because in KSM v2.0+, the old metrics have been removed.
This particular migration is easy because we whitelisted
`kube_pod_container_resource_requests` many months ago, at the same
time we whitelisted the old metrics being replaced in this commit.

Achieved with:
```
fd --type f | xargs sed -i 's/kube_pod_container_resource_requests_memory_bytes{/kube_pod_container_resource_requests{resource="memory", unit="byte", /g'

fd --type f | xargs sed -i 's/kube_pod_container_resource_requests_memory_bytes/kube_pod_container_resource_requests{resource="memory", unit="byte"}/g'

fd --type f | xargs sed -i 's/kube_pod_container_resource_requests_cpu_cores{/kube_pod_container_resource_requests{resource="cpu", unit="core", /g'

fd --type f | xargs sed -i 's/kube_pod_container_resource_requests_cpu_cores/kube_pod_container_resource_requests{resource="cpu", unit="core"}/g'
```

## Testing
See https://github.com/kubecost/kubecost-cost-model/pull/427