### PR TITLE
Add a custom 504 page to NGINX config

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -77,6 +77,12 @@ data:
         index index.html;
         large_client_header_buffers 4 32k;
         add_header Cache-Control "must-revalidate";
+
+        error_page 504 /custom_504.html;
+        location = /custom_504.html {
+            internal;
+        }
+
 {{- if .Values.saml.enabled }}
         add_header Cache-Control "max-age=0";
         location / {


### PR DESCRIPTION
## What does this PR change?

A common source of confusion when doing support is finding out where 504
errors are coming from. Often this is caused by slowness of a backing
API, but debugging should be substantially improved with a custom 504
page that will let us discover if our NGINX is the source of a 504 vs.
an external gateway, like a user's load balancer etc.

The new custom_504.html page is introduced in a separate frontend PR.

Ref: https://www.digitalocean.com/community/tutorials/how-to-configure-nginx-to-use-custom-error-pages-on-ubuntu-14-04

## Does this PR rely on any other PRs?

- https://github.com/kubecost/cost-analyzer-frontend/pull/512

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Kubecost will now return a custom 504 page if Kubecost's frontend is timing out. This should help disambiguate 504 errors in situation where multiple gateways/proxies are present.

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

Tested with a custom "location" to force a 504:
```
        location /504 {
            return 504;
        }
```

Observed the new custom_504.html page at `/504` when I deployed the change.

## Have you made an update to documentation?

N/A