### PR TITLE
Make awsstore service account creation optional and make the complete…

### DIFF
--- a/cost-analyzer/templates/awsstore-deployment-template.yaml
+++ b/cost-analyzer/templates/awsstore-deployment-template.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.awsstore }}
+{{- if .Values.awsstore.useAwsStore }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cost-analyzer/templates/awsstore-deployment-template.yaml
+++ b/cost-analyzer/templates/awsstore-deployment-template.yaml
@@ -23,4 +23,7 @@ spec:
         containers:
             - image: {{ .Values.awsstore.imageNameAndVersion }}
               name: awsstore
+              # Just sleep forever
+              command: [ "sleep" ]
+              args: [ "infinity" ]
 {{- end }}

--- a/cost-analyzer/templates/awsstore-service-account-template.yaml
+++ b/cost-analyzer/templates/awsstore-service-account-template.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.awsstore }}
+{{- if .Values.awsstore.createServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -570,6 +570,8 @@ serviceAccount:
   create: true # Set this to false if you're bringing your own service account.
   annotations: {}
   # name: kc-test
+awsstore:
+  createServiceAccount: true
 
 
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -571,7 +571,8 @@ serviceAccount:
   annotations: {}
   # name: kc-test
 awsstore:
-  createServiceAccount: true
+  useAwsStore: false
+  createServiceAccount: false
 
 
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request


### PR DESCRIPTION
…d awsstore pod sleep infinitely

This pull request will fix two issues:
Make aws store creation configurable - https://github.com/kubecost/cost-analyzer-helm-chart/issues/968
Aws store pod keeps crashing - https://github.com/kubecost/cost-analyzer-helm-chart/issues/969

Strategy:
1. eksctl command creates namespace and service account so by default setting createServiceAccount as false.
2. Running the awsstore pod forever: https://stackoverflow.com/questions/31870222/how-can-i-keep-a-container-running-on-kubernetes/54688590#54688590

Testing steps:
Ran the following command:
Step1:
Create service account rolebinding.
```
eksctl create iamserviceaccount \
    --name awsstore-serviceaccount \
    --namespace kubecost \
    --cluster <cluster-name>\
    --attach-policy-arn arn:aws:iam::<account-id>:policy/MarketplaceRegisterUsage \
    --approve \
    --override-existing-serviceaccounts
```
Step2:
helm install: Get the token from [here](https://www.kubecost.com/install#show-instructions)
```
helm install kubecost ./cost-analyzer --namespace kubecost --set kubecostToken=<token> \
--set kubecostModel.image=117940112483.dkr.ecr.us-east-1.amazonaws.com/8cc31d15-33f6-49fe-8d6c-e9c0366cefa0/cg-142668492/gcr.io/kubecost1/cost-model \
--set kubecostFrontend.image=117940112483.dkr.ecr.us-east-1.amazonaws.com/8cc31d15-33f6-49fe-8d6c-e9c0366cefa0/cg-142668492/gcr.io/kubecost1/frontend \
--set kubecost.image=117940112483.dkr.ecr.us-east-1.amazonaws.com/8cc31d15-33f6-49fe-8d6c-e9c0366cefa0/cg-142668492/gcr.io/kubecost1/server \
--set kubecostChecks.enabled=false \
--set prometheus.alertmanager.enabled=false \
--set prometheus.nodeExporter.enabled=false \
--set imageVersion="1.61.3-latest" \
--set global.grafana.enabled=false \
--set global.grafana.proxy=false \
--set awsstore.useAwsStore=true \
--set awsstore.imageNameAndVersion=117940112483.dkr.ecr.us-east-1.amazonaws.com/8cc31d15-33f6-49fe-8d6c-e9c0366cefa0/cg-142668492/gcr.io/kubecost1/awsstore:1.61.3-latest

```

Result:
![image](https://user-images.githubusercontent.com/80087885/126844238-0727a559-a4aa-49f7-a392-84a0d9cdd0f7.png)

![image](https://user-images.githubusercontent.com/80087885/126844309-1a2d9046-da26-4165-84b0-0387e8872863.png)

helm install without awsstore paramters: Get the token from [here](https://www.kubecost.com/install#show-instructions)
```
helm install kubecost ./cost-analyzer --namespace kubecost --set kubecostToken=<token> \
--set kubecostModel.image=117940112483.dkr.ecr.us-east-1.amazonaws.com/8cc31d15-33f6-49fe-8d6c-e9c0366cefa0/cg-142668492/gcr.io/kubecost1/cost-model \
--set kubecostFrontend.image=117940112483.dkr.ecr.us-east-1.amazonaws.com/8cc31d15-33f6-49fe-8d6c-e9c0366cefa0/cg-142668492/gcr.io/kubecost1/frontend \
--set kubecost.image=117940112483.dkr.ecr.us-east-1.amazonaws.com/8cc31d15-33f6-49fe-8d6c-e9c0366cefa0/cg-142668492/gcr.io/kubecost1/server \
--set kubecostChecks.enabled=false \
--set prometheus.alertmanager.enabled=false \
--set prometheus.nodeExporter.enabled=false \
--set imageVersion="1.61.3-latest" \
--set global.grafana.enabled=false \
--set global.grafana.proxy=false
```
![image](https://user-images.githubusercontent.com/80087885/126844358-6d827f6b-238d-45f9-831f-8894357ae54a.png)


    