### PR TITLE
fix 'app' label is overwritten by commonLabels for network costs service

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -9,8 +9,8 @@ metadata:
     prometheus.io/scrape: "{{ .Values.networkCosts.prometheusScrape }}"
     prometheus.io/port: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
   labels:
-    app: {{ template "cost-analyzer.networkCostsName" . -}}
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    app: {{ template "cost-analyzer.networkCostsName" . -}}
 spec:
   clusterIP: None
   ports:

--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -10,7 +10,7 @@ metadata:
     prometheus.io/port: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    app: {{ template "cost-analyzer.networkCostsName" . -}}
+    app: {{ template "cost-analyzer.networkCostsName" . }}
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
## What does this PR change?

Swags L12 and L13 around so the specific app label overwrites the commonLabel in the network service template.

## Does this PR rely on any other PRs?

No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Fix for label selector issues when using a ServiceMonitor from a prometheus managed by prometheus-operator. 

## Links to Issues or ZD tickets this PR addresses or fixes

Fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1176 

## How was this PR tested?

Will be tested by deploying network costs pods on a cluster with prometheus-operator. 