### PR TITLE
chore: Use consistent tags in deployment utilization dashboard

### DIFF
--- a/cost-analyzer/deployment-utilization.json
+++ b/cost-analyzer/deployment-utilization.json
@@ -1225,8 +1225,9 @@
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
-    "kubernetes",
-    "deployment"
+    "cost",
+    "utilization",
+    "metrics"
   ],
   "templating": {
     "list": [


### PR DESCRIPTION
## What does this PR change?
Adds the same "cost", "utilization", "metrics" tags to the `Deployment/Statefulset/Daemonset utilization metrics` grafana dashboard, just to be consistent with the other cost dashboards.
![image](https://user-images.githubusercontent.com/5897740/130538903-cadf1abc-f680-4748-b802-004b3d811567.png)


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Different tags displayed in the grafana UI, little to no impact


## Links to Issues or ZD tickets this PR addresses or fixes


## How was this PR tested?
Manually imported the updated dashboard json
![image](https://user-images.githubusercontent.com/5897740/130539203-7689ffe5-640b-4bd3-867d-b9e57821d8e6.png)

