### PR TITLE
add generic cost-analyzer network policy template

### DIFF
--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -30,6 +30,11 @@ Parameter | Description | Default
 `ingress.hosts` | Ingress hostnames | `[cost-analyzer.local]`
 `ingress.tls` | Ingress TLS configuration (YAML) | `[]`
 `networkPolicy.enabled` | If true, create a NetworkPolicy to deny egress  | `false`
+`networkPolicy.costAnalyzer.enabled` | If true, create a newtork policy for cost-analzyer | `false`
+`networkPolicy.costAnalyzer.annotations` | Annotations to be added to the network policy | `{}`
+`networkPolicy.costAnalyzer.additionalLabels` | Additional labels to be added to the network policy | `{}`
+`networkPolicy.costAnalyzer.ingressRules` | A list of network policy ingress rules | `null`
+`networkPolicy.costAnalyzer.egressRules` | A list of network policy egress rules | `null`
 `networkCosts.enabled` | If true, collect network allocation metrics [More info](http://docs.kubecost.com/network-allocation) | `false`
 `networkCosts.podMonitor.enabled` | If true, a [PodMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#podmonitor) for the network-cost daemonset is created | `false`
 `serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`

--- a/cost-analyzer/templates/cost-analyzer-network-policy-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-policy-template.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.networkPolicy -}}
+{{- if .Values.networkPolicy.costAnalyzer.enabled -}}
+kind: NetworkPolicy
+apiVersion: {{ include "cost-analyzer.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "cost-analyzer.fullname" . }}
+{{- if .Values.networkPolicy.costAnalyzer.annotations }}
+  annotations:
+{{ toYaml .Values.networkPolicy.costAnalyzer.annotations | indent 4}}
+{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{- if .Values.networkPolicy.costAnalyzer.additionalLabels }}
+{{ toYaml .Values.networkPolicy.costAnalyzer.additionalLabels | indent 4 }}
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "cost-analyzer.selectorLabels" . | nindent 6 }}
+  policyTypes:
+{{- if .Values.networkPolicy.costAnalyzer.ingressRules }}
+    - Ingress
+{{- end }}
+{{- if .Values.networkPolicy.costAnalyzer.egressRules }}
+    - Egress
+{{- end }}
+{{- if .Values.networkPolicy.costAnalyzer.egressRules }}
+  egress:
+{{-  range $rule := .Values.networkPolicy.costAnalyzer.egressRules }}
+    - to:
+{{ toYaml $rule.selectors | indent 7 }}
+      ports:
+{{ toYaml $rule.ports | indent 9 }}  
+{{- end }}
+{{- end }}
+{{- if .Values.networkPolicy.costAnalyzer.ingressRules }}
+  ingress:
+{{-  range $rule := .Values.networkPolicy.costAnalyzer.ingressRules }}
+    - from:
+{{ toYaml $rule.selectors | indent 7 }}
+      ports:
+{{ toYaml $rule.ports | indent 9 }}  
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -271,6 +271,31 @@ networkPolicy:
   sameNamespace: true # Set to true if cost analyser and prometheus are on the same namespace
 #  namespace: kubecost # Namespace where prometheus is installed
 
+  # Cost-analyzer specific vars using the new template
+  costAnalyzer:
+    enabled: false # If true, create a newtork policy for cost-analzyer
+    annotations: {} # annotations to be added to the network policy
+    additionalLabels: {} # additional labels to be added to the network policy
+    # Examples rules:
+    # ingressRules:
+    #   - selectors: # allow ingress from self on all ports
+    #     - podSelector:
+    #         matchLabels:
+    #           app.kubernetes.io/name: cost-analyzer
+    #   - selectors: # allow egress access to prometheus
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           name: prometheus
+    #       podSelector:
+    #         matchLabels:
+    #           app: prometheus
+    #     ports:
+    #       - protocol: TCP
+    #         port: 9090
+    # egressRules:
+    #   - selectors: # restrict egress to inside cluster
+    #     - namespaceSelector: {}
+
 podSecurityPolicy:
   enabled: true
 


### PR DESCRIPTION
### Background
The [current cost-analyzer network policy template](https://github.com/kubecost/cost-analyzer-helm-chart/blob/develop/cost-analyzer/templates/cost-analyzer-network-policy.yaml) isn't sufficient for our use case. It's also somewhat non-standard because rather than targeting cost-analzyer pods, it conditionally can target prometheus pods which I haven't seen too often.

From what I gather, the current policy template supports:
* Restricting egress to inside the cluster only
* Restricting ingress to self (cost-analzyer pods)
* Allowing ingress access to prometheus from cost-analzyer pods

For the above, I don't believe you can combine them as well.

We needed to append a few ingress/egress rules to the template and so I wasn't sure where to start with adding to the pre-existing template. My solution in this PR is to add a new template where the rules are generic and the target pods are cost-analyzer specific, leaving the old template for backwards compat purposes.

The general concept was _borrowed_ from https://github.com/ameijer/k8s-as-helm/blob/master/charts/networkpolicy/templates/networkpolicy.yaml -- although I did update the metadata to be specific to this chart.

### Changes
* Add a new network policy template called `cost-analyzer-network-policy-template.yaml` that is disabled by default which dynamically defines ingress/egress rules from values in values.yaml files.
* Add related defaults in `values.yaml`
* Update readme

### Testing
Testing input vars:
```
networkPolicy:
  costAnalyzer:
    enabled: true
    annotations:
      foo: bar
    additionalLabels:
      foo: bar
    ingressRules:
      - selectors: # allow ingress from self on all ports
        - podSelector:
            matchLabels:
              app.kubernetes.io/name: cost-analyzer
    egressRules:
      - selectors: # allow egress to self on all ports
        - podSelector:
            matchLabels:
              app.kubernetes.io/name: cost-analyzer
      - selectors: # allow egress access to prometheus
        - namespaceSelector:
            matchLabels:
              name: prometheus
          podSelector:
            matchLabels:
              app: prometheus
        ports:
          - protocol: TCP
            port: 9090
```

Resulting rendered template:
```
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: kubecost-cost-analyzer
  annotations:
    foo: bar
  namespace: kubecost
  labels:
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.83.2
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
    foo: bar
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/name: cost-analyzer
      app.kubernetes.io/instance: kubecost
      app: cost-analyzer
  policyTypes:
    - Ingress
    - Egress
  egress:
    - to:
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: cost-analyzer
      ports:
         null
    - to:
       - namespaceSelector:
           matchLabels:
             name: prometheus
         podSelector:
           matchLabels:
             app: prometheus
      ports:
         - port: 9090
           protocol: TCP
  ingress:
    - from:
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: cost-analyzer
      ports:
         null
```

Null port entries in these policies maps to `<any>` in the final policy from my testing which is desired:
```
      ports:
         null
```