### PR TITLE
Give cluster-controller access to KC cluster ID

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -206,6 +206,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: CLUSTER_ID
+          value: {{ .Values.prometheus.server.global.external_labels.cluster_id }}
         - name: TURNDOWN_NAMESPACE
           value: {{ .Release.Namespace }}
         - name: TURNDOWN_DEPLOYMENT


### PR DESCRIPTION
## What does this PR change?

Adds an environment variable for cluster-controller to know the cluster ID of its local cluster.

Knowing the ID of the cluster it is running in helps cluster-controller
work with ETL-based data to avoid problematic write scenarios, like
resizing itself, thus aborting the resize partway.

Long-term, this probably shouldn't be necessary if we put sizing state
in proper K8s structures like a CRD.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

See https://github.com/kubecost/cluster-controller/pull/2

## Have you made an update to documentation?

N/A