### PR TITLE
Fix: 'app' label is overwritten by commonLabels for kubecost metrics …

### DIFF
--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{ unset (include "cost-analyzer.commonLabels" . | fromYaml) "app" | toYaml | nindent 4 }}
     app: {{ template "kubecost.kubeMetricsName" . }}
 {{- with .Values.kubecostMetrics.exporter.labels }}
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
## What does this PR change?

This fixes a duplicate "app" label in the kubecost-agent Deployment

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

No impact

## Links to Issues or ZD tickets this PR addresses or fixes

- #1322  

## How was this PR tested?

Diffed the result between the chart in develop and in this branch:

> ➜  ~ diff -u original.yaml updated.yaml
> --- original.yaml       2022-03-22 16:40:01.622002841 +0100
> +++ updated.yaml        2022-03-22 16:40:15.382002845 +0100
> @@ -18177,11 +18177,10 @@
>    name: kubecost-agent
>    labels:
> 
> \-    app.kubernetes.io/name: cost-analyzer
> \-    helm.sh/chart: cost-analyzer-1.91.0
>      app.kubernetes.io/instance: kubecost
>      app.kubernetes.io/managed-by: Helm
> \-    app: cost-analyzer
> \+    app.kubernetes.io/name: cost-analyzer
> \+    helm.sh/chart: cost-analyzer-1.91.0
>      app: kubecost-agent
>  spec:
>    replicas: 1