### PR TITLE
Update network costs to v16, stub out configuration, disable by default.

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -460,7 +460,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v15.7
+  image: gcr.io/kubecost1/kubecost-network-costs:v16.0
   imagePullPolicy: Always
   # For existing Prometheus Installs, create a Service which generates Endpoints for each of the network-costs pods.
   # This Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.
@@ -512,6 +512,26 @@ networkCosts:
       #   zone: "us-east1-c"
       #   ips:
       #     - "10.0.0.0/24"
+    services:
+      # google-cloud-services: when set to true, enables labeling traffic metrics with google cloud 
+      # service endpoints 
+      google-cloud-services: false
+      # amazon-web-services: when set to true, enables labeling traffic metrics with amazon web service 
+      # endpoints.
+      amazon-web-services: false
+      # azure-cloud-services: when set to true, enables labeling traffic metrics with azure cloud service 
+      # endpoints 
+      azure-cloud-services: false   
+      # user defined services provide a way to define custom service endpoints which will label traffic metrics 
+      # falling within the defined address range.
+      #services: 
+      #  - service: "test-service-1"
+      #    ips:
+      #      - "19.1.1.2"
+      #  - service: "test-service-2"
+      #    ips:
+      #      - "15.128.15.2"
+      #      - "20.0.0.0/8"
 
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
## What does this PR change?
* Adds network costs v16 image and stubs out documented configuration options. 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Adds a `service` label to all emitted network-costs metrics


## How was this PR tested?
* Against 2 of our live clusters, helm template:
```yaml
# Source: cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: network-costs-config
  labels:
    
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.89.1
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
data:
  config.yaml: |
    destinations:
      cross-region: []
      direct-classification: []
      in-region: []
      in-zone:
      - 127.0.0.1
      - 169.254.0.0/16
      - 10.0.0.0/8
      - 172.16.0.0/12
      - 192.168.0.0/16
    services:
      amazon-web-services: false
      azure-cloud-services: false
      google-cloud-services: false
```

## Have you made an update to documentation?
Yes, directly in the `values.yaml` - fields defaults will likely change at a future date. 
