### PR TITLE
fixed record rules labels, container_name->container, pod_name->pod

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -414,15 +414,15 @@ prometheus:
       groups:
         - name: CPU
           rules:
-            - expr: sum(rate(container_cpu_usage_seconds_total{container_name!=""}[5m]))
+            - expr: sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))
               record: cluster:cpu_usage:rate5m
-            - expr: rate(container_cpu_usage_seconds_total{container_name!=""}[5m])
+            - expr: rate(container_cpu_usage_seconds_total{container!=""}[5m])
               record: cluster:cpu_usage_nosum:rate5m
-            - expr: avg(irate(container_cpu_usage_seconds_total{container_name!="POD", container_name!=""}[5m])) by (container_name,pod_name,namespace)
+            - expr: avg(irate(container_cpu_usage_seconds_total{container!="POD", container!=""}[5m])) by (container,pod,namespace)
               record: kubecost_container_cpu_usage_irate
-            - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""}) by (container_name,pod_name,namespace)
+            - expr: sum(container_memory_working_set_bytes{container!="POD",container!=""}) by (container,pod,namespace)
               record: kubecost_container_memory_working_set_bytes
-            - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""})
+            - expr: sum(container_memory_working_set_bytes{container!="POD",container!=""})
               record: kubecost_cluster_memory_working_set_bytes
         - name: Savings
           rules:
@@ -442,11 +442,11 @@ prometheus:
               record: kubecost_savings_memory_allocation_bytes
               labels:
                 daemonset: "true"
-            - expr: label_replace(sum(kube_pod_status_phase{phase="Running",namespace!="kube-system"} > 0) by (pod, namespace), "pod_name", "$1", "pod", "(.+)")
+            - expr: label_replace(sum(kube_pod_status_phase{phase="Running",namespace!="kube-system"} > 0) by (pod, namespace), "pod", "$1", "pod", "(.+)")
               record: kubecost_savings_running_pods
-            - expr: sum(rate(container_cpu_usage_seconds_total{container_name!="",container_name!="POD",instance!=""}[5m])) by (namespace, pod_name, container_name, instance)
+            - expr: sum(rate(container_cpu_usage_seconds_total{container!="",container!="POD",instance!=""}[5m])) by (namespace, pod, container, instance)
               record: kubecost_savings_container_cpu_usage_seconds
-            - expr: sum(container_memory_working_set_bytes{container_name!="",container_name!="POD",instance!=""}) by (namespace, pod_name, container_name, instance)
+            - expr: sum(container_memory_working_set_bytes{container!="",container!="POD",instance!=""}) by (namespace, pod, container, instance)
               record: kubecost_savings_container_memory_usage_bytes
             - expr: avg(sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!="kube-system"}) by (pod, namespace, instance)) by (pod, namespace)
               record: kubecost_savings_pod_requests_cpu_cores


### PR DESCRIPTION
Signed-off-by: Oscar Chen <oscar.chen.btw@gmail.com>

## What does this PR change?
According to Kubernetes instrumentation guidelines, the pod_name and container_name metrics are deprecated for almost 2 years and have not been available since K8s 1.16. The community has changed related code in the other issue[1].

The record rule template needs to change the label to align new format.

## Does this PR rely on any other PRs?
No



## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fix kubecost record rules template


## Links to Issues or ZD tickets this PR addresses or fixes
1. The original discussions: https://github.com/kubecost/cost-analyzer-helm-chart/issues/747



## How was this PR tested?
Yes, in my personal environment.

## Have you made an update to documentation?
No
