### PR TITLE
Update ksm chart to use values.disabled instead of values.enabled

### DIFF
--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if (.Values.enabled | default true) }}
+{{ if not .Values.disabled }}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if (.Values.enabled | default true) }}
+{{ if not .Values.disabled }}
 {{- if and .Values.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## What does this PR change?
The logic for deciding to deploy a ksm cluster role binding


## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
When disabling ksm previously, the cluster role binding would still get deployed. Once released, the cluster role binding will no longer be created if ksm is disabled via `prometheus.kube-state-metrics.disabled=true`.

## Links to Issues or ZD tickets this PR addresses or fixes
#1220 

## How was this PR tested?
Against dev cluster running 1.90 rc0
![image](https://user-images.githubusercontent.com/15660532/151616365-00066e2b-2639-47cd-a45c-c5dfe4a103d4.png)


## Have you made an update to documentation?
No. No updates required.
