### PR TITLE
Add extraVolumes and extraVolumeMounts parameters to Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ Parameter | Description | Default
 `serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`
 `tolerations` | node taints to tolerate | `[]`
 `affinity` | pod affinity | `{}`
+`extraVolumes` | A list of volumes to be added to the pod | `[]`|
+`extraVolumeMounts` | A list of volume mounts to be added to the pod | `[]`

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -268,6 +268,10 @@ spec:
           volumeMounts:
             - name: persistent-configs
               mountPath: /var/configs
+            {{- if .Values.extraVolumeMounts }}
+            # Extra volume mount(s)
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
             {{- if .Values.kubecostModel.etlBucketConfigSecret }}
             - name: etl-bucket-config
               mountPath: /var/configs/etl
@@ -671,6 +675,10 @@ spec:
           volumeMounts:
             - name: persistent-configs
               mountPath: /var/configs
+            {{- if .Values.extraVolumeMounts }}
+            # Extra volume mount(s)
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
               valueFrom:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -227,10 +227,6 @@ spec:
           volumeMounts:
             - name: persistent-configs
               mountPath: /var/configs
-            {{- if .Values.extraVolumeMounts }}
-            # Extra volume mount(s)
-            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
-            {{- end }}
             {{- if and (.Values.kubecostModel.etlToDisk | default true) .Values.persistentVolume.dbPVEnabled }}
             - name: persistent-db
               mountPath: /var/db
@@ -675,10 +671,6 @@ spec:
           volumeMounts:
             - name: persistent-configs
               mountPath: /var/configs
-            {{- if .Values.extraVolumeMounts }}
-            # Extra volume mount(s)
-            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
-            {{- end }}
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
               valueFrom:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -171,6 +171,10 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if .Values.extraVolumes }}
+        # Extra volume(s)
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
         - name: persistent-configs
 {{- if .Values.persistentVolume }}
 {{- if .Values.persistentVolume.enabled }}
@@ -223,6 +227,10 @@ spec:
           volumeMounts:
             - name: persistent-configs
               mountPath: /var/configs
+            {{- if .Values.extraVolumeMounts }}
+            # Extra volume mount(s)
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
             {{- if and (.Values.kubecostModel.etlToDisk | default true) .Values.persistentVolume.dbPVEnabled }}
             - name: persistent-db
               mountPath: /var/db

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -274,6 +274,13 @@ networkPolicy:
 podSecurityPolicy:
   enabled: true
 
+## @param extraVolumes A list of volumes to be added to the pod
+##
+extraVolumes: []
+## @param extraVolumeMounts A list of volume mounts to be added to the pod
+##
+extraVolumeMounts: []
+
 # Define persistence volume for cost-analyzer, more information at https://github.com/kubecost/docs/blob/master/storage.md
 persistentVolume:
   size: 32Gi


### PR DESCRIPTION
Hi all,

The PR is adding two common parameters which give you an option to mount extra volumes to cost-analyzer pod. By saying common I mean it's commonly used in other charts like external-dns or cert-manager. In my case it's required to mount CSI Azure KeyVault volume to mount secret from KeyVault (Azure Service Principal credentials).