### PR TITLE
Update cluster-controller to v0.0.5

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -604,7 +604,7 @@ kubecostDeployment:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.0.2
+  image: gcr.io/kubecost1/cluster-controller:v0.0.5
   imagePullPolicy: Always
 
 reporting:


### PR DESCRIPTION
## What does this PR change?

Updates the cluster-controller image to v0.0.5. (https://github.com/kubecost/cluster-controller/releases/tag/v0.0.5)

The update includes "1-click request sizing" endpoints and updated cluster-turndown (v1.3.0).


## Does this PR rely on any other PRs?

N/A


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Beta support for "1-click request sizing"

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

Install with the new image:
```bash
helm repo update

CHART="kubecost/cost-analyzer"

helm upgrade \
    -i \
    --create-namespace kubecost \
    ${CHART} \
    --namespace kubecost \
    --set clusterController.enabled=true \
    --set clusterController.image=gcr.io/kubecost1/cluster-controller:v0.0.5
```

I verified that one of the new endpoints in v0.0.5 is available and functioning:
```bash
curl -XGET 'localhost:9090/model/savings/requestSizing' \
    -d 'window=2d' \
    |
    curl -H "Content-Type: application/json" \
        -XPOST \
        --data-binary @- \
        'http://localhost:9090/cluster/requestsizer/plan' \
        | jq
```
## Have you made an update to documentation?

N/A