### PR TITLE
Thanos 0.24 Upgrade

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -39,8 +39,8 @@ alertmanager:
   ## alertmanager container image
   ##
   image:
-    repository: prom/alertmanager
-    tag: v0.20.0
+    repository: quay.io/prometheus/alertmanager
+    tag: v0.23.0
     pullPolicy: IfNotPresent
 
   ## alertmanager priorityClassName
@@ -358,7 +358,7 @@ configmapReload:
     ##
     image:
       repository: jimmidyson/configmap-reload
-      tag: v0.5.0
+      tag: v0.6.1
       pullPolicy: IfNotPresent
 
     ## Additional configmap-reload container arguments
@@ -535,8 +535,8 @@ server:
   ## Prometheus server container image
   ##
   image:
-    repository: prom/prometheus
-    tag: v2.22.2
+    repository: quay.io/prometheus/prometheus
+    tag: v2.31.1
     pullPolicy: IfNotPresent
 
   ## prometheus server priorityClassName
@@ -916,7 +916,7 @@ pushgateway:
   ##
   image:
     repository: prom/pushgateway
-    tag: v1.0.1
+    tag: v1.4.2
     pullPolicy: IfNotPresent
 
   ## pushgateway priorityClassName

--- a/cost-analyzer/charts/thanos/Chart.yaml
+++ b/cost-analyzer/charts/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.22.0
+appVersion: 0.24.0
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.22.0
+version: 0.24.0
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/cost-analyzer/charts/thanos/templates/query-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         - "--store=dnssrv+_grpc._tcp.{{ include "thanos.componentname" (list $ "sidecar") }}-grpc.{{ .Release.Namespace }}.svc"
         {{- end  }}
         {{- range .Values.query.stores }}
-        - "--store={{ . }}"
+        - "--endpoint={{ . }}"
         {{- end }}
         {{- range .Values.query.serviceDiscoveryFiles }}
         - "--store.sd-files={{ . }}"

--- a/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
@@ -58,6 +58,24 @@ spec:
         - "--query-range.max-query-length={{ .Values.queryFrontend.maxQueryLength }}"
         - "--query-range.max-query-parallelism={{ .Values.queryFrontend.maxQueryParallelism }}"
         - "--query-range.response-cache-max-freshness={{ .Values.queryFrontend.responseCacheMaxFreshness }}"
+        {{- if .Values.queryFrontend.downstreamTripper.enabled }}
+        {{- with .Values.queryFrontend.downstreamTripper }}
+        - |-
+          --query-frontend.downstream-tripper-config=
+            idle_conn_timeout: {{ quote .idleConnectionTimeout }}
+            response_header_timeout: {{ quote .responseHeaderTimeout }}
+            tls_handshake_timeout: {{ quote .tlsHandshakeTimeout }}
+            expect_continue_timeout: {{ quote .expectContinueTimeout }}
+            max_idle_conns: {{ .maxIdleConnections }}
+            max_idle_conns_per_host: {{ .maxIdleConnectionsPerHost }}
+            max_conns_per_host: {{ .maxConnectionsPerHost }}
+        {{- end }}
+        {{- else if .Values.queryFrontend.downstreamTripperConfigFile }}
+          - "--query-frontend.downstream-tripper-config-file={{ .Values.queryFrontend.downstreamTripperConfigFile }}"
+        {{- else if .Values.queryFrontend.downstreamTripperConfig }}
+          - |-
+          --query-frontend.downstream-tripper-config={{ toYaml .Values.queryFrontend.downstreamTripperConfig | nindent 12 }}
+        {{- end }}
         {{- if .Values.queryFrontend.responseCache.enabled }}
         {{- with .Values.queryFrontend.responseCache }}
         - |-

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: thanosio/thanos
-  tag: v0.22.0
+  tag: v0.24.0
   pullPolicy: IfNotPresent
 
 store:
@@ -171,13 +171,26 @@ queryFrontend:
   # Path to YAML file that contains response cache configuration.
   # responseCacheConfigFile:
 
- # Response Cache Configuration
+  # Response Cache Configuration
   responseCache:
     enabled: false
     maxSize: 512MB
     maxSizeItems: 0
     validity: 10m
 
+  downstreamTripper:
+    enabled: false 
+    idleConnectionTimeout: 90s
+    responseHeaderTimeout: 2m
+    tlsHandshakeTimeout: 10s
+    expectContinueTimeout: 1s
+    maxIdleConnections: 200
+    maxIdleConnectionsPerHost: 100
+    maxConnectionsPerHost: 0
+
+  # Downstream Tripper Configuration Content
+  # downstreamTripperConfig:
+    
   # Response cache configuration content
   # responseCacheConfig:
 

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -28,7 +28,7 @@ prometheus:
     enableAdminApi: true
     sidecarContainers:
     - name: thanos-sidecar
-      image: thanosio/thanos:v0.22.0
+      image: thanosio/thanos:v0.24.0
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001
@@ -97,6 +97,16 @@ thanos:
   queryFrontend:
     enabled: true
     compressResponses: true
+    # Downstream Tripper Configuration
+    downstreamTripper:
+      enabled: true 
+      idleConnectionTimeout: 90s
+      responseHeaderTimeout: 2m
+      tlsHandshakeTimeout: 10s
+      expectContinueTimeout: 1s
+      maxIdleConnections: 200
+      maxIdleConnectionsPerHost: 100
+      maxConnectionsPerHost: 0
     # Response Cache Configuration
     # Configure either a max size constraint or max items. 
     responseCache:


### PR DESCRIPTION
## What does this PR change?
Updates Thanos from 0.22 to 0.24, adds new configuration updates to helm chart for thanos. 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Up to 20% decrease in latency from query-frontend to query by allowing > 2 idle http connections. 


## How was this PR tested?
* Installation on bolt-1/bolt-2, and verifying updated configuration options via `helm template` 
```
containers:
      - name: thanos-query-frontend
        image: "thanosio/thanos:v0.24.0"
        imagePullPolicy: IfNotPresent
        args:
        - "query-frontend"
        - "--log.level=info"
        - "--http-address=0.0.0.0:10902"
        - "--query-frontend.downstream-url=http://kubecost-thanos-query-http.kubecost:10902"
        - "--query-range.split-interval=24h"
        - "--query-range.max-retries-per-request=5"
        - "--query-range.max-query-length=0"
        - "--query-range.max-query-parallelism=14"
        - "--query-range.response-cache-max-freshness=1m"
        - |-
          --query-frontend.downstream-tripper-config=
            idle_conn_timeout: "90s"
            response_header_timeout: "2m"
            tls_handshake_timeout: "10s"
            expect_continue_timeout: "1s"
            max_idle_conns: 200
            max_idle_conns_per_host: 100
            max_conns_per_host: 0
        - |-
          --query-range.response-cache-config=
            config:
              max_size: "1.25GB"
              max_size_items: 0
              validity: "2m"
            type: "in-memory"
        - "--query-frontend.compress-responses"
```

## Have you made an update to documentation?

