### PR TITLE
Bump grafana version

### DIFF
--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -25,7 +25,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.1.2
+  tag: 8.3.2
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## What does this PR change?
Bump version for
CVE-2021-43798 

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Contains fix for CVE-2021-43798

## How was this PR tested?
Deployed to develop

## Have you made an update to documentation?
No
