### PR TITLE
[DRAFT] 

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1226,8 +1226,13 @@ serverFiles:
       # service then set this appropriately.
       - job_name: 'kubernetes-service-endpoints'
 
-        kubernetes_sd_configs:
-          - role: endpoints
+        metrics_path: /metrics
+        scheme: http
+        dns_sd_configs:
+        - names:
+          - kubecost-kube-state-metrics
+          type: 'A'
+          port: 8080
 
         relabel_configs:
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]


### PR DESCRIPTION
## What does this PR change?

Hardcoded discovery of KSM instead of other service endpoints. Sample for testing only.
kubecost-kube-state-metrics           ClusterIP      10.11.242.245   <none>         8080/TCP                     60d


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Forces KSM to be discovered manually, meaning only the KSM in the same namespace as kubecost will work.

## How was this PR tested?
TODO

## Have you made an update to documentation?
None should be required...seamless.
