### PR TITLE
Fix missing assetReports.reports key

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -120,6 +120,7 @@ global:
   # Ref: http://docs.kubecost.com/saved-reports
   assetReports:
     enabled: false # If true, overwrites report parameters set through UI
+    reports:
     - title: "Example Asset Report 0"
       window: "today"
       aggregateBy: "type"


### PR DESCRIPTION
The `global.assetReports.reports` key was missing causing the YAML to be invalid.