### PR TITLE
bug fix: solve large headers, cookie problem with nginx

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -74,6 +74,7 @@ data:
         server_name _;
         root /var/www;
         index index.html;
+        large_client_header_buffers 4 32k;
         add_header Cache-Control "max-age=300";
         add_header Cache-Control "must-revalidate";
 {{- if .Values.imageVersion }}


### PR DESCRIPTION
If the kubecost frontend receives a large header or cookie it will return a "400 request header or cookie too large". By adding the large client header buffer 4 32k this problem will be solved. 