### PR TITLE
Bump version of configmap reload.

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -320,7 +320,7 @@ configmapReload:
     ##
     image:
       repository: jimmidyson/configmap-reload
-      tag: v0.6.1
+      tag: v0.7.1
       pullPolicy: IfNotPresent
 
     ## Additional configmap-reload container arguments
@@ -358,7 +358,7 @@ configmapReload:
     ##
     image:
       repository: jimmidyson/configmap-reload
-      tag: v0.6.1
+      tag: v0.7.1
       pullPolicy: IfNotPresent
 
     ## Additional configmap-reload container arguments


### PR DESCRIPTION
## What does this PR change?
Bump version of configmap-reload


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No impact


## Links to Issues or ZD tickets this PR addresses or fixes
Fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1297

## How was this PR tested?
Just run the application with the new prometheus image

## Have you made an update to documentation?
Not necessary.
