### PR TITLE
emit ksm v1 node metrics only

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -474,7 +474,7 @@ spec:
             {{- end }}
             {{- if .Values.kubecostMetrics }}
             - name: EMIT_KSM_NODE_METRICS_ONLY
-              value: {{ (quote .Values.kubecostMetrics.emitKsmNodeMetricsOnly) | default (quote true) }}
+              value: {{ (quote .Values.kubecostMetrics.emitKsmNodeMetricsOnly) | default (quote false) }}
             {{- end }}
             {{- if .Values.reporting }}
             - name: LOG_COLLECTION_ENABLED

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -472,6 +472,10 @@ spec:
             - name: EMIT_KSM_V1_METRICS
               value: {{ (quote .Values.kubecostMetrics.emitKsmV1Metrics) | default (quote true) }}
             {{- end }}
+            {{- if .Values.kubecostMetrics }}
+            - name: EMIT_KSM_NODE_METRICS_ONLY
+              value: {{ (quote .Values.kubecostMetrics.emitKsmNodeMetricsOnly) | default (quote true) }}
+            {{- end }}
             {{- if .Values.reporting }}
             - name: LOG_COLLECTION_ENABLED
               value: {{ (quote .Values.reporting.logCollection) | default (quote true) }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -473,8 +473,8 @@ spec:
               value: {{ (quote .Values.kubecostMetrics.emitKsmV1Metrics) | default (quote true) }}
             {{- end }}
             {{- if .Values.kubecostMetrics }}
-            - name: EMIT_KSM_NODE_METRICS_ONLY
-              value: {{ (quote .Values.kubecostMetrics.emitKsmNodeMetricsOnly) | default (quote false) }}
+            - name: EMIT_KSM_V1_METRICS_ONLY # ONLY emit KSM v1 metrics that do not exist in KSM 2 by default
+              value: {{ (quote .Values.kubecostMetrics.emitKsmV1MetricsOnly) | default (quote false) }}
             {{- end }}
             {{- if .Values.reporting }}
             - name: LOG_COLLECTION_ENABLED

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -606,6 +606,10 @@ awsstore:
   useAwsStore: false
   createServiceAccount: false
 
+#kubecostMetrics:
+#  emitKsmV1Metrics: true # emit all KSM metrics in KSM v1.
+#  emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only.
+
 
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request
 


### PR DESCRIPTION
## What does this PR change?
Duplicate only the minimal KSM metrics for accurate node pricing.

Metrics missing from default KSM v2 installations are 
```kube_pod_labels, kube_node_labels, kube_node_status_capacity_*```

These are re-added to better support running kubecost and KSM v2 with minimal metric duplication. Running KSM v2 next to kubecost has always been supported, but users are finding it difficult to dedupe existing queries by "job=kubecost".

Testing done: Run https://github.com/kubecost/cost-model/pull/970 with these flags and note that these metrics are still emitted.