### PR TITLE
Bump chart version for v1.91.0-rc.1

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "1.91.0-rc.0"
+appVersion: "1.91.0-rc.1"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer
-version: "1.91.0-rc.0"
+version: "1.91.0-rc.1"
 annotations:
   "artifacthub.io/links": |
     - name: Homepage


### PR DESCRIPTION
I forgot to do this when I updated the tag to 1.91.0-rc.1