### PR TITLE
Revert "Change method of checking if networking.k8s.io/v1/Ingress is …

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
@@ -5,7 +5,7 @@
 {{- $ingressPaths := .Values.ingress.paths -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $apiV1 := false -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare "^1.19-0" .Capabilities.KubeVersion.GitVersion) }}
 {{- $apiV1 = true -}}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}


### PR DESCRIPTION
…supported"

This reverts commit 3d1f53d754b4a50808b90288b0de5c1aaa5a0b5c.

## What does this PR change?
Revert commit that changes ingress spec logic from using `.Capabilities.KubeVersion` to  `.Capabilities.APIVersions`, as this change has been causing issues with the ingress template.

## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Tested on 1.22 GKE cluster with ingress enabled, as well as with helm template/helm install --dry-run.

## Have you made an update to documentation?

