### PR TITLE
add store pvc default

### DIFF
--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -31,10 +31,10 @@ store:
   # - "--extraargs=extravalue"
   #
   # Data volume for the store to store temporary data defaults to emptyDir
-  # dataVolume:
-  #  persistentVolumeClaim:
-  #    claimName: store-data-volume
-  #    storage: 100Gi
+  dataVolume:
+    persistentVolumeClaim:
+      claimName: store-data-volume
+      storage: 100Gi
   # Number of replicas running from store component
   replicaCount: 1
   # Extra labels for store pod template

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -451,7 +451,7 @@ prometheus:
 ## Module for measuring network costs
 ## Ref: https://github.com/kubecost/docs/blob/master/network-allocation.md
 networkCosts:
-  enabled: false
+  enabled: true
   podSecurityPolicy:
     enabled: false
   image: gcr.io/kubecost1/kubecost-network-costs:v15.7

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -451,7 +451,7 @@ prometheus:
 ## Module for measuring network costs
 ## Ref: https://github.com/kubecost/docs/blob/master/network-allocation.md
 networkCosts:
-  enabled: true
+  enabled: false
   podSecurityPolicy:
     enabled: false
   image: gcr.io/kubecost1/kubecost-network-costs:v15.7


### PR DESCRIPTION
## What does this PR change?
Use a PVC by default for thanos-store


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
On some mid-size installations, thanos-store would run perfectly fine for months then fail due to ephemeral storage issues. This makes a disk by default to prevent that.

## Testing
Deploy thanos-store with these configurations and note:
```
atripathy@Ajays-MacBook-Pro kubecost-network-costs % kubectl get pvc -n kubecost 
NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
compact-data-volume          Bound    pvc-07a120d0-858f-4704-a4a0-98cdd21fe62a   100Gi      RWO            standard       66m
kubecost-cost-analyzer       Bound    pvc-120c6bc1-32fa-44b2-8db9-d203187e9f95   32Gi       RWO            standard       47d
kubecost-prometheus-server   Bound    pvc-492d7b65-6e24-471b-b463-354914105ebf   32Gi       RWO            standard       30d
store-data-volume            Bound    pvc-3f51fe92-89f4-41cf-911d-f4a09a36cc2c   100Gi      RWO            standard       3m21s
```
