### PR TITLE
Create shareTenancyCosts flag

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -73,6 +73,13 @@ data:
   {{- if .Values.kubecostProductConfigs.sharedNamespaces }}
     sharedNamespaces: "{{ .Values.kubecostProductConfigs.sharedNamespaces }}"
   {{- end -}}
+  {{- if gt (len (toString .Values.kubecostProductConfigs.shareTenancyCosts)) 0 }}
+  {{- if eq (toString .Values.kubecostProductConfigs.shareTenancyCosts) "false" }}
+    shareTenancyCosts: "false"
+  {{- else if eq (toString .Values.kubecostProductConfigs.shareTenancyCosts) "true" }}
+    shareTenancyCosts: "true"
+  {{- end -}}
+  {{- end -}}
   {{- if .Values.kubecostProductConfigs.spotLabel }}
     spotLabel: "{{ .Values.kubecostProductConfigs.spotLabel }}"
   {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -667,6 +667,7 @@ serviceAccount:
 #  serviceKeySecretName: "" # Use an existing AWS or Azure secret with format as in aws-service-key-secret.yaml or azure-service-key-secret.yaml. Leave blank if using createServiceKeySecret
 #  createServiceKeySecret: true # Creates a secret representing your cloud service key based on data in values.yaml. If you are storing unencrypted values, add a secret manually
 #  sharedNamespaces: "" # namespaces with shared workloads, example value: "kube-system\,ingress-nginx\,kubecost\,monitoring"
+#  shareTenancyCosts: true # enable or disable sharing costs such as cluster management fees (defaults to "true" on Settings page)
 #  productKey: # apply business or enterprise product license
 #    key: ""
 #    enabled: false


### PR DESCRIPTION
Requires https://github.com/kubecost/cost-model/pull/864
Requires https://github.com/kubecost/kubecost-cost-model/pull/471
Requires https://github.com/kubecost/cost-analyzer-frontend/pull/328

## Changes
- Add flag to set `shareTenancyCosts` to `true` or `false`, but defaulting to whatever Settings has stored.

## Testing

### helm template
If not explicitly set, it should default to no values:
- `helm template ./cost-analyzer` produces no ConfigMap at all (same previous behavior)
- `helm template ./cost-analyzer --set kubecostProductConfigs.clusterName=niko` produces a ConfigMap with only `clusterName` set (no `shareTenancyCosts` value is set)

If explicitly set, if should contain that value:
- `helm template ./cost-analyzer --set kubecostProductConfigs.shareTenancyCosts=true` produces no ConfigMap with `shareTenancyCosts: "true"`
- `helm template ./cost-analyzer --set kubecostProductConfigs.shareTenancyCosts=false` produces no ConfigMap with `shareTenancyCosts: "false"`

### Manual use
- Without passing anything, the setting is enabled.
- `helm upgrade` with `--set kubecostProductConfigs.shareTenancyCosts=false` does disable the setting, as intended.
- `helm upgrade` with `--set kubecostProductConfigs.shareTenancyCosts=true` does enable the setting, as intended.
