### PR TITLE
Thanos 0.22.0 Update

### DIFF
--- a/cost-analyzer/charts/thanos/Chart.yaml
+++ b/cost-analyzer/charts/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.19.0
+appVersion: 0.22.0
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.19.0
+version: 0.22.0
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: thanosio/thanos
-  tag: v0.19.0
+  tag: v0.22.0
   pullPolicy: IfNotPresent
 
 store:

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -28,7 +28,7 @@ prometheus:
     enableAdminApi: true
     sidecarContainers:
     - name: thanos-sidecar
-      image: thanosio/thanos:v0.19.0
+      image: thanosio/thanos:v0.22.0
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001


### PR DESCRIPTION
Observations from updating to 0.22 on our scale testing cluster:
* Less overall memory consumption building ETL, no OOM evictions.
* No problems with gRPC timeouts between store and querier after heavy traffic scenarios