### PR TITLE
Add commonLabels where missing in main cost-analyzer chart

### DIFF
--- a/cost-analyzer/templates/aws-service-key-secret.yaml
+++ b/cost-analyzer/templates/aws-service-key-secret.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-service-key
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque
 stringData:
   service-key.json: |-

--- a/cost-analyzer/templates/azure-service-key-secret.yaml
+++ b/cost-analyzer/templates/azure-service-key-secret.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-service-key
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque
 stringData:
   service-key.json: |-

--- a/cost-analyzer/templates/azure-storage-config-secret.yaml
+++ b/cost-analyzer/templates/azure-storage-config-secret.yaml
@@ -8,6 +8,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: azure-storage-config
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque
 stringData:
   azure-storage-config.json: |-

--- a/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
@@ -4,6 +4,8 @@ kind: Role
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "cost-analyzer.serviceAccountName" . }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 rules:
 - apiGroups: 
     - ''

--- a/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-psp
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
   annotations:
 {{- if .Values.podSecurityPolicy.annotations }}
 {{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}

--- a/cost-analyzer/templates/cost-analyzer-psp-rolebinding.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp-rolebinding.template.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
     name: {{ template "cost-analyzer.fullname" . }}-psp
+    labels:
+      {{ include "cost-analyzer.commonLabels" . | nindent 6 }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role

--- a/cost-analyzer/templates/cost-analyzer-psp.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp.template.yaml
@@ -4,6 +4,8 @@ apiVersion: {{ include "cost-analyzer.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
     name: {{ template "cost-analyzer.fullname" . }}-psp
+    labels:
+      {{ include "cost-analyzer.commonLabels" . | nindent 6 }}
 spec:
     privileged: false
     seLinux:

--- a/cost-analyzer/templates/kubecost-agent-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secret-template.yaml
@@ -4,6 +4,8 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ template "kubecost.agentStoreSecretName" . }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   object-store.yaml: {{ .Values.agentKey }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -5,6 +5,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     app: {{ template "kubecost.clusterControllerName" . }}
 ---
 #
@@ -17,6 +18,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     app: {{ template "kubecost.clusterControllerName" . }}
 rules:
   - apiGroups:
@@ -153,6 +155,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     app: {{ template "kubecost.clusterControllerName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -167,6 +170,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   strategy:
     rollingUpdate:
@@ -222,6 +227,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}-service
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
@@ -237,6 +244,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: turndownschedules.kubecost.k8s.io
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   group: kubecost.k8s.io
   version: v1alpha1

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -6,6 +6,7 @@ kind: Deployment
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
   labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     app: {{ template "kubecost.kubeMetricsName" . }}
 {{- with .Values.kubecostMetrics.exporter.labels }}
 {{ toYaml . | indent 4 }}

--- a/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
@@ -8,6 +8,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "kubecost.kubeMetricsName" . }}
   labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{ include "kubecost.chartLabels" . | nindent 4 }}
     {{- if .Values.kubecostMetrics.exporter.serviceMonitor.additionalLabels }}
     {{ toYaml .Values.kubecostMetrics.exporter.serviceMonitor.additionalLabels | nindent 4 }}

--- a/cost-analyzer/templates/kubecost-metrics-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-template.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ (quote .Values.kubecostMetrics.exporter.port) | default (quote 9005) }}

--- a/cost-analyzer/templates/kubecost-priority-class-template.yaml
+++ b/cost-analyzer/templates/kubecost-priority-class-template.yaml
@@ -5,6 +5,8 @@ apiVersion: {{ include "cost-analyzer.priorityClass.apiVersion" . }}
 kind: PriorityClass
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-priority
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 value: {{ .Values.priority.value | default "1000000" }}
 globalDefault: false
 description: "Priority class for scheduling the cost-analyzer pod"

--- a/cost-analyzer/templates/network-costs-psp.template.yaml
+++ b/cost-analyzer/templates/network-costs-psp.template.yaml
@@ -6,6 +6,8 @@ apiVersion: {{ include "cost-analyzer.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
     name: kubecost-network-costs
+    labels:
+      {{ include "cost-analyzer.commonLabels" . | nindent 6 }}
 spec:
     privileged: true
     hostNetwork: true

--- a/cost-analyzer/templates/network-costs-role.template.yaml
+++ b/cost-analyzer/templates/network-costs-role.template.yaml
@@ -6,6 +6,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kubecost-network-costs
+  lables:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
   annotations:
 {{- if .Values.networkCosts.podSecurityPolicy.annotations }}
 {{ toYaml .Values.networkCosts.podSecurityPolicy.annotations | indent 4 }}

--- a/cost-analyzer/templates/network-costs-rolebinding.template.yaml
+++ b/cost-analyzer/templates/network-costs-rolebinding.template.yaml
@@ -6,6 +6,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
     name: kubecost-network-costs
+    labels:
+      {{ include "cost-analyzer.commonLabels" . | nindent 6 }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role


### PR DESCRIPTION
## What does this PR change?
- This change add the helper commonLabels function for the main kubecost charts. 
- This also adds proper newline endings to the modified files


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Standardizes labels for the main kubecost chart


## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/1227


## How was this PR tested?
Helm template ran through kubeval

## Have you made an update to documentation?
Not needed
