### PR TITLE
add azureDurableOfferID config

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -58,8 +58,11 @@ data:
   {{- if .Values.kubecostProductConfigs.azureClientID }}
     azureClientID: "{{ .Values.kubecostProductConfigs.azureClientID }}"
   {{- end -}}
-    {{- if .Values.kubecostProductConfigs.azureTenantID }}
+  {{- if .Values.kubecostProductConfigs.azureTenantID }}
     azureTenantID: "{{ .Values.kubecostProductConfigs.azureTenantID }}"
+  {{- end -}}
+  {{- if .Values.kubecostProductConfigs.azureOfferDurableID }}
+    azureOfferDurableID: "{{ .Values.kubecostProductConfigs.azureOfferDurableID }}"
   {{- end -}}
   {{- if .Values.kubecostProductConfigs.discount }}
     discount: "{{ .Values.kubecostProductConfigs.discount }}"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -754,6 +754,7 @@ awsstore:
 #  azureClientID: f2ef6f7d-71fb-47c8-b766-8d63a19db017
 #  azureTenantID: 72faf3ff-7a3f-4597-b0d9-7b0b201bb23a
 #  azureClientPassword: fake key # Only use if your values.yaml are stored encrypted. Otherwise provide an existing secret via serviceKeySecretName
+#  azureOfferDurableID: "MS-AZR-0003p"
 #  azureStorageSecretName: "azure-storage-config" # Name of Kubernetes Secret where Azure Storage Configuration is stored
 #  discount: "" # percentage discount applied to compute
 #  negotiatedDiscount: "" # custom negotiated cloud provider discount


### PR DESCRIPTION
## What does this PR change?
This PR adds a field to the helm configuration which allows users to select the appropriate Durable Offer ID for their subscription, when using the Azure Rate Card API.


## Does this PR rely on any other PRs?

- https://github.com/kubecost/cost-model/pull/1086
- https://github.com/kubecost/kubecost-cost-model/pull/683


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Using this feature should allow users to get more accurate pricing prediction using the Rate Card API


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
See https://github.com/kubecost/cost-model/pull/1086

## Have you made an update to documentation?
https://github.com/kubecost/docs/pull/186
