### PR TITLE
fix: Comment out ingress className

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -236,7 +236,7 @@ kubecostModel:
 # Basic Kubecost ingress, more examples available at https://github.com/kubecost/docs/blob/master/ingress-examples.md
 ingress:
   enabled: false
-  className: nginx
+  # className: nginx
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
## What does this PR change?
The addition of default `ingress.className: nginx` should have been commented out. This breaks configs that are using annotations to set the ingress class.

error:
```
Helm install failed: Ingress.extensions "<...>" is invalid: annotations.kubernetes.io/ingress.class: Invalid value: "<...>": can not be set when the class field is also set
```

## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
fix: Remove `ingress.className` default value from the ingress definition


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?

