### PR TITLE
Fix isGLUUProvider env var parsing

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -618,7 +618,7 @@ spec:
             {{- end }}
             {{- if .Values.saml.isGLUUProvider }}
             - name: GLUU_SAML_PROVIDER
-              value: {{ .Values.saml.isGLUUProvider }}
+              value: {{ (quote .Values.saml.isGLUUProvider) }}
             {{- end }}
             {{- if .Values.saml.nameIDFormat }}
             - name: NAME_ID_FORMAT


### PR DESCRIPTION
## What does this PR change?
- Fixes malformed parsing of `.Values.saml.isGLUUProvider` that caused failure in `helm upgrade` 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- See above.

## Links to Issues or ZD tickets this PR addresses or fixes
- https://kubecost.zendesk.com/agent/tickets/1442

## How was this PR tested?
Manually. @nikovacevic and @keithhand were able to reproduce using user's instructions. @nikovacevic used the fix and was able to upgrade.