### PR TITLE
Add multi-cloud config secret

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -117,13 +117,13 @@ spec:
           secret:
             secretName: azure-storage-config
         {{- end }}
-        {{- if .Values.kubecostProductConfigs.multiCloudSecret }}
-        - name: multi-cloud-config
+        {{- if .Values.kubecostProductConfigs.cloudIntegrationSecret }}
+        - name: cloud-integration
           secret:
-            secretName: {{ .Values.kubecostProductConfigs.multiCloudSecret }}
+            secretName: {{ .Values.kubecostProductConfigs.cloudIntegrationSecret }}
             items:
-              - key: multi-cloud-config.json
-                path: multi-cloud-config.json
+              - key: cloud-integration.json
+                path: cloud-integration.json
         {{- end }}
         {{- if .Values.kubecostProductConfigs.clusters }}
         - name: kubecost-clusters
@@ -283,9 +283,9 @@ spec:
             - name: azure-storage-config
               mountPath: /var/azure-storage-config
             {{- end }}
-            {{- if .Values.kubecostProductConfigs.multiCloudSecret}}
-            - name: multi-cloud-config
-              mountPath: /var/multi-cloud-config
+            {{- if .Values.kubecostProductConfigs.cloudIntegrationSecret}}
+            - name: cloud-integration
+              mountPath: /var/cloud-integration
             {{- end }}
             {{- if or .Values.kubecostProductConfigs.serviceKeySecretName .Values.kubecostProductConfigs.createServiceKeySecret }}
             - name: service-key-secret

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -117,6 +117,14 @@ spec:
           secret:
             secretName: azure-storage-config
         {{- end }}
+        {{- if .Values.kubecostProductConfigs.multiCloudSecret }}
+        - name: multi-cloud-config
+          secret:
+            secretName: {{ .Values.kubecostProductConfigs.multiCloudSecret }}
+            items:
+              - key: multi-cloud-config.json
+                path: multi-cloud-config.json
+        {{- end }}
         {{- if .Values.kubecostProductConfigs.clusters }}
         - name: kubecost-clusters
           configMap:
@@ -274,6 +282,10 @@ spec:
             {{- if or .Values.kubecostProductConfigs.azureStorageSecretName .Values.kubecostProductConfigs.azureStorageCreateSecret}}
             - name: azure-storage-config
               mountPath: /var/azure-storage-config
+            {{- end }}
+            {{- if .Values.kubecostProductConfigs.multiCloudSecret}}
+            - name: multi-cloud-config
+              mountPath: /var/multi-cloud-config
             {{- end }}
             {{- if or .Values.kubecostProductConfigs.serviceKeySecretName .Values.kubecostProductConfigs.createServiceKeySecret }}
             - name: service-key-secret

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -671,4 +671,4 @@ serviceAccount:
 #    key: ""
 #    enabled: false
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
-#  multiCloudSecret: "multi-cloud-config"
+#  multiCloudSecret: "multi-cloud-config"#  cloudIntegrationSecret: "cloud-integration"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -671,3 +671,4 @@ serviceAccount:
 #    key: ""
 #    enabled: false
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
+#  multiCloudSecret: "multi-cloud-config"


### PR DESCRIPTION
Required by: https://github.com/kubecost/kubecost-cost-model/pull/445
Related to : https://github.com/kubecost/cost-model/pull/856

Update to mount secret containing multi-cloud-config. Enabling multi-cloud and multi-account cloud resources and reconciliation.