### PR TITLE
Allow setting customised fqdn values for NGINX config (kubecostFrontend)

### DIFF
--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -50,3 +50,4 @@ Parameter | Description | Default
 `kubecostFrontend.api.fqdn` | Customize the upstream api FQDN | `computed in terms of the service name and namespace`
 `kubecostFrontend.model.fqdn` | Customize the upstream model FQDN | `computed in terms of the service name and namespace`
 `clusterController.fqdn` | Customize the upstream cluster controller FQDN | `computed in terms of the service name and namespace`
+`global.grafana.fqdn` | Customize the upstream grafana FQDN | `computed in terms of the release name and namespace`

--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -47,6 +47,6 @@ Parameter | Description | Default
 `tolerations` | node taints to tolerate | `[]`
 `affinity` | pod affinity | `{}`
 `kubecostProductConfigs.productKey.mountPath` | Use instead of `kubecostProductConfigs.productKey.secretname` to declare the path at which the product key file is mounted (eg. by a secrets provisioner) | `N/A`
-`kubecostFrontend.api.fqdn` | Customize the upstream api FQDN | `kubecost-api.kubecost.svc.cluster.local`
-`kubecostFrontend.model.fqdn` | Customize the upstream model FQDN | `kubecost-model.kubecost.svc.cluster.local`
-`clusterController.fqdn` | Customize the cluster controller FQDN | `kubecost-cluster-controller.kubecost.svc.cluster.local`
+`kubecostFrontend.api.fqdn` | Customize the upstream api FQDN | `kubecost-api.kubecost.svc.cluster.local:9001`
+`kubecostFrontend.model.fqdn` | Customize the upstream model FQDN | `kubecost-model.kubecost.svc.cluster.local:9003`
+`clusterController.fqdn` | Customize the upstream cluster controller FQDN | `kubecost-cluster-controller.kubecost.svc.cluster.local:9731`

--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -47,6 +47,6 @@ Parameter | Description | Default
 `tolerations` | node taints to tolerate | `[]`
 `affinity` | pod affinity | `{}`
 `kubecostProductConfigs.productKey.mountPath` | Use instead of `kubecostProductConfigs.productKey.secretname` to declare the path at which the product key file is mounted (eg. by a secrets provisioner) | `N/A`
-`kubecostFrontend.api.fqdn` | Customize the upstream api FQDN | `kubecost-api.kubecost.svc.cluster.local:9001`
-`kubecostFrontend.model.fqdn` | Customize the upstream model FQDN | `kubecost-model.kubecost.svc.cluster.local:9003`
-`clusterController.fqdn` | Customize the upstream cluster controller FQDN | `kubecost-cluster-controller.kubecost.svc.cluster.local:9731`
+`kubecostFrontend.api.fqdn` | Customize the upstream api FQDN | `computed in terms of the service name and namespace`
+`kubecostFrontend.model.fqdn` | Customize the upstream model FQDN | `computed in terms of the service name and namespace`
+`clusterController.fqdn` | Customize the upstream cluster controller FQDN | `computed in terms of the service name and namespace`

--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -47,3 +47,6 @@ Parameter | Description | Default
 `tolerations` | node taints to tolerate | `[]`
 `affinity` | pod affinity | `{}`
 `kubecostProductConfigs.productKey.mountPath` | Use instead of `kubecostProductConfigs.productKey.secretname` to declare the path at which the product key file is mounted (eg. by a secrets provisioner) | `N/A`
+`kubecostFrontend.api.fqdn` | Customize the upstream api FQDN | `kubecost-api.kubecost.svc.cluster.local`
+`kubecostFrontend.model.fqdn` | Customize the upstream model FQDN | `kubecost-model.kubecost.svc.cluster.local`
+`clusterController.fqdn` | Customize the cluster controller FQDN | `kubecost-cluster-controller.kubecost.svc.cluster.local`

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -83,14 +83,14 @@ data:
 
 {{- if .Values.global.grafana.proxy }}
     upstream grafana {
+{{- if .Values.global.grafana.enabled }}
 {{- if .Values.global.grafana.fqdn }}
         server {{ .Values.global.grafana.fqdn }};
 {{- else }}
-{{- if .Values.global.grafana.enabled }}
         server {{ .Release.Name }}-grafana.{{ .Release.Namespace }};
+{{- end }}
 {{- else }}
         server {{.Values.global.grafana.domainName}};
-{{- end }}
 {{- end }}
     }
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -84,6 +84,8 @@ data:
 {{- if .Values.global.grafana.proxy }}
     upstream grafana {
 {{- if .Values.global.grafana.enabled }}
+        server {{ .Release.Name }}-grafana.{{ .Release.Namespace }};
+{{ else }}
         server {{.Values.global.grafana.domainName}};
 {{ end }}
     }

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -72,7 +72,11 @@ data:
 {{- if .Values.clusterController }}
 {{- if .Values.clusterController.enabled }}
     upstream clustercontroller {
+{{- if .Values.clusterController.fqdn }}
+        server {{ .Values.clusterController.fqdn }};
+{{- else }}
         server {{ template "kubecost.clusterControllerName" . }}-service.{{ .Release.Namespace }}:9731;
+{{-end }}
     }
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -84,8 +84,6 @@ data:
 {{- if .Values.global.grafana.proxy }}
     upstream grafana {
 {{- if .Values.global.grafana.enabled }}
-        server {{ .Release.Name }}-grafana.{{ .Release.Namespace }};
-{{ else }}
         server {{.Values.global.grafana.domainName}};
 {{ end }}
     }

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -46,11 +46,27 @@ data:
         text/x-cross-domain-policy;
 
     upstream api {
+{{- if.Values.kubecostFrontend.api }}
+{{- if.Values.kubecostFrontend.api.fqdn }}
+        server {{ .Values.kubecostFrontend.api.fqdn }};
+{{- else }}
         server {{ $serviceName }}.{{ .Release.Namespace }}:9001;
+{{- end }}
+{{- else }}
+        server {{ $serviceName }}.{{ .Release.Namespace }}:9001;
+{{- end }}
     }
 
     upstream model {
+{{- if.Values.kubecostFrontend.model }}
+{{- if.Values.kubecostFrontend.model.fqdn }}
+        server {{ .Values.kubecostFrontend.model.fqdn }};
+{{- else }}
         server {{ $serviceName }}.{{ .Release.Namespace }}:9003;
+{{- end }}
+{{- else }}
+        server {{ $serviceName }}.{{ .Release.Namespace }}:9003;
+{{- end }}
     }
 
 {{- if .Values.clusterController }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -76,7 +76,7 @@ data:
         server {{ .Values.clusterController.fqdn }};
 {{- else }}
         server {{ template "kubecost.clusterControllerName" . }}-service.{{ .Release.Namespace }}:9731;
-{{-end }}
+{{- end }}
     }
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -83,13 +83,17 @@ data:
 
 {{- if .Values.global.grafana.proxy }}
     upstream grafana {
+{{- if .Values.global.grafana.fqdn }}
+        server {{ .Values.global.grafana.fqdn }};
+{{- else }}
 {{- if .Values.global.grafana.enabled }}
         server {{ .Release.Name }}-grafana.{{ .Release.Namespace }};
-{{ else }}
+{{- else }}
         server {{.Values.global.grafana.domainName}};
-{{ end }}
+{{- end }}
+{{- end }}
     }
-{{ end }}
+{{- end }}
 
     server {
         server_name _;

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -17,7 +17,7 @@ global:
 
   grafana:
     enabled: true # If false, Grafana will not be installed
-    domainName: cost-analyzer-grafana.default.svc #example grafana domain
+    domainName: cost-analyzer-grafana.default.svc #example grafana domain Ignored if enabled: true
     scheme: "http" # http or https, for the domain name above.
     proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
 
@@ -197,10 +197,10 @@ kubecostFrontend:
     #limits:
     #  cpu: "100m"
     #  memory: "256Mi"
-  api:
-    fqdn: TODO-some-fqdn-example
-  model:
-    fqdn: TODO-some-fqdn-example
+#  api:
+#    fqdn: kubecost-api.kubecost.svc.cluster.local
+#  model:
+#    fqdn: kubecost-model.kubecost.svc.cluster.local
 
 kubecost:
   # Disables the cost-analyzer-server container to spin up as part of kubecost
@@ -619,7 +619,7 @@ clusterController:
   enabled: false
   image: gcr.io/kubecost1/cluster-controller:v0.0.5
   imagePullPolicy: Always
-  fqdn: TODO-some-fqdn-example
+  # fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local
 
 reporting:
   # Kubecost bug report feature: Logs access/collection limited to .Release.Namespace

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -20,7 +20,7 @@ global:
     domainName: cost-analyzer-grafana.default.svc #example grafana domain Ignored if enabled: true
     scheme: "http" # http or https, for the domain name above.
     proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
-    # fqdn: cost-analyzer-grafana.default.svc # example grafana fqdn, if enabled overrides other address computation
+    # fqdn: cost-analyzer-grafana.default.svc
 
   notifications:
     # Kubecost alerting configuration

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -619,6 +619,7 @@ clusterController:
   enabled: false
   image: gcr.io/kubecost1/cluster-controller:v0.0.5
   imagePullPolicy: Always
+  fqdn: TODO-some-fqdn-example
 
 reporting:
   # Kubecost bug report feature: Logs access/collection limited to .Release.Namespace

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -20,7 +20,7 @@ global:
     domainName: cost-analyzer-grafana.default.svc #example grafana domain Ignored if enabled: true
     scheme: "http" # http or https, for the domain name above.
     proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
-    # fqdn: cost-analyzer-grafana.default.svc
+#    fqdn: cost-analyzer-grafana.default.svc
 
   notifications:
     # Kubecost alerting configuration
@@ -620,7 +620,7 @@ clusterController:
   enabled: false
   image: gcr.io/kubecost1/cluster-controller:v0.0.5
   imagePullPolicy: Always
-  # fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
+#  fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
 
 reporting:
   # Kubecost bug report feature: Logs access/collection limited to .Release.Namespace

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -17,7 +17,7 @@ global:
 
   grafana:
     enabled: true # If false, Grafana will not be installed
-    domainName: cost-analyzer-grafana.default.svc #example grafana domain Ignored if enabled: true
+    domainName: cost-analyzer-grafana.default.svc #example grafana domain
     scheme: "http" # http or https, for the domain name above.
     proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -197,6 +197,10 @@ kubecostFrontend:
     #limits:
     #  cpu: "100m"
     #  memory: "256Mi"
+  api:
+    fqdn: TODO-some-fqdn-example
+  model:
+    fqdn: TODO-some-fqdn-example
 
 kubecost:
   # Disables the cost-analyzer-server container to spin up as part of kubecost

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -198,9 +198,9 @@ kubecostFrontend:
     #  cpu: "100m"
     #  memory: "256Mi"
 #  api:
-#    fqdn: kubecost-api.kubecost.svc.cluster.local
+#    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:
-#    fqdn: kubecost-model.kubecost.svc.cluster.local
+#    fqdn: kubecost-model.kubecost.svc.cluster.local:9003
 
 kubecost:
   # Disables the cost-analyzer-server container to spin up as part of kubecost
@@ -619,7 +619,7 @@ clusterController:
   enabled: false
   image: gcr.io/kubecost1/cluster-controller:v0.0.5
   imagePullPolicy: Always
-  # fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local
+  # fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
 
 reporting:
   # Kubecost bug report feature: Logs access/collection limited to .Release.Namespace

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -20,6 +20,7 @@ global:
     domainName: cost-analyzer-grafana.default.svc #example grafana domain Ignored if enabled: true
     scheme: "http" # http or https, for the domain name above.
     proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
+    # fqdn: cost-analyzer-grafana.default.svc # example grafana fqdn, if enabled overrides other address computation
 
   notifications:
     # Kubecost alerting configuration


### PR DESCRIPTION
## What does this PR change?
This PR defines several new values to be populated in values.yaml:
- `.kubecostFrontend.api.fqdn`
- `.kubecostFrontend.model.fqdn`
- `.clusterController.fqdn`
- `.global.grafana.fqdn`

If any of these three values are defined by the user, they will be applied in the `upstream api/model/clusterController/grafana` NGINX configuration, otherwise the existing defaults would be used.


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can now set customised fqdn values in the NGINX config. 


## Links to Issues or ZD tickets this PR addresses or fixes

- fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1271 


## How was this PR tested?
After defining the placeholders and populating them in `values.yaml`, I verified that the customised values appear in the `nginx-conf` map under the `upstream` definitions, as well as that if no `.fqdn` values exist, the defaults are used in creating the configmap.

## Have you made an update to documentation?
Updated the list at the [cost-analyzer-helm-chart README](https://github.com/kubecost/cost-analyzer-helm-chart#kubecost-helm-chart) to include the newly-added values.
