### PR TITLE
Upgrade network costs

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -454,7 +454,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v15.6
+  image: gcr.io/kubecost1/kubecost-network-costs:v15.7
   imagePullPolicy: Always
   # For existing Prometheus Installs, create a Service which generates Endpoints for each of the network-costs pods.
   # This Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.


### PR DESCRIPTION
## What does this PR change?
Upgrade/rebuild network-costs image to bump to alpine:latest (no other changes)


## Does this PR rely on any other PRs?
No 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Should address some CVEs reported by twistlock



## How was this PR tested?


## Have you made an update to documentation?
n/A
