### PR TITLE
migrate healthz endpoints outside of auth redirect to better support ingress healthchecks

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -88,6 +88,18 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
             error_page 401 = /login;
         }
+        location /healthz {
+            return 200;
+            add_header Content-Type text/plain;
+        }
+        location /api/healthz {
+            return 200;
+            add_header Content-Type text/plain;
+        }
+        location /model/healthz {
+            return 200;
+            add_header Content-Type text/plain;
+        }
 {{- else }}
         add_header Cache-Control "max-age=300";
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
Don't auth redirect the healthz endpoints


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Because the healthz endpoint was responding with a redirect to the SAML provider, certain External Load Balancers and V2 Ingresses were failing. 

## How was this PR tested?
curl the /healthz endpoints and note that they no longer issue redirects.

## Have you made an update to documentation?
No, this should work seamlessly.
