### PR TITLE
add store PVC

### DIFF
--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -255,7 +255,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:1.12.0
+  image: kiwigrid/k8s-sidecar:1.12.2
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:

--- a/cost-analyzer/charts/thanos/templates/store-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-deployment.yaml
@@ -96,7 +96,21 @@ spec:
           {{ toYaml .Values.store.resources | nindent 10 }}
       volumes:
       - name: data
+      {{- if .Values.store.dataVolume }}
+      {{- if .Values.store.dataVolume.persistentVolumeClaim }}
+      {{- if .Values.store.dataVolume.persistentVolumeClaim.claimName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.store.dataVolume.persistentVolumeClaim.claimName }}
+      {{- else }}
         emptyDir: {}
+      {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}          
+      {{- else }}
       - name: config-volume
         secret:
           secretName: {{ include "thanos.secretname" . }}

--- a/cost-analyzer/charts/thanos/templates/store-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-deployment.yaml
@@ -110,7 +110,6 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}          
-      {{- else }}
       - name: config-volume
         secret:
           secretName: {{ include "thanos.secretname" . }}

--- a/cost-analyzer/charts/thanos/templates/store-pvc.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-pvc.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.global.thanos.enabled }}
+{{- if .Values.store.enabled }}
+{{- if .Values.store.dataVolume -}}
+{{- if .Values.store.dataVolume.persistentVolumeClaim -}}
+{{- if .Values.store.dataVolume.persistentVolumeClaim.claimName -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.store.dataVolume.persistentVolumeClaim.claimName }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.store.dataVolume.persistentVolumeClaim.storageClass }}
+  storageClassName: {{ .Values.store.dataVolume.persistentVolumeClaim.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+    {{- if .Values.store.dataVolume.persistentVolumeClaim.storage }}
+      storage: {{ .Values.store.dataVolume.persistentVolumeClaim.storage }}
+    {{- else }}
+      storage: 100Gi
+    {{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{ end }}

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -30,11 +30,11 @@ store:
   extraArgs: []
   # - "--extraargs=extravalue"
   #
-  # Data volume for the compactor to store temporary data defaults to emptyDir
+  # Data volume for the store to store temporary data defaults to emptyDir
   # dataVolume:
-    #  persistentVolumeClaim:
-    #    claimName: store-data-volume
-    #    storage: 100Gi
+  #  persistentVolumeClaim:
+  #    claimName: store-data-volume
+  #    storage: 100Gi
   # Number of replicas running from store component
   replicaCount: 1
   # Extra labels for store pod template

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -30,6 +30,11 @@ store:
   extraArgs: []
   # - "--extraargs=extravalue"
   #
+  # Data volume for the compactor to store temporary data defaults to emptyDir
+  # dataVolume:
+    #  persistentVolumeClaim:
+    #    claimName: store-data-volume
+    #    storage: 100Gi
   # Number of replicas running from store component
   replicaCount: 1
   # Extra labels for store pod template


### PR DESCRIPTION
On larger clusters, this can end up exceeding the size of small nodes and causing evictions due to running out of ephemeral storage...we should support using a PVC for the local data dir.

Testing done: set values and kubectl apply.
```
atripathy@Ajays-MacBook-Pro samples % kubectl get pods -n kubecost                                                       
NAME                                              READY   STATUS    RESTARTS   AGE
kubecost-cost-analyzer-6b6c678db7-q4mlh           3/3     Running   0          2m24s
kubecost-grafana-67748c7b6f-cmd9w                 3/3     Running   0          33h
kubecost-kube-state-metrics-56766ff87c-6ng95      1/1     Running   0          5d9h
kubecost-prometheus-node-exporter-5q7m9           0/1     Pending   0          2d5h
kubecost-prometheus-node-exporter-jrkkg           0/1     Pending   0          2d5h
kubecost-prometheus-node-exporter-l2tjc           0/1     Pending   0          2d5h
kubecost-prometheus-node-exporter-llrd2           0/1     Pending   0          5h17m
kubecost-prometheus-node-exporter-mglpl           0/1     Pending   0          2d5h
kubecost-prometheus-node-exporter-xv9df           0/1     Pending   0          2d5h
kubecost-prometheus-server-6c46db5969-28tcl       3/3     Running   0          6m29s
kubecost-thanos-compact-8644c7755d-sk2cw          1/1     Running   0          6m39s
kubecost-thanos-query-7f87d98667-5b5jv            1/1     Running   0          6m39s
kubecost-thanos-query-frontend-6b79b58c59-gl5nd   1/1     Running   0          6m39s
kubecost-thanos-store-7ddcd4c896-9gknl            1/1     Running   0          2m25s
atripathy@Ajays-MacBook-Pro samples % kubectl get pvc -n kubecost
NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
compact-data-volume          Bound    pvc-924a503e-c34c-461d-b526-ee2d42a78985   100Gi      RWO            standard       7m7s
kubecost-cost-analyzer       Bound    pvc-9eb4c4cd-6ccf-4d3a-a055-00f7275876c0   32Gi       RWO            standard       5d9h
kubecost-prometheus-server   Bound    pvc-70e1a602-3219-4bb2-9201-0026f63598f4   32Gi       RWO            standard       2d5h
store-data-volume            Bound    pvc-e937a19b-23dd-469f-a22f-bb4a561d45f9   100Gi      RWO            standard       7m7s
```

It still uses no pvc by default:
```
atripathy@Ajays-MacBook-Pro samples % kubectl get pods -n kubecost
NAME                                              READY   STATUS    RESTARTS   AGE
kubecost-cost-analyzer-76fff5fd48-cj4mw           0/3     Running   0          49s
kubecost-grafana-67748c7b6f-cmd9w                 3/3     Running   0          33h
kubecost-kube-state-metrics-56766ff87c-6ng95      1/1     Running   0          5d9h
kubecost-prometheus-node-exporter-5q7m9           0/1     Pending   0          2d5h
kubecost-prometheus-node-exporter-jrkkg           0/1     Pending   0          2d5h
kubecost-prometheus-node-exporter-l2tjc           0/1     Pending   0          2d5h
kubecost-prometheus-node-exporter-llrd2           0/1     Pending   0          5h30m
kubecost-prometheus-node-exporter-mglpl           0/1     Pending   0          2d5h
kubecost-prometheus-node-exporter-xv9df           0/1     Pending   0          2d5h
kubecost-prometheus-server-6c46db5969-28tcl       3/3     Running   0          19m
kubecost-thanos-compact-8644c7755d-sk2cw          1/1     Running   0          19m
kubecost-thanos-query-7f87d98667-5b5jv            1/1     Running   0          19m
kubecost-thanos-query-frontend-6b79b58c59-gl5nd   1/1     Running   0          19m
kubecost-thanos-store-7b46f4fbfd-87bft            1/1     Running   0          50s
atripathy@Ajays-MacBook-Pro samples % kubectl get pvc -n kubecost 
NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
compact-data-volume          Bound    pvc-924a503e-c34c-461d-b526-ee2d42a78985   100Gi      RWO            standard       20m
kubecost-cost-analyzer       Bound    pvc-9eb4c4cd-6ccf-4d3a-a055-00f7275876c0   32Gi       RWO            standard       5d9h
kubecost-prometheus-server   Bound    pvc-70e1a602-3219-4bb2-9201-0026f63598f4   32Gi       RWO            standard       2d5h
```