### PR TITLE
Add dependency section and associated lockfile

### DIFF
--- a/cost-analyzer/Chart.lock
+++ b/cost-analyzer/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: grafana
+  repository: ""
+  version: 1.17.2
+- name: prometheus
+  repository: ""
+  version: 11.0.2
+- name: thanos
+  repository: ""
+  version: 0.22.0
+digest: sha256:cfbd975c4c846ab1c4cb79be70fa5981aa2bbf5f33c7ad4cec6ecad085334c9a
+generated: "2021-10-25T12:05:24.614775-07:00"

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -9,3 +9,10 @@ annotations:
   "artifacthub.io/links": |
     - name: Homepage
       url: https://www.kubecost.com
+dependencies:
+  - name: grafana
+    version: 1.17.2
+  - name: prometheus
+    version: 11.0.2
+  - name: thanos
+    version: 0.22.0


### PR DESCRIPTION
## What does this PR change?
This PR adds a dependency section which instantiates the three local charts in the `charts/` directory as direct dependencies of this chart.


## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can now safely run `helm lint` or `helmfile lint` as dependencies are correctly defined.

## Links to Issues or ZD tickets this PR addresses or fixes

- OP Issue: #1025.

## How was this PR tested?
Ran local `helm lint` tests.

## Have you made an update to documentation?
No need
