### PR TITLE
remove values and add note to secret creation template

### DIFF
--- a/cost-analyzer/templates/azure-storage-config-secret.yaml
+++ b/cost-analyzer/templates/azure-storage-config-secret.yaml
@@ -1,3 +1,4 @@
+{{/*This method of configuration is depricated*/}}
 {{- if .Values.kubecostProductConfigs }}
 {{- if .Values.kubecostProductConfigs.azureStorageCreateSecret }}
 {{- if .Values.kubecostProductConfigs.azureStorageAccessKey }}

--- a/cost-analyzer/templates/azure-storage-config-secret.yaml
+++ b/cost-analyzer/templates/azure-storage-config-secret.yaml
@@ -1,4 +1,4 @@
-{{/*This method of configuration is depricated*/}}
+{{/*This method of configuration is deprecated*/}}
 {{- if .Values.kubecostProductConfigs }}
 {{- if .Values.kubecostProductConfigs.azureStorageCreateSecret }}
 {{- if .Values.kubecostProductConfigs.azureStorageAccessKey }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -698,11 +698,7 @@ awsstore:
 #  azureClientID: f2ef6f7d-71fb-47c8-b766-8d63a19db017
 #  azureTenantID: 72faf3ff-7a3f-4597-b0d9-7b0b201bb23a
 #  azureClientPassword: fake key # Only use if your values.yaml are stored encrypted. Otherwise provide an existing secret via serviceKeySecretName
-#  azureStorageAccount: "kubecoststore" # Name of Azure Storage account where cost report is being saved
-#  azureStorageAccessKey: "" # Azure Storage account access key found in Azure Storage portal for account where cost report is being saved
-#  azureStorageContainer: "test" # Name of daily month-to-date cost report for Azure
 #  azureStorageSecretName: "azure-storage-config" # Name of Kubernetes Secret where Azure Storage Configuration is stored
-#  azureStorageCreateSecret: true # Create secret for Azure Storage config from values in this file
 #  discount: "" # percentage discount applied to compute
 #  negotiatedDiscount: "" # custom negotiated cloud provider discount
 #  defaultIdle: false


### PR DESCRIPTION
## What does this PR change?
This PR deprecates configuration of Azure through helm values by removing commented values.yaml values for this configuration and marking template with depreciation comment.


## Does this PR rely on any other PRs?

- https://github.com/kubecost/cost-model/pull/1001
- https://github.com/kubecost/kubecost-cost-model/pull/593


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?
Documentation on this type of configuration is also removed here.
https://github.com/kubecost/docs/pull/153

