### PR TITLE
Fix typo in network-costs role template

### DIFF
--- a/cost-analyzer/templates/network-costs-role.template.yaml
+++ b/cost-analyzer/templates/network-costs-role.template.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kubecost-network-costs
-  lables:
+  labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
   annotations:
 {{- if .Values.networkCosts.podSecurityPolicy.annotations }}


### PR DESCRIPTION
## What does this PR change?

- Fix typo for `labels` field in the network-costs role template

## Does this PR rely on any other PRs?

No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Users cannot deploy network-costs through the helm chart due to the syntax error

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

- Manually using helm template command
- Upgrade of existing helm chart on a k8s cluster

## Have you made an update to documentation?

No