### PR TITLE
fix backwards compat

### DIFF
--- a/cost-analyzer/templates/awsstore-deployment-template.yaml
+++ b/cost-analyzer/templates/awsstore-deployment-template.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.awsstore }}
 {{- if .Values.awsstore.useAwsStore }}
 apiVersion: apps/v1
 kind: Deployment
@@ -26,4 +27,5 @@ spec:
               # Just sleep forever
               command: [ "sleep" ]
               args: [ "infinity" ]
+{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/awsstore-service-account-template.yaml
+++ b/cost-analyzer/templates/awsstore-service-account-template.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.awsstore }}
 {{- if .Values.awsstore.createServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
@@ -8,5 +9,6 @@ metadata:
 {{- with .Values.awsstore.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Check for the existence of the awsstore variable before trying to template out the helm chart

Testing done-- delete awsstore variables entirely and run helm upgrade:

```
atripathy@Ajays-MacBook-Pro cost-analyzer-helm-chart % helm upgrade kubecost ./cost-analyzer --namespace kubecost -f ./cost-analyzer/values.yaml -f ./cost-analyzer/values-thanos.yaml
Release "kubecost" has been upgraded. Happy Helming!
NAME: kubecost
LAST DEPLOYED: Tue Jul 27 16:59:04 2021
NAMESPACE: kubecost
STATUS: deployed
REVISION: 14
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed. When pods are Ready, you can enable port-forwarding with the following command:
    
    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090
```