### PR TITLE
Allow UpdateStrategy Passthrough on Network Costs

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -7,8 +7,10 @@ metadata:
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
+  {{- if .Values.networkCosts.updateStrategy }}
   updateStrategy:
-    type: RollingUpdate
+    {{- toYaml .Values.networkCosts.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "cost-analyzer.networkCostsName" . }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -462,6 +462,8 @@ networkCosts:
     enabled: false
   image: gcr.io/kubecost1/kubecost-network-costs:v15.7
   imagePullPolicy: Always
+  updateStrategy:
+    type: RollingUpdate
   # For existing Prometheus Installs, create a Service which generates Endpoints for each of the network-costs pods.
   # This Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.
   # NOTE: Setting this option to true and leaving the above extraScrapeConfig "job_name: kubecost-networking" configured will cause the


### PR DESCRIPTION
## What does this PR change?
This should handle the cases where the updateStrategy and all specific parameters can be passed via the values.yaml


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Allow the Network Costs `updateStrategy` to be set via `values.yaml` 


## Links to Issues or ZD tickets this PR addresses or fixes
- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1195


## How was this PR tested?
Verified using helm template with networkCosts enabled:
```yaml
# Source: cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: kubecost-network-costs
  labels:
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.89.0-rc.0
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
spec:
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app: kubecost-network-costs
  template:
    metadata:
      labels:
        app: kubecost-network-costs
    spec:
      hostNetwork: true
      serviceAccountName: kubecost-cost-analyzer
```

