### PR TITLE
FIX: add required field to awsstore object in values.yaml (ISSUE: #1273)

### DIFF
--- a/cost-analyzer/templates/awsstore-deployment-template.yaml
+++ b/cost-analyzer/templates/awsstore-deployment-template.yaml
@@ -25,7 +25,7 @@ spec:
             - image: {{ .Values.awsstore.imageNameAndVersion }}
               name: awsstore
               # Just sleep forever
-              command: [ "sleep" ]
-              args: [ "infinity" ]
+              command: [ "/bin/sh" ]
+              args: [ "-c", "while true; do go/bin/app; sleep infinity; done" ]
 {{- end }}
 {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -667,6 +667,7 @@ serviceAccount:
 awsstore:
   useAwsStore: false
   createServiceAccount: false
+  imageNameAndVersion: alpine:latest # An image must be defined for the awsstore deployment.
 
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -667,7 +667,7 @@ serviceAccount:
 awsstore:
   useAwsStore: false
   createServiceAccount: false
-  imageNameAndVersion: alpine:latest # An image must be defined for the awsstore deployment.
+  imageNameAndVersion: gcr.io/kubecost1/awsstore:latest
 
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request
 


### PR DESCRIPTION
## What does this PR change?

adds the required key:value imageNameAndVersion to the awsstore object in the values.yaml, changes the command that the awsstore deployment runs so that it actually gets the AWS Marketplace subscription.

## Does this PR rely on any other PRs?

no


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

fixes issue where the awsstore deploy doesnt deploy.

## Links to Issues or ZD tickets this PR addresses or fixes

- fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1273


## How was this PR tested?
in production

## Have you made an update to documentation?

no, no update necessary 