### PR TITLE
Remove trim whitespace hyphen on app label

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -10,7 +10,7 @@ metadata:
     prometheus.io/port: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    app: {{ template "cost-analyzer.networkCostsName" . -}}
+    app: {{ template "cost-analyzer.networkCostsName" . }}
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
## What does this PR change?
Removes a whitespace trim inside `cost-analyzer-helm-chart/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml` that was causing some users to not have successful install/upgrades.


## Does this PR rely on any other PRs?
N/A


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixes a templating error when `networkCosts.enabled` and `networkCosts.prometheusScrape` are true


## Links to Issues or ZD tickets this PR addresses or fixes
- Fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1236


## How was this PR tested?
1. You can see find the successfully templated Kubernetes manifest with desired labels with
```
$ helm template kubecost ./cost-analyzer/ --set networkCosts.enabled=true --set networkCosts.prometheusScrape=true | grep -A 25 cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml

# Source: cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
apiVersion: v1
kind: Service
metadata:
  name: kubecost-network-costs
  annotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "3001"
  labels:

    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.90.0
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
    app: kubecost-network-costs
spec:
  clusterIP: None
  ports:
  - name: metrics
    port: 3001
    protocol: TCP
    targetPort: 3001
  selector:
    app: kubecost-network-costs
  type: ClusterIP
```
2. As well as a successful install/upgrade command:
```
$ helm upgrade kubecost ./cost-analyzer --set networkCosts.enabled=true --set networkCosts.prometheusScrape=true

W0204 14:17:23.112194    8537 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0204 14:17:23.119482    8537 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0204 14:17:23.214156    8537 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0204 14:17:23.221125    8537 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0204 14:17:23.227340    8537 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0204 14:17:23.236405    8537 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Release "kubecost" has been upgraded. Happy Helming!
NAME: kubecost
LAST DEPLOYED: Fri Feb  4 14:17:21 2022
NAMESPACE: kubecost
STATUS: deployed
REVISION: 17
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed. When pods are Ready, you can enable port-forwarding with the following command:
    
    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090
    
Next, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install
```


## Have you made an update to documentation?
No, because this is for a bug fix.
