### PR TITLE
Add HELM_VALUES env variable and enableServer flag for toggling cost-analyzer-server container

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -329,6 +329,12 @@ spec:
             {{- end }}
             {{- end }}
           env:
+            {{- if .Values.reporting }}
+            {{- if .Values.reporting.valuesReporting }}
+            - name: HELM_VALUES
+              value: {{ template "cost-analyzer.filterEnabled" .Values }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.alertConfigmapName }}
             - name: ALERT_CONFIGMAP_NAME
               value: {{ .Values.alertConfigmapName }}
@@ -681,6 +687,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 200
+        {{- if .Values.kubecost.enableServer }}   
         {{- if .Values.kubecost }}
         {{- if .Values.kubecost.fullImageName }}
         - image: {{ .Values.kubecost.fullImageName }}
@@ -802,6 +809,7 @@ spec:
                 configMapKeyRef:
                   name: external-grafana-config-map
                   key: grafanaURL
+            {{- end }}
             {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -193,6 +193,9 @@ kubecostFrontend:
     #  memory: "256Mi"
 
 kubecost:
+  # Enables the cost-analyzer-server container to spin up as part of kubecost
+  # Setting this to false will mean all /api/ endpoints will be unavailable
+  enableServer: false
   image: "gcr.io/kubecost1/server"
   resources:
     requests:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -195,7 +195,7 @@ kubecostFrontend:
 kubecost:
   # Enables the cost-analyzer-server container to spin up as part of kubecost
   # Setting this to false will mean all /api/ endpoints will be unavailable
-  enableServer: false
+  enableServer: true
   image: "gcr.io/kubecost1/server"
   resources:
     requests:


### PR DESCRIPTION
## What does this PR change?
Adds HELM_VALUES as an environment variable (required for bug report generation) to the cost-model container, and adds the `Values.kubecost.enableServer` flag in values.yaml for toggling the cost-analzyer-server container.


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds the `Values.kubecost.enableServer` flag in to toggle the creation of the cost-analyzer-server container in Kubecost.



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Toggled flag and observed kubecost-cost-analyzer pod container creation.

## Have you made an update to documentation?
No.
