### PR TITLE
feat: dedicated networkcosts labels

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -99,11 +99,22 @@ Create the name of the service account
 Create the common labels.
 */}}
 {{- define "cost-analyzer.commonLabels" -}}
+{{- if .Values.global.additionalLabels }}
+{{- toYaml .Values.global.additionalLabels -}}
+{{- end }}
 app.kubernetes.io/name: {{ include "cost-analyzer.name" . }}
 helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app: cost-analyzer
+{{- end -}}
+
+{{- define "cost-analyzer.networkCostsLabels" -}}
+{{- $labelChart := include "cost-analyzer.chart" $ -}}
+{{- $labelApp := include "cost-analyzer.networkCostsName" $ -}}
+{{- $labelName := include "cost-analyzer.name" $ -}}
+{{- $labels := dict "app.kubernetes.io/name" $labelName "app" $labelApp "helm.sh/chart" $labelChart "app.kubernetes.io/instance" .Release.Name  "app.kubernetes.io/managed-by" .Release.Service -}}
+{{ merge .extraLabels $labels | toYaml | indent 4 }}
 {{- end -}}
 
 {{/*

--- a/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
@@ -6,7 +6,7 @@ kind: ConfigMap
 metadata:
   name: network-costs-config
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{ template "cost-analyzer.networkCostsLabels" merge (dict "extraLabels" .Values.networkCosts.additionalLabels) .  }}
 data:
   config.yaml: |
 {{- toYaml .Values.networkCosts.config | nindent 4 }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-podmonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-podmonitor-template.yaml
@@ -7,7 +7,7 @@ kind: PodMonitor
 metadata:
   name: {{ include "cost-analyzer.networkCostsName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{ template "cost-analyzer.networkCostsLabels" merge (dict "extraLabels" .Values.networkCosts.additionalLabels) .  }}
     {{- if .Values.networkCosts.podMonitor.additionalLabels }}
     {{ toYaml .Values.networkCosts.podMonitor.additionalLabels | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -9,8 +9,7 @@ metadata:
     prometheus.io/scrape: "{{ .Values.networkCosts.prometheusScrape }}"
     prometheus.io/port: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
   labels:
-    app: {{ template "cost-analyzer.networkCostsName" . -}}
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{ template "cost-analyzer.networkCostsLabels" merge (dict "extraLabels" .Values.networkCosts.additionalLabels) .  }}
 spec:
   clusterIP: None
   ports:

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
   labels:
-    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{ template "cost-analyzer.networkCostsLabels" merge (dict "extraLabels" .Values.networkCosts.additionalLabels) .  }}
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -19,7 +19,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: {{ template "cost-analyzer.networkCostsName" . }}
         {{- if .Values.networkCosts.additionalLabels }}
         {{ toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
         {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-network-policy-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-policy-template.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{ template "cost-analyzer.networkCostsLabels" merge (dict "extraLabels" .Values.networkCosts.additionalLabels) .  }}
 {{- if .Values.networkPolicy.costAnalyzer.additionalLabels }}
 {{ toYaml .Values.networkPolicy.costAnalyzer.additionalLabels | indent 4 }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?

- Adds aligned labels for all stuff related to network costs - this stack of resources is to different and it doesn't need commonLabels
- Adds global.additionalLabels to commonLabels - kubecost relies on pod labels but couldn't labels all workloads itself
- Resolves [this](https://github.com/kubecost/cost-analyzer-helm-chart/issues/1176 ) and [this](https://github.com/kubecost/cost-analyzer-helm-chart/issues/1150) issues


## Does this PR rely on any other PRs?
No
- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/1176
https://github.com/kubecost/cost-analyzer-helm-chart/issues/1150
- 
- 


## How was this PR tested?
```helm template --debug kubecost . --values values.yaml > kubecost.yaml && yamllint kubecost.yaml``` to exclude key-duplication + validate that all labels are at their places

## Have you made an update to documentation?
no new parameters/variables were added 
