### PR TITLE
fix ksm disabling

### DIFF
--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrole.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if not .Values.disabled }}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrole.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -178,3 +179,4 @@ rules:
   verbs: ["list", "watch"]
 {{ end -}}
 {{- end -}}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -17,3 +18,4 @@ subjects:
   name: {{ template "kube-state-metrics.fullname" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- end -}}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if (.Values.enabled | default true) }}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/deployment.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if not .Values.disabled }}
 apiVersion: apps/v1
 {{- if .Values.autosharding.enabled }}
 kind: StatefulSet

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/deployment.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 apiVersion: apps/v1
 {{- if .Values.autosharding.enabled }}
 kind: StatefulSet
@@ -188,3 +189,4 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -37,3 +38,4 @@ spec:
         max: 65535
   readOnlyRootFilesystem: false
 {{- end }}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if not .Values.disabled }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 {{- if and .Values.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -15,3 +16,4 @@ rules:
   resourceNames:
   - {{ template "kube-state-metrics.fullname" . }}
 {{- end }}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if not .Values.disabled }}
 {{- if and .Values.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 {{- if and .Values.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -17,3 +18,4 @@ subjects:
     name: {{ template "kube-state-metrics.fullname" . }}
     namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- end }}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if (.Values.enabled | default true) }}
 {{- if and .Values.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/service.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -34,3 +35,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/service.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if not .Values.disabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if not .Values.disabled }}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -12,3 +13,4 @@ metadata:
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
 {{- end -}}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if not .Values.disabled }}
 {{- if .Values.prometheus.monitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 {{- if .Values.prometheus.monitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -23,3 +24,4 @@ spec:
       honorLabels: true
       {{- end }}
 {{- end }}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/stsdiscovery-role.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/stsdiscovery-role.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 {{- if and .Values.autosharding.enabled .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -25,3 +26,4 @@ rules:
   verbs:
   - get
 {{- end }}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/stsdiscovery-role.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/stsdiscovery-role.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if not .Values.disabled }}
 {{- if and .Values.autosharding.enabled .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.kubeStateMetrics.enabled }}
 {{- if and .Values.autosharding.enabled .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -18,3 +19,4 @@ subjects:
     name: {{ template "kube-state-metrics.fullname" . }}
     namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- end }}
+{{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.kubeStateMetrics.enabled }}
+{{ if not .Values.disabled }}
 {{- if and .Values.autosharding.enabled .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -384,7 +384,7 @@ configmapReload:
     ##
     resources: {}
 
-kubeStateMetrics:
+kube-state-metrics:
   ## If false, kube-state-metrics sub-chart will not be installed
   ## Please see https://github.com/helm/charts/tree/master/stable/kube-state-metrics for configurable values
   ##


### PR DESCRIPTION
Fix for https://github.com/kubecost/cost-analyzer-helm-chart/issues/983

Note that helm3 conditionals appear to be broken for at least some versions https://github.com/helm/helm/issues/4490, so we need to wrap each chart in a template variable. Also, note that we do not want to turn off ksm simply because a field was left out of values.yaml, so you must explicitly set "disabled" here.

Testing done:

```
helm upgrade kubecost -n kubecost ./cost-analyzer -f ./cost-analyzer/values.yaml --set prometheus.kube-state-metrics.disabled=true

atripathy@Ajays-MacBook-Pro buildscripts % kubectl get pods -n kubecost 
NAME                                           READY   STATUS              RESTARTS   AGE
kubecost-cost-analyzer-794b6f7f7b-wg24f        0/3     ContainerCreating   0          5s
kubecost-cost-analyzer-8687ffdf7c-wrqnx        0/3     Terminating         0          4m16s
kubecost-grafana-664c8fd885-gdhhs              3/3     Running             0          39m
kubecost-kube-state-metrics-56766ff87c-n68q8   0/1     Terminating         0          4m16s
kubecost-prometheus-node-exporter-jrkkg        0/1     Pending             0          2d20h
kubecost-prometheus-node-exporter-l2tjc        0/1     Pending             0          2d20h
kubecost-prometheus-node-exporter-llrd2        0/1     Pending             0          20h
kubecost-prometheus-node-exporter-mglpl        0/1     Pending             0          2d20h
kubecost-prometheus-node-exporter-ttpzk        0/1     Pending             0          8h
kubecost-prometheus-node-exporter-xv9df        0/1     Pending             0          2d20h
kubecost-prometheus-server-7b6d787fcd-6x2th    2/2     Running             0          103m

helm upgrade kubecost -n kubecost ./cost-analyzer -f ./cost-analyzer/values.yaml 

atripathy@Ajays-MacBook-Pro buildscripts % kubectl get pods -n kubecost 
NAME                                           READY   STATUS        RESTARTS   AGE
kubecost-cost-analyzer-794b6f7f7b-wg24f        0/3     Terminating   0          95s
kubecost-cost-analyzer-8687ffdf7c-nxwtx        0/3     Running       0          6s
kubecost-grafana-664c8fd885-gdhhs              3/3     Running       0          40m
kubecost-kube-state-metrics-56766ff87c-hrvnb   0/1     Running       0          7s
kubecost-prometheus-node-exporter-jrkkg        0/1     Pending       0          2d20h
kubecost-prometheus-node-exporter-l2tjc        0/1     Pending       0          2d20h
kubecost-prometheus-node-exporter-llrd2        0/1     Pending       0          20h
kubecost-prometheus-node-exporter-mglpl        0/1     Pending       0          2d20h
kubecost-prometheus-node-exporter-ttpzk        0/1     Pending       0          8h
kubecost-prometheus-node-exporter-xv9df        0/1     Pending       0          2d20h
kubecost-prometheus-server-7b6d787fcd-6x2th    2/2     Running       0          105m

```