### PR TITLE
chore: Bump configmap-reload tags

### DIFF
--- a/cost-analyzer/charts/prometheus/README.md
+++ b/cost-analyzer/charts/prometheus/README.md
@@ -183,7 +183,7 @@ Parameter | Description | Default
 `configmapReload.prometheus.enabled` | If false, the configmap-reload container for Prometheus will not be deployed | `true`
 `configmapReload.prometheus.name` | configmap-reload container name | `configmap-reload`
 `configmapReload.prometheus.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
-`configmapReload.prometheus.image.tag` | configmap-reload container image tag | `v0.3.0`
+`configmapReload.prometheus.image.tag` | configmap-reload container image tag | `v0.5.0`
 `configmapReload.prometheus.image.pullPolicy` | configmap-reload container image pull policy | `IfNotPresent`
 `configmapReload.prometheus.extraArgs` | Additional configmap-reload container arguments | `{}`
 `configmapReload.prometheus.extraVolumeDirs` | Additional configmap-reload volume directories | `{}`
@@ -192,7 +192,7 @@ Parameter | Description | Default
 `configmapReload.alertmanager.enabled` | If false, the configmap-reload container for AlertManager will not be deployed | `true`
 `configmapReload.alertmanager.name` | configmap-reload container name | `configmap-reload`
 `configmapReload.alertmanager.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
-`configmapReload.alertmanager.image.tag` | configmap-reload container image tag | `v0.3.0`
+`configmapReload.alertmanager.image.tag` | configmap-reload container image tag | `v0.5.0`
 `configmapReload.alertmanager.image.pullPolicy` | configmap-reload container image pull policy | `IfNotPresent`
 `configmapReload.alertmanager.extraArgs` | Additional configmap-reload container arguments | `{}`
 `configmapReload.alertmanager.extraVolumeDirs` | Additional configmap-reload volume directories | `{}`

--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -320,7 +320,7 @@ configmapReload:
     ##
     image:
       repository: jimmidyson/configmap-reload
-      tag: v0.3.0
+      tag: v0.5.0
       pullPolicy: IfNotPresent
 
     ## Additional configmap-reload container arguments
@@ -358,7 +358,7 @@ configmapReload:
     ##
     image:
       repository: jimmidyson/configmap-reload
-      tag: v0.3.0
+      tag: v0.5.0
       pullPolicy: IfNotPresent
 
     ## Additional configmap-reload container arguments


### PR DESCRIPTION
Bumps `jimmidyson/configmap-reload` image tags to v0.5.0 which fixes a few CVEs