### PR TITLE
Configurable SAML token expiration and SAML logout functionality

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -614,6 +614,14 @@ spec:
             - name: NAME_ID_FORMAT
               value: {{ .Values.saml.nameIDFormat }}
             {{- end}}
+            {{- if .Values.saml.authTimeout }}
+            - name: AUTH_TOKEN_TIMEOUT
+              value: {{ (quote .Values.saml.authTimeout) }}
+            {{- end}}
+            {{- if .Values.saml.redirectURL }}
+            - name: LOGOUT_REDIRECT_URL
+              value: {{ .Values.saml.redirectURL }}
+            {{- end}}
             {{- if .Values.saml.rbac.enabled }}
             - name: SAML_RBAC_ENABLED
               value: "true"

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -187,6 +187,18 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        location /logout {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://model/logout;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
     {{- if .Values.global.grafana.proxy }}
         location /grafana/ {
         {{- if .Values.saml.enabled }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -153,6 +153,8 @@ saml:
   #metadataSecretName: "kubecost-authzero-metadata" # One of metadataSecretName or idpMetadataURL must be set. defaults to metadataURL if set
   idpMetadataURL: "https://dev-elu2z98r.auth0.com/samlp/metadata/c6nY4M37rBP0qSO1IYIqBPPyIPxLS8v2"
   appRootURL: "http://localhost:9090" # sample URL
+  authTimeout: 1440 # number of minutes the JWT will be valid
+  redirectURL: "https://dev-elu2z98r.auth0.com/v2/logout" # callback URL redirected to after logout
   # audienceURI: "http://localhost:9090" # by convention, the same as the appRootURL, but any string uniquely identifying kubecost to your samp IDP. Optional if you follow the convention
   # nameIDFormat: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" If your SAML provider requires a specific nameid format
   # isGLUUProvider: false # An additional URL parameter must be appended for GLUU providers


### PR DESCRIPTION
## What does this PR change?
Adds configurable SAML cookie timeout and a logout button/endpoint that invalidates the cookie and redirects to a configurable URL.
![image](https://user-images.githubusercontent.com/32113845/153495531-07343843-a7db-426c-9322-8516b022ddeb.png)


## Does this PR rely on any other PRs?

- https://github.com/kubecost/cost-analyzer-frontend/pull/504
- https://github.com/kubecost/kubecost-cost-model/pull/654


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds configurable SAML session timeout and logout redirect URL (with associated logout button on FE).

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1223
- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1224


## How was this PR tested?
Manually with Auth0.

## Have you made an update to documentation?
No.
