### PR TITLE
Add helm config parameter for shared overhead costs

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -73,6 +73,9 @@ data:
   {{- if .Values.kubecostProductConfigs.sharedNamespaces }}
     sharedNamespaces: "{{ .Values.kubecostProductConfigs.sharedNamespaces }}"
   {{- end -}}
+  {{- if .Values.kubecostProductConfigs.sharedOverhead }}
+    sharedOverhead: "{{ .Values.kubecostProductConfigs.sharedOverhead }}"
+  {{- end -}}
   {{- if gt (len (toString .Values.kubecostProductConfigs.shareTenancyCosts)) 0 }}
   {{- if eq (toString .Values.kubecostProductConfigs.shareTenancyCosts) "false" }}
     shareTenancyCosts: "false"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -668,6 +668,7 @@ serviceAccount:
 #  serviceKeySecretName: "" # Use an existing AWS or Azure secret with format as in aws-service-key-secret.yaml or azure-service-key-secret.yaml. Leave blank if using createServiceKeySecret
 #  createServiceKeySecret: true # Creates a secret representing your cloud service key based on data in values.yaml. If you are storing unencrypted values, add a secret manually
 #  sharedNamespaces: "" # namespaces with shared workloads, example value: "kube-system\,ingress-nginx\,kubecost\,monitoring"
+#  sharedOverhead: "" # value representing a fixed external cost per month to be distributed among aggregations.
 #  shareTenancyCosts: true # enable or disable sharing costs such as cluster management fees (defaults to "true" on Settings page)
 #  productKey: # apply business or enterprise product license
 #    key: ""


### PR DESCRIPTION
Ref https://github.com/kubecost/cost-analyzer-helm-chart/issues/972
Requires X

Add `sharedOverhead` to `values.yaml` which allows users to set the value for "Shared Overhead" from the settings page.