### PR TITLE
feature/#1139 - better statement on how to manage productkey secret

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -714,5 +714,5 @@ awsstore:
 #  productKey: # apply business or enterprise product license
 #    key: ""
 #    enabled: false
-#    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
+#    secretname: productkeysecret # kubectl create secret generic productkeysecret -n kubecost --from-file=product.json <--- update your productKey in a file named "productkey.json" of format { "key": "kc-b1325234" }
 #  cloudIntegrationSecret: "cloud-integration"


### PR DESCRIPTION
## What does this PR change?

better statement on how to manage productkey secret

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

For enterprise / business (paid) user, they deploy kubecost helm chart with own **productKey**, it is different to the trial version with sample option `--set kubecostToken="aGVsbUBrdWJlY29zdC5jb20=xm343yadf98`

this PR provides better comments on how to manage the productKey as secrets.

## Links to Issues or ZD tickets this PR addresses or fixes

#1139 


## How was this PR tested?

not required, just comments updated

## Have you made an update to documentation?

Not sure where to update, if need, let me know