### PR TITLE
Update cost-analyzer ingress

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -149,19 +149,6 @@ Return the appropriate apiVersion for networkpolicy.
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for Ingress.
-*/}}
-{{- define "cost-analyzer.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- else if semverCompare "^1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return the appropriate apiVersion for podsecuritypolicy.
 */}}
 {{- define "cost-analyzer.podSecurityPolicy.apiVersion" -}}

--- a/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
@@ -3,7 +3,15 @@
 {{- $fullName := include "cost-analyzer.fullname" . -}}
 {{- $serviceName := include "cost-analyzer.serviceName" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: {{ include "cost-analyzer.ingress.apiVersion" . }}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,12 +37,22 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-	{{- range $ingressPaths }}
+        {{- range $ingressPaths }}
+          {{- if $apiV1 }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  name: tcp-frontend
+          {{- else }}
           - path: {{ . }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: tcp-frontend
-	{{- end }}
+          {{- end }}
+        {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
Consolidates the logic for picking the Ingress API version into `cost-analyzer-ingress-template.yaml` and removes the related lines in `_helpers.tpl` which become unneeded.

Also adds if/else to the path definition portion of `cost-analyzer-ingress-template.yaml` to base the yaml used off the Ingress API version.  The two versions of the Ingress API (`v1` and `v1beta1`) use different path values and not accounting for this causes errors.

Example difference between API versions:
`serviceName` -> `service.name`
`servicePort` -> `service.port.name` OR `service.port.name` (depending on the type of value)
https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules

Here's a random stackoverflow example of what one would hit changing the Ingress API version but not updating the path:
https://stackoverflow.com/questions/64125048/get-error-unknown-field-servicename-in-io-k8s-api-networking-v1-ingressbacken

## Does this PR rely on any other PRs?
No.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
This should allow for ingress to work for kubecost cost-analyzer with regardless of the version of Kubernetes.


## Links to Issues or ZD tickets this PR addresses or fixes
N/A


## How was this PR tested?
Did a dry-run of the updated helm chart to confirm the result from `cost-analyzer/templates/cost-analyzer-ingress-template.yaml` would produce the correct result.  Only have a `1.19` cluster though.

## Have you made an update to documentation?
Don't believe this should require a documentation update.  This change should require a change in values that a user has to provide.
