### PR TITLE
Deprecate UTC Offset

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -222,11 +222,6 @@ kubecostModel:
   etlHourlyStoreDurationHours: 49
   # max number of concurrent Prometheus queries
   maxQueryConcurrency: 5
-  # utcOffset represents a timezone in hours and minutes east (+) or west (-)
-  # of UTC, itself, which is defined as +00:00.
-  # See the tz database of timezones to look up your local UTC offset:
-  # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-  utcOffset: "+00:00"
   resources:
     requests:
       cpu: "200m"


### PR DESCRIPTION
## What does this PR change?
Deprecate UTC offset. It is not uniformly supported across all cloud provider CURs and is leading to confusion.


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Removes the ability to configure viewing kubecost data in different timezones. Timezone skew is not supported in many cloudprovider's data, making comparisons across CUR data more complex.


## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/816

## How was this PR tested?
This is the default and we're removing a feature.
