### PR TITLE
Update default chunk pool size

### DIFF
--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -66,6 +66,7 @@ prometheus:
 thanos:
   store:
     enabled: true
+    chunkPoolSize: 8GB
     grpcSeriesMaxConcurrency: 20
     blockSyncConcurrency: 20
     extraEnv:


### PR DESCRIPTION
Updates the default chunk pool size to be a bit more in line with a mid-size user's needs. Unfortunately when the chunk pool is exhausted, thanos can silently fail so it is better to be a bit high here than too low.