### PR TITLE
Adds metrics configmap template and field in values.yaml

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -366,6 +366,10 @@ spec:
             - name: PRICING_CONFIGMAP_NAME
               value: {{ .Values.pricingConfigmapName }}
             {{- end }}
+            {{- if .Values.metricsConfigmapName }}
+            - name: METRICS_CONFIGMAP_NAME
+              value: {{ .Values.metricsConfigmapName }}
+            {{- end }}
             - name: READ_ONLY
               value: {{ (quote .Values.readonly) | default (quote false) }}
             - name: PROMETHEUS_SERVER_ENDPOINT

--- a/cost-analyzer/templates/cost-analyzer-metrics-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-metrics-config-map-template.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.kubecostProductConfigs -}}
+{{- if .Values.kubecostProductConfigs.metricsConfigs -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ default "metrics-config" .Values.metricsConfigmapName }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  metrics.json: '{{ toJson .Values.kubecostProductConfigs.metricsConfigs }}'
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -760,6 +760,8 @@ awsstore:
 #  sharedNamespaces: "" # namespaces with shared workloads, example value: "kube-system\,ingress-nginx\,kubecost\,monitoring"
 #  sharedOverhead: "" # value representing a fixed external cost per month to be distributed among aggregations.
 #  shareTenancyCosts: true # enable or disable sharing costs such as cluster management fees (defaults to "true" on Settings page)
+#  metricsConfigs: # configuration for metrics emitted by Kubecost
+#    disabledMetrics: [] # list of metrics that Kubecost with not emit. Note that disabling metrics can lead to unexpected behavior in the cost-model.
 #  productKey: # apply business or enterprise product license
 #    key: ""
 #    enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -763,7 +763,7 @@ awsstore:
 #  sharedOverhead: "" # value representing a fixed external cost per month to be distributed among aggregations.
 #  shareTenancyCosts: true # enable or disable sharing costs such as cluster management fees (defaults to "true" on Settings page)
 #  metricsConfigs: # configuration for metrics emitted by Kubecost
-#    disabledMetrics: [] # list of metrics that Kubecost with not emit. Note that disabling metrics can lead to unexpected behavior in the cost-model.
+#    disabledMetrics: [] # list of metrics that Kubecost will not emit. Note that disabling metrics can lead to unexpected behavior in the cost-model.
 #  productKey: # apply business or enterprise product license
 #    key: ""
 #    enabled: false


### PR DESCRIPTION
## What does this PR change?
Adds a metrics configuration configmap template and the associated field(s) in values.yaml. As of this PR, this only contains `disabledMetrics` for disabling emission of certain metrics, but should expand functionality soon.

More information in the associated cost-model PR.

## Does this PR rely on any other PRs?

- https://github.com/kubecost/cost-model/pull/1060
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
See cost-model PR.

## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
See cost-model PR.

## Have you made an update to documentation?

