### PR TITLE
Removing redundant ingress annotation

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -235,7 +235,7 @@ ingress:
   enabled: false
   className: nginx
   annotations:
-    kubernetes.io/ingress.class: nginx
+    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   paths: ["/"] # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing
   hosts:


### PR DESCRIPTION
## What does this PR change?

This removes redundant ingress annotation when used in conjunction with `ingress.className`. If both used together the seeing following issue:

```
Error: INSTALLATION FAILED: Ingress.extensions "cost-analyzer" is invalid: annotations.kubernetes.io/ingress.class: Invalid value: "nginx": can not be set when the class field is also set
```

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

This will cause an error in the installation helm chart with custom ingress spec e.g:

```
ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: nginx
    kubernetes.io/tls-acme: "true"
    cert-manager.io/cluster-issuer: "letsencrypt-prod"
    # Adding basic authentication
    nginx.ingress.kubernetes.io/auth-type: basic
    nginx.ingress.kubernetes.io/auth-secret: basic-auth
    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
  paths: ["/"] # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing
  hosts:
  - <your-host-name>
  tls:
  - secretName: kubecost-tls
    hosts:
    - <your-host-name>
```

## Links to Issues or ZD tickets this PR addresses or fixes

NA

## How was this PR tested?

Locally

## Have you made an update to documentation?

NA

