### PR TITLE
updated README's and pvc template  to  reflect new default `persistentVolume.size` size

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Parameter | Description | Default
 `prometheus.alertmanager.persistentVolume.enabled` | If true, Alertmanager will create a Persistent Volume Claim. | `true`
 `prometheus.pushgateway.persistentVolume.enabled` | If true, Prometheus Pushgateway will create a Persistent Volume Claim. | `true`
 `persistentVolume.enabled` | If true, Kubecost will create a Persistent Volume Claim for product config data.  | `true`
-`persistentVolume.size` | Define PVC size for cost-analyzer  | `0.2Gi`
+`persistentVolume.size` | Define PVC size for cost-analyzer  | `32.0Gi`
 `persistentVolume.dbSize` | Define PVC size for cost-analyzer's flat file database  | `32.0Gi`
 `persistentVolume.storageClass` | Define storage class for cost-analyzer's persistent volume  | `-`
 `ingress.enabled` | If true, Ingress will be created | `false`

--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -22,7 +22,7 @@ Parameter | Description | Default
 `prometheus.alertmanager.persistentVolume.enabled` | If true, Alertmanager will create a Persistent Volume Claim. | `true`
 `prometheus.pushgateway.persistentVolume.enabled` | If true, Prometheus Pushgateway will create a Persistent Volume Claim. | `true`
 `persistentVolume.enabled` | If true, Kubecost will create a Persistent Volume Claim for product config data.  | `true`
-`persistentVolume.size` | Define PVC size for cost-analyzer  | `0.2Gi`
+`persistentVolume.size` | Define PVC size for cost-analyzer  | `32.0Gi`
 `persistentVolume.dbSize` | Define PVC size for cost-analyzer's flat file database  | `32.0Gi`
 `ingress.enabled` | If true, Ingress will be created | `false`
 `ingress.annotations` | Ingress annotations | `{}`

--- a/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
@@ -18,7 +18,7 @@ spec:
     {{- if .Values.persistentVolume }}
       storage: {{ .Values.persistentVolume.size }}
     {{- else }}
-      storage: 0.2Gi
+      storage: 32.0Gi
     {{ end }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## What does this PR change?
- Updates the default `pvc` size value for `persistentVolume.size` in the READMES's and template from `0.2gi` to to `32.0gi`  to reflect the new default value as described here: https://github.com/kubecost/docs/blob/master/storage.md

## Does this PR rely on any other PRs?
- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Corrects documentation.
- Sets proper default if not vaule is provided.

## Links to Issues or ZD tickets this PR addresses or fixes

- Issue: 899 https://github.com/kubecost/cost-analyzer-helm-chart/issues/899

## How was this PR tested?
- Manually on  Microk8s v1.23.3

```
Ubuntu 20.04.3# microk8s helm3 upgrade -i --create-namespace kubecost ./cost-analyzer --namespace kubecost
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /var/snap/microk8s/2948/credentials/client.config
Release "kubecost" does not exist. Installing it now.
W0201 04:22:07.679709 1790100 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0201 04:22:07.687809 1790100 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0201 04:22:08.938264 1790100 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0201 04:22:08.957781 1790100 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
NAME: kubecost
LAST DEPLOYED: Tue Feb  1 04:22:06 2022
NAMESPACE: kubecost
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed. When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090

Next, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install
Ubuntu 20.04.3#
Ubuntu 20.04.3# kubectl get pvc -n kubecost
NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
kubecost-cost-analyzer       Bound    pvc-9192591f-8d23-4169-a3b3-d8775c8cb784   32Gi       RWO            microk8s-hostpath   16s
kubecost-prometheus-server   Bound    pvc-a24f0016-6258-49ed-b7cb-caaa2578d5df   32Gi       RWO            microk8s-hostpath   16s
```

## Have you made an update to documentation?
- Yes
