### PR TITLE
Add ipv6 support

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -101,11 +101,14 @@ data:
         ssl_certificate     /etc/ssl/certs/kc.crt;
         ssl_certificate_key /etc/ssl/certs/kc.key;
         listen 443 ssl;
+        listen [::]:443 ssl;
 {{- else }}
         listen {{ $nginxPort }};
+        listen [::]:{{ $nginxPort }};
 {{- end }}
 {{- else }}
         listen {{ $nginxPort }};
+        listen [::]:{{ $nginxPort }};
 {{- end }}
         location /api/ {
             {{- if .Values.saml.enabled }}

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -531,6 +531,7 @@ data:
         add_header Cache-Control "max-age=300";
         add_header ETag "1.90.0-rc.0";
         listen 9090;
+        listen [::]:9090;
         location /api/ {
             proxy_pass http://api/;
             proxy_redirect off;


### PR DESCRIPTION
## What does this PR change?
Add ipv6.


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
User will be able to use ipv6 out-of-the-box.


## Links to Issues or ZD tickets this PR addresses or fixes
Fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1092

## How was this PR tested?
Manually and locally only.

Before
❯ kubectl exec -i -t kubecost-cost-analyzer-bcbb4569-kxs4j -n kubecost --container cost-analyzer-frontend -- netstat -tunlp

Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:9090            0.0.0.0:*               LISTEN      1/nginx: master pro
tcp        0      0 :::9001                 :::*                    LISTEN      -
tcp        0      0 :::9003                 :::*                    LISTEN      -

After
❯ kubectl exec -i -t kubecost-cost-analyzer-667bbf8f76-v56rx -n kubecost --container cost-analyzer-frontend -- netstat -tunlp
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:9090            0.0.0.0:*               LISTEN      1/nginx: master pro
tcp        0      0 :::9090                 :::*                    LISTEN      1/nginx: master pro
tcp        0      0 :::9001                 :::*                    LISTEN      -
tcp        0      0 :::9003                 :::*                    LISTEN      -

## Have you made an update to documentation?
Not sure what documentation can be updated to reflect this change.
