### PR TITLE
Pin local chart dependencies in Chart.yaml files

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -10,9 +10,12 @@ annotations:
     - name: Homepage
       url: https://www.kubecost.com
 dependencies:
-  - name: grafana
+  - condition: global.grafana.enabled
+    name: grafana
     repository: file://./charts/grafana
-  - name: prometheus
+  - condition: global.prometheus.enabled
+    name: prometheus
     repository: file://./charts/prometheus
-  - name: thanos
+  - condition: global.thanos.enabled
+    name: thanos
     repository: file://./charts/thanos

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -9,3 +9,10 @@ annotations:
   "artifacthub.io/links": |
     - name: Homepage
       url: https://www.kubecost.com
+dependencies:
+  - name: grafana
+    repository: file://./charts/grafana
+  - name: prometheus
+    repository: file://./charts/prometheus
+  - name: thanos
+    repository: file://./charts/thanos

--- a/cost-analyzer/charts/prometheus/Chart.yaml
+++ b/cost-analyzer/charts/prometheus/Chart.yaml
@@ -19,5 +19,6 @@ sources:
 tillerVersion: '>=2.8.0'
 version: 11.0.2
 dependencies:
-  - name: kube-state-metrics
+  - condition: kube-state-metrics.disabled
+    name: kube-state-metrics
     repository: file://./charts/kube-state-metrics

--- a/cost-analyzer/charts/prometheus/Chart.yaml
+++ b/cost-analyzer/charts/prometheus/Chart.yaml
@@ -18,3 +18,6 @@ sources:
 - https://github.com/kubernetes/kube-state-metrics
 tillerVersion: '>=2.8.0'
 version: 11.0.2
+dependencies:
+  - name: kube-state-metrics
+    repository: file://./charts/kube-state-metrics


### PR DESCRIPTION
## What does this PR change?

Pins local chart dependencies inside helm `Chart.yaml` files

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows `helm lint` command to pass.

## Links to Issues or ZD tickets this PR addresses or fixes

- #1025 

## How was this PR tested?

After successfully upgrading the helm chart I was able to also successfully run `helm lint`.

```
$ helm upgrade -f values.yaml kubecost ./cost-analyzer/
W0105 12:44:47.649368   28904 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0105 12:44:47.654934   28904 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0105 12:44:47.663873   28904 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0105 12:44:47.671629   28904 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0105 12:44:47.677892   28904 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0105 12:44:47.685105   28904 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Release "kubecost" has been upgraded. Happy Helming!
NAME: kubecost
LAST DEPLOYED: Wed Jan  5 12:44:46 2022
NAMESPACE: kubecost
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed. When pods are Ready, you can enable port-forwarding with the following command:
    
    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090
    
Next, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install

$ helm lint ./cost-analyzer/
==> Linting ./cost-analyzer/
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

## Have you made an update to documentation?

N/A