### PR TITLE
Add flag for AWS Cloud Asset granularity reduction

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -517,6 +517,8 @@ spec:
             {{- end }}
             - name : ETL_CLOUD_ASSETS_ENABLED
               value: {{ (quote .Values.kubecostModel.etlCloudAssets) | default (quote true) }}
+            - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
+              value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}
             {{- if .Values.persistentVolume.dbPVEnabled }}
             - name: ETL_PATH_PREFIX
               value: "/var/db"


### PR DESCRIPTION
## What does this PR change?
This PR adds a value to values.yaml which can disable Cloud Asset use of ProviderId to reduce the granularity of queries.


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will be able to control this feature via the helm chart.


## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/kubecost-cost-model/pull/569
- 


## How was this PR tested?
Tested by enabling and disabling, while rebuilding assets on aws cluster to see if functionality turned on and off


## Have you made an update to documentation?
https://github.com/kubecost/docs/pull/143
