### PR TITLE
Save mount path of productKey secret into environment variable

### DIFF
--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -46,3 +46,4 @@ Parameter | Description | Default
 `serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`
 `tolerations` | node taints to tolerate | `[]`
 `affinity` | pod affinity | `{}`
+`kubecostProductConfigs.productKey.mountPath` | Customize path at which to mount the product key secret | `"/var/configs/productkey"`

--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -46,4 +46,4 @@ Parameter | Description | Default
 `serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`
 `tolerations` | node taints to tolerate | `[]`
 `affinity` | pod affinity | `{}`
-`kubecostProductConfigs.productKey.mountPath` | Set the path at which the product key secret is mounted (eg. by a secrets provisioner) | `"/var/configs/productkey"`
+`kubecostProductConfigs.productKey.mountPath` | Set the path at which the product key secret is mounted (eg. by a secrets provisioner) | `"/var/configs/productkey/productkey.json"`

--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -46,4 +46,4 @@ Parameter | Description | Default
 `serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`
 `tolerations` | node taints to tolerate | `[]`
 `affinity` | pod affinity | `{}`
-`kubecostProductConfigs.productKey.mountPath` | Set the path at which the product key secret is mounted (eg. by a secrets provisioner) | `"/var/configs/productkey/productkey.json"`
+`kubecostProductConfigs.productKey.mountPath` | Use instead of `kubecostProductConfigs.productKey.secretname` to declare the path at which the product key file is mounted (eg. by a secrets provisioner) | `N/A`

--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -46,5 +46,4 @@ Parameter | Description | Default
 `serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`
 `tolerations` | node taints to tolerate | `[]`
 `affinity` | pod affinity | `{}`
-`kubecostProductConfigs.productKey.volumeMountPath` | Customize the path at which the product key secret should be mounted (as a volume) | `"/var/configs/productkey"`
-`kubecostProductConfigs.productKey.envvarMountPath` | Customize the path at which the product key secret is mounted (as an environment variable) | `"/var/configs/productkey"`
+`kubecostProductConfigs.productKey.mountPath` | Set the path at which the product key secret is mounted (eg. by a secrets provisioner) | `"/var/configs/productkey"`

--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -46,4 +46,5 @@ Parameter | Description | Default
 `serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`
 `tolerations` | node taints to tolerate | `[]`
 `affinity` | pod affinity | `{}`
-`kubecostProductConfigs.productKey.mountPath` | Customize path at which to mount the product key secret | `"/var/configs/productkey"`
+`kubecostProductConfigs.productKey.volumeMountPath` | Customize the path at which the product key secret should be mounted (as a volume) | `"/var/configs/productkey"`
+`kubecostProductConfigs.productKey.envvarMountPath` | Customize the path at which the product key secret is mounted (as an environment variable) | `"/var/configs/productkey"`

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -287,7 +287,7 @@ spec:
             {{- if .Values.kubecostProductConfigs.productKey }}
             {{- if .Values.kubecostProductConfigs.productKey.secretname }}
             - name: productkey-secret
