### PR TITLE
Permissions for request sizing application

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -206,6 +206,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: CLUSTER_ID
+          value: {{ .Values.prometheus.server.global.external_labels.cluster_id }}
         - name: TURNDOWN_NAMESPACE
           value: {{ .Release.Namespace }}
         - name: TURNDOWN_DEPLOYMENT


### PR DESCRIPTION
## What does this PR change?

Adds permissions to the cost-analyzer ClusterRoleBinding for application of request sizing recommendations.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Kubecost is given `update` and `get` verbs on StatefulSets, Deployments, DaemonSets, and ReplicaSets to support a new automation feature.

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

See PRs implementing core functionality. This chart edit was used to deploy those PRs.

## Have you made an update to documentation?

N/A