### PR TITLE
Allow adding annotations to dashboard configmaps

### DIFF
--- a/cost-analyzer/templates/grafana-attached-disk-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-attached-disk-metrics-template.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- else }}
     grafana_dashboard: "1"
     {{- end }}
+  annotations:
+{{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
 data:
     attached-disks.json: |-
 {{ .Files.Get "attached-disks.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- else }}
     grafana_dashboard: "1"
     {{- end }}
+  annotations:
+{{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
 data:
     cluster-metrics.json: |-
 {{ .Files.Get "cluster-metrics.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- else }}
     grafana_dashboard: "1"
     {{- end }}
+  annotations:
+{{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
 data:
     cluster-utilization.json: |-
 {{ .Files.Get "cluster-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- else }}
     grafana_dashboard: "1"
     {{- end }}
+  annotations:
+{{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
 data:
     deployment-utilization.json: |-
 {{ .Files.Get "deployment-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- else }}
     grafana_dashboard: "1"
     {{- end }}
+  annotations:
+{{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
 data:
     label-cost-utilization.json: |-
 {{ .Files.Get "label-cost-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- else }}
     grafana_dashboard: "1"
     {{- end }}
+  annotations:
+{{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
 data:
     namespace-utilization.json: |-
 {{ .Files.Get "namespace-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- else }}
     grafana_dashboard: "1"
     {{- end }}
+  annotations:
+{{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
 data:
     node-utilization.json: |-
 {{ .Files.Get "node-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- else }}
     grafana_dashboard: "1"
     {{- end }}
+  annotations:
+{{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
 data:
     pod-utilization.json: |-
 {{ .Files.Get "pod-utilization.json" | indent 8 }}

--- a/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- else }}
     grafana_dashboard: "1"
     {{- end }}
+  annotations:
+{{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
 data:
     prom-benchmark.json: |-
 {{ .Files.Get "prom-benchmark.json" | indent 8 }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -549,6 +549,7 @@ grafana:
       # label that the configmaps with dashboards are marked with
       label: grafana_dashboard
       # set sidecar ERROR_THROTTLE_SLEEP env var from default 5s to 0s -> fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/877
+      annotations: {}
       error_throttle_sleep: 0
     datasources:
       # dataSourceFilename: foo.yml # If you need to change the name of the datasource file


### PR DESCRIPTION
When a Grafana instance is used for more than 1 purpose, it is useful to be able to organize the dashboards into folders. Personally, I use the kube-prometheus-stack Grafana instance where I've configured `grafana.sidecar.dashboards.folderAnnotation: k8s-sidecar-target-directory`. This allows me to have Grafana place dashboards into a folder based on an annotation on the dashboard configmap. I was trying to place the KubeCost dashboards into a folder by adding `grafana.sidecar.dashboards.annotations.k8s-sidecar-target-directory: /tmp/dashboards/KubeCost` as a value in the Helm chart. However, the dashboard configmaps were not setup to allow adding annotations to them.

This PR adds the ability for people to add annotations to the Grafana dashboards deployed as part of this chart.

/cc @AjayTripathy 