-              mountPath: {{ .Values.kubecostProductConfigs.productKey.mountPath | default "/var/configs/productkey" }}
+              mountPath: {{ .Values.kubecostProductConfigs.productKey.volumeMountPath | default "/var/configs/productkey" }}
             {{- end }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
@@ -400,7 +400,7 @@ spec:
             {{- end }}
             {{- if .Values.kubecostProductConfigs.productKey }}
             - name: PRODUCT_KEY_MOUNT_PATH
-              value: {{ .Values.kubecostProductConfigs.productKey.mountPath | default "/var/configs/productkey" }}
+              value: {{ .Values.kubecostProductConfigs.productKey.envvarMountPath | default "/var/configs/productkey" }}
             {{- end }}
             - name: REMOTE_WRITE_PASSWORD
               value: {{ .Values.remoteWrite.postgres.auth.password }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -398,9 +398,9 @@ spec:
             {{- else }}
               value: production
             {{- end }}
-            {{- if .Values.kubecostProductConfigs.productKey }}
+            {{- if .Values.kubecostProductConfigs.productKey.mountPath }}
             - name: PRODUCT_KEY_MOUNT_PATH
-              value: {{ .Values.kubecostProductConfigs.productKey.mountPath | default "/var/configs/productkey/productkey.json" }}
+              value: {{ .Values.kubecostProductConfigs.productKey.mountPath }}
             {{- end }}
             - name: REMOTE_WRITE_PASSWORD
               value: {{ .Values.remoteWrite.postgres.auth.password }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -287,7 +287,7 @@ spec:
             {{- if .Values.kubecostProductConfigs.productKey }}
             {{- if .Values.kubecostProductConfigs.productKey.secretname }}
             - name: productkey-secret
-              mountPath: {{ .Values.kubecostProductConfigs.productKey.mountPath }}
+              mountPath: {{ .Values.kubecostProductConfigs.productKey.mountPath | default "/var/configs/productkey" }}
             {{- end }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -287,7 +287,7 @@ spec:
             {{- if .Values.kubecostProductConfigs.productKey }}
             {{- if .Values.kubecostProductConfigs.productKey.secretname }}
             - name: productkey-secret
-              mountPath: /var/configs/productkey
+              mountPath: {{ .Values.kubecostProductConfigs.productKey.mountPath }}
             {{- end }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
@@ -397,6 +397,10 @@ spec:
               value: {{ .Values.kubecostProductConfigs.clusterProfile | default "production" }}
             {{- else }}
               value: production
+            {{- end }}
+            {{- if .Values.kubecostProductConfigs.productKey }}
+            - name: PRODUCT_KEY_MOUNT_PATH
+              value: {{ .Values.kubecostProductConfigs.productKey.mountPath | default "/var/configs/productkey" }}
             {{- end }}
             - name: REMOTE_WRITE_PASSWORD
               value: {{ .Values.remoteWrite.postgres.auth.password }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -287,7 +287,7 @@ spec:
             {{- if .Values.kubecostProductConfigs.productKey }}
             {{- if .Values.kubecostProductConfigs.productKey.secretname }}
             - name: productkey-secret
-              mountPath: {{ .Values.kubecostProductConfigs.productKey.volumeMountPath | default "/var/configs/productkey" }}
+              mountPath: /var/configs/productkey
             {{- end }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
@@ -400,7 +400,7 @@ spec:
             {{- end }}
             {{- if .Values.kubecostProductConfigs.productKey }}
             - name: PRODUCT_KEY_MOUNT_PATH
-              value: {{ .Values.kubecostProductConfigs.productKey.envvarMountPath | default "/var/configs/productkey" }}
+              value: {{ .Values.kubecostProductConfigs.productKey.mountPath | default "/var/configs/productkey" }}
             {{- end }}
             - name: REMOTE_WRITE_PASSWORD
               value: {{ .Values.remoteWrite.postgres.auth.password }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -400,7 +400,7 @@ spec:
             {{- end }}
             {{- if .Values.kubecostProductConfigs.productKey }}
             - name: PRODUCT_KEY_MOUNT_PATH
-              value: {{ .Values.kubecostProductConfigs.productKey.mountPath | default "/var/configs/productkey" }}
+              value: {{ .Values.kubecostProductConfigs.productKey.mountPath | default "/var/configs/productkey/productkey.json" }}
             {{- end }}
             - name: REMOTE_WRITE_PASSWORD
               value: {{ .Values.remoteWrite.postgres.auth.password }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -779,5 +779,6 @@ awsstore:
 #    key: ""
 #    enabled: false
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
-#    mountPath: "/var/configs/productkey"
+#    volumeMountPath: "/var/configs/productkey" # set the path at which the secret should be mounted (accessible as a volume)
+#    envvarMountPath: "/var/configs/productkey" # set the path at which the secret is mounted (accessible as an environment variable)
 #  cloudIntegrationSecret: "cloud-integration"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -779,4 +779,5 @@ awsstore:
 #    key: ""
 #    enabled: false
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
+#    mountPath: "/var/configs/productkey"
 #  cloudIntegrationSecret: "cloud-integration"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -779,5 +779,5 @@ awsstore:
 #    key: ""
 #    enabled: false
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
-#    mountPath: "/var/configs/productkey" # set the path at which the secret is mounted (eg. by a secrets provisioner)
+#    mountPath: "/var/configs/productkey/productkey.json" # set the path at which the secret is mounted (eg. by a secrets provisioner)
 #  cloudIntegrationSecret: "cloud-integration"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -779,6 +779,5 @@ awsstore:
 #    key: ""
 #    enabled: false
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
-#    volumeMountPath: "/var/configs/productkey" # set the path at which the secret should be mounted (accessible as a volume)
-#    envvarMountPath: "/var/configs/productkey" # set the path at which the secret is mounted (accessible as an environment variable)
+#    mountPath: "/var/configs/productkey" # set the path at which the secret is mounted (eg. by a secrets provisioner)
 #  cloudIntegrationSecret: "cloud-integration"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -779,5 +779,5 @@ awsstore:
 #    key: ""
 #    enabled: false
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
-#    mountPath: "/some/custom/path/productkey.json" # declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
+#    mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
 #  cloudIntegrationSecret: "cloud-integration"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -779,5 +779,5 @@ awsstore:
 #    key: ""
 #    enabled: false
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
-#    mountPath: "/var/configs/productkey/productkey.json" # set the path at which the secret is mounted (eg. by a secrets provisioner)
+#    mountPath: "/some/custom/path/productkey.json" # declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
 #  cloudIntegrationSecret: "cloud-integration"


### PR DESCRIPTION
## What does this PR change?
This PR defines:
- a `mountPath` parameter and calls it to populate a new `PRODUCT_KEY_MOUNT_PATH` environment variable

## Does this PR rely on any other PRs?
This PR should only be merged **after** the read source for the `ProductKeySecret` is modified in [this file](https://github.com/kubecost/kubecost-cost-model/blob/f14c1ab3aa6bedfdd81f8dc1cf7908e9f26a0e58/pkg/product/productkey.go#L19).


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can now customise the path at which the product key secret is mounted: the user can declare the path at which an external secret provisioner has mounted the secret, informing us of its location (mountPath)


## Links to Issues or ZD tickets this PR addresses or fixes
- fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1021


## How was this PR tested?
`kubectl exec container-name -it sh` and verifying that the expected files exist:
- `printenv PRODUCT_KEY_MOUNT_PATH` returns the path defined by the user in values.yaml

## Have you made an update to documentation?
Defined the new field in the README.