### PR TITLE
Mount GCP Service Key Secret Correctly

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -93,7 +93,7 @@ spec:
             secretName: {{ .Values.kubecostProductConfigs.gcpSecretName }}
             items:
             - key: compute-viewer-kubecost-key.json
-              path: key.json
+              path: service-key.json
         {{- end }}
         {{- end -}}
         {{- if .Values.kubecostProductConfigs.serviceKeySecretName }}
@@ -285,13 +285,13 @@ spec:
             {{- end }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
             - name: gcp-key-secret
-              mountPath: /models
+              mountPath: /var/secrets
             {{- end }}
-            {{- if or .Values.kubecostProductConfigs.azureStorageSecretName .Values.kubecostProductConfigs.azureStorageCreateSecret}}
+            {{- if or .Values.kubecostProductConfigs.azureStorageSecretName .Values.kubecostProductConfigs.azureStorageCreateSecret }}
             - name: azure-storage-config
               mountPath: /var/azure-storage-config
             {{- end }}
-            {{- if .Values.kubecostProductConfigs.cloudIntegrationSecret}}
+            {{- if .Values.kubecostProductConfigs.cloudIntegrationSecret }}
             - name: cloud-integration
               mountPath: /var/cloud-integration
             {{- end }}
@@ -373,15 +373,7 @@ spec:
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
             - name: GOOGLE_APPLICATION_CREDENTIALS
-            {{- if .Values.kubecostProductConfigs }}
-            {{- if .Values.kubecostProductConfigs.gcpSecretName }}
-              value: /models/key.json
-            {{- else }}
               value: /var/configs/key.json
-            {{- end }}
-            {{- else }}
-              value: /var/configs/key.json
-            {{- end }}
             - name: CONFIG_PATH
               value: /var/configs/
             - name: DB_PATH


### PR DESCRIPTION
## What does this PR change?
* The location in which the GCP service key is mounted: `/var/secrets/service-key.json` 
* Do not change key location in configuration, GCP auth handling code already exists (it's just looking in the incorrect place). 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Allows use of `gcpSecretName` in the helm chart. 

## Links to Issues or ZD tickets this PR addresses or fixes
- Fix: https://github.com/kubecost/cost-analyzer-helm-chart/issues/1135

## How was this PR tested?
- Updated our local GCP cluster with chart updates

