### PR TITLE
Add imagePullPolicy for cost-analyzer-server

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -711,6 +711,11 @@ spec:
           resources:
 {{ toYaml .Values.kubecost.resources | indent 12 }}
           name: cost-analyzer-server
+        {{- if .Values.kubecost.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.kubecost.imagePullPolicy }}
+        {{- else }}
+          imagePullPolicy: Always
+        {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -198,6 +198,7 @@ kubecost:
   # Setting this to true will mean all /api/ endpoints will be unavailable
   disableServer: false
   image: "gcr.io/kubecost1/server"
+  imagePullPolicy: IfNotPresent
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
## What does this PR change?
* Adds "imagePullPolicy" for cost-analyzer-server
* Sets default value for new "kubecost.imagePullPolicy" to "IfNotPresent"



## Does this PR rely on any other PRs?

None



## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Added possibility to use pull policy for kubecost server image.


## Links to Issues or ZD tickets this PR addresses or fixes

None 


## How was this PR tested?

The chart and its subchart was installed/upgraded on a K8s cluster.


## Have you made an update to documentation?

No documentation updates because of generally missing image-related parameterrs in documentation. 