### PR TITLE
Add support for specifying custom nginx ssl_protocols

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -13,9 +13,9 @@ data:
 
     # Enable gzip encoding for content of the provided types of 50kb and higher.
     gzip on;
-    gzip_min_length 50000; 
+    gzip_min_length 50000;
     gzip_proxied expired no-cache no-store private auth;
-    gzip_types 
+    gzip_types
         application/atom+xml
         application/geo+json
         application/javascript
@@ -104,6 +104,9 @@ data:
 {{- end }}
 {{- if .Values.kubecostFrontend.tls }}
 {{- if .Values.kubecostFrontend.tls.enabled }}
+{{- if .Values.kubecostFrontend.tls.specifyProtocols }}
+        ssl_protocols       {{ $.Values.kubecostFrontend.tls.protocols }};
+{{- end }}
         ssl_certificate     /etc/ssl/certs/kc.crt;
         ssl_certificate_key /etc/ssl/certs/kc.key;
         listen 443 ssl;
@@ -138,7 +141,7 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        
+
         location ~ ^/(turndown|cluster)/ {
 
             add_header 'Access-Control-Allow-Origin' '*' always;
@@ -151,7 +154,7 @@ data:
             auth_request /authrbac;
             {{- end }}
             {{- end }}
-            
+
             rewrite ^/(?:turndown|cluster)/(.*)$ /$1 break;
             proxy_pass http://clustercontroller;
             proxy_connect_timeout       180;
@@ -162,7 +165,7 @@ data:
             proxy_set_header Connection "";
             proxy_set_header X-Real-IP  $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        
+
 {{- else }}
             return 404;
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
- Allows setting custom TLS protocols using helm values
  - `--set kubecostFrontend.tls.specifyProtocols=true` to specify TLS protocols
  - `--set kubecostFrontend.tls.protocols=TLSv1.2` to specify only "TLSv1.2", e.g.

## How does this PR impact users?
- Allows users with specific security requirements to narrow TLS versions.

## Links to issues or tickets this PR addresses
- Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1272

## How was this PR tested?
Manually by inspecting the nginx configs and by testing the behavior. See below.

### Inspecting configs
With just TLS enabled, but no custom TLS settings, defaults are used:
```
ssl_certificate     /etc/ssl/certs/kc.crt;
ssl_certificate_key /etc/ssl/certs/kc.key;
listen 443 ssl;
listen [::]:443 ssl;
```
[after.tls-on.conf.txt](https://github.com/kubecost/cost-analyzer-helm-chart/files/8189454/after.tls-on.conf.txt)

With custom TLS settings enabled, we can override the ssl_protocols:
```
ssl_protocols       TLSv1.2;
ssl_certificate     /etc/ssl/certs/kc.crt;
ssl_certificate_key /etc/ssl/certs/kc.key;
listen 443 ssl;
listen [::]:443 ssl;
```
[after.tls-custom.conf.txt](https://github.com/kubecost/cost-analyzer-helm-chart/files/8189453/after.tls-custom.conf.txt)

### Testing behavior
1. Enabled TLS without setting custom `ssl_protocols` and noted that it works. [1]
2. Enabled TLS with custom `ssl_protocols` using helm values `kubecostFrontend.tls.specifyProtocols=true` and `kubecostFrontend.tls.protocols=TLSv1.2` and noted that the page loaded with standard browser TLS settings. [2, 3]
3. Changed the browser TLS setting to use 1.1 and noted that the page refused to load. [4, 5]

[1]
![Screenshot from 2022-03-04 17-22-40](https://user-images.githubusercontent.com/8070055/156859891-c6ee66fc-5fad-4d97-bf76-9666887ed896.png)

[2]
![Screenshot from 2022-03-04 17-34-44](https://user-images.githubusercontent.com/8070055/156859946-27edb5a8-819d-4876-9860-0f34c83e053d.png)

[3]
![Screenshot from 2022-03-04 17-32-49](https://user-images.githubusercontent.com/8070055/156859870-e6483e78-52b3-4378-8f70-e8a16ebed4d2.png)

[4]
![Screenshot from 2022-03-04 17-42-19](https://user-images.githubusercontent.com/8070055/156859987-6df4567e-99d0-43ea-8547-53a49a941293.png)

[5]
![Screenshot from 2022-03-04 17-35-16](https://user-images.githubusercontent.com/8070055/156860000-16d1d3f8-b340-4cd8-9777-cd9751fac5de.png)

## Have you made an update to documentation?
Yes.
