### PR TITLE
Add command and args fields for cost-model and network-costs pods

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -250,10 +250,6 @@ spec:
         - image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
         {{ end }}
           name: cost-model
-        {{- if .Values.kubecostModel.command }}
-          command:
-          {{- toYaml .Values.kubecostModel.command | nindent 12 }}
-        {{- end }}
         {{- if .Values.kubecostModel.extraArgs }}
           args:
           {{- toYaml .Values.kubecostModel.extraArgs | nindent 12 }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -250,6 +250,14 @@ spec:
         - image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
         {{ end }}
           name: cost-model
+        {{- if .Values.kubecostModel.command }}
+          command:
+          {{- toYaml .Values.kubecostModel.command | nindent 12 }}
+        {{- end }}
+        {{- if .Values.kubecostModel.args }}
+          args:
+          {{- toYaml .Values.kubecostModel.args | nindent 12 }}
+        {{- end }}
         {{- if .Values.kubecostModel.imagePullPolicy }}
           imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}
         {{- else }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -254,9 +254,9 @@ spec:
           command:
           {{- toYaml .Values.kubecostModel.command | nindent 12 }}
         {{- end }}
-        {{- if .Values.kubecostModel.args }}
+        {{- if .Values.kubecostModel.extraArgs }}
           args:
-          {{- toYaml .Values.kubecostModel.args | nindent 12 }}
+          {{- toYaml .Values.kubecostModel.extraArgs | nindent 12 }}
         {{- end }}
         {{- if .Values.kubecostModel.imagePullPolicy }}
           imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -35,10 +35,6 @@ spec:
       containers:
       - name: {{ template "cost-analyzer.networkCostsName" . }}
         image: {{ .Values.networkCosts.image }}
-        {{- if .Values.networkCosts.command }}
-        command:
-          {{- toYaml .Values.networkCosts.command | nindent 8 }}
-        {{- end }}
         {{- if .Values.networkCosts.extraArgs }}
         args:
           {{- toYaml .Values.networkCosts.extraArgs | nindent 8 }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -35,6 +35,14 @@ spec:
       containers:
       - name: {{ template "cost-analyzer.networkCostsName" . }}
         image: {{ .Values.networkCosts.image }}
+        {{- if .Values.networkCosts.command }}
+        command:
+          {{- toYaml .Values.networkCosts.command | nindent 8 }}
+        {{- end }}
+        {{- if .Values.networkCosts.args }}
+        args:
+          {{- toYaml .Values.networkCosts.args | nindent 8 }}
+        {{- end }}
 {{- if .Values.networkCosts.imagePullPolicy }}
         imagePullPolicy: {{ .Values.networkCosts.imagePullPolicy }}
 {{- else }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -39,9 +39,9 @@ spec:
         command:
           {{- toYaml .Values.networkCosts.command | nindent 8 }}
         {{- end }}
-        {{- if .Values.networkCosts.args }}
+        {{- if .Values.networkCosts.extraArgs }}
         args:
-          {{- toYaml .Values.networkCosts.args | nindent 8 }}
+          {{- toYaml .Values.networkCosts.extraArgs | nindent 8 }}
         {{- end }}
 {{- if .Values.networkCosts.imagePullPolicy }}
         imagePullPolicy: {{ .Values.networkCosts.imagePullPolicy }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -172,6 +172,9 @@ spec:
             {{- end }}
           args: 
             - agent
+            {{- if .Values.kubecostMetrics.exporter.extraArgs }}
+            {{ toYaml .Values.kubecostMetrics.exporter.extraArgs | nindent 12 }}
+            {{- end }}
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
               valueFrom:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -247,6 +247,7 @@ kubecostMetrics:
     additionalLabels: {}
     nodeSelector: {}
     annotations: {}
+    extraArgs: []
 
 kubecostModel:
   image: "gcr.io/kubecost1/cost-model"
@@ -275,8 +276,7 @@ kubecostModel:
     #limits:
     #  cpu: "800m"
     #  memory: "256Mi"
-  #command: []
-  #args: []
+  extraArgs: []
 
 # Basic Kubecost ingress, more examples available at https://github.com/kubecost/docs/blob/master/ingress-examples.md
 ingress:
@@ -513,8 +513,7 @@ networkCosts:
     #requests:
     #  cpu: "50m"
     #  memory: "20Mi"
-  #command: []
-  #args: []
+  extraArgs: []
   config:
     # Configuration for traffic destinations, including specific classification
     # for IPs and CIDR blocks. This configuration will act as an override to the

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -275,6 +275,8 @@ kubecostModel:
     #limits:
     #  cpu: "800m"
     #  memory: "256Mi"
+  #command: []
+  #args: []
 
 # Basic Kubecost ingress, more examples available at https://github.com/kubecost/docs/blob/master/ingress-examples.md
 ingress:
@@ -511,6 +513,8 @@ networkCosts:
     #requests:
     #  cpu: "50m"
     #  memory: "20Mi"
+  #command: []
+  #args: []
   config:
     # Configuration for traffic destinations, including specific classification
     # for IPs and CIDR blocks. This configuration will act as an override to the


### PR DESCRIPTION
## What does this PR change?

- Add command and args fields for cost-model and network-costs pods


## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Users will be able to override default command and args of cost-model and network-costs pods if they want to.

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

- Manually using helm template command
- Upgrade of existing helm chart on a k8s cluster

## Have you made an update to documentation?

Not sure what documentation can be updated to reflect this change.