### PR TITLE
Alter ingress template to work for K8s v1.18.x

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
@@ -5,7 +5,7 @@
 {{- $ingressPaths := .Values.ingress.paths -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $apiV1 := false -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare "^1.19-0" .Capabilities.KubeVersion.GitVersion) }}
 {{- $apiV1 = true -}}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}

--- a/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
@@ -5,7 +5,7 @@
 {{- $ingressPaths := .Values.ingress.paths -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $apiV1 := false -}}
-{{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare "^1.19-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 {{- $apiV1 = true -}}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}


### PR DESCRIPTION
## What does this PR change?
Quick fix to make the ingress template apiVersion to work with K8s v1.18.x, as the Ingress type does not exist in `networking.k8s.io/v1` until ^v1.19.0.

I believe this was introduced in https://github.com/kubecost/cost-analyzer-helm-chart/pull/1090.

## Does this PR rely on any other PRs?
No.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixed `cost-analyzer-ingress.yaml` having the wrong apiVersion for K8s v1.18.x.


## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1216
- 


## How was this PR tested?
Tested locally.

## Have you made an update to documentation?
No.
