### PR TITLE
Add flag for ingesting pod UID from KSM

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -405,6 +405,10 @@ spec:
               value: {{ .Values.kubecostProductConfigs.productKey.mountPath }}
             {{- end }}
             {{- end }}
+            {{- if .Values.kubecostProductConfigs.ingestPodUID }}
+            - name: INGEST_POD_UID
+              value: {{ (quote .Values.kubecostProductConfigs.ingestPodUID) }}
+            {{- end }}
             {{- end }}
             - name: REMOTE_WRITE_PASSWORD
               value: {{ .Values.remoteWrite.postgres.auth.password }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -688,7 +688,7 @@ awsstore:
 # These configs can also be set from the Settings page in the Kubecost product UI
 # Values in this block override config changes in the Settings UI on pod restart
 #
-kubecostProductConfigs:
+#kubecostProductConfigs:
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.
 # Ref: https://github.com/kubecost/docs/blob/master/multi-cluster.md
@@ -787,4 +787,4 @@ kubecostProductConfigs:
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
 #    mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
 #  cloudIntegrationSecret: "cloud-integration"
-  ingestPodUID: false
+#  ingestPodUID: false # Enables using UIDs to uniquely ID pods. This requires either Kubecost's replicated KSM metrics, or KSM v2.1.0+. This may impact performance, and changes the default cost-model allocation behavior.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -688,7 +688,7 @@ awsstore:
 # These configs can also be set from the Settings page in the Kubecost product UI
 # Values in this block override config changes in the Settings UI on pod restart
 #
-#kubecostProductConfigs:
+kubecostProductConfigs:
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.
 # Ref: https://github.com/kubecost/docs/blob/master/multi-cluster.md
@@ -787,3 +787,4 @@ awsstore:
 #    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }
 #    mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
 #  cloudIntegrationSecret: "cloud-integration"
+  ingestPodUID: false


### PR DESCRIPTION
## What does this PR change?
Adds a flag `.Values.kubecostProductConfigs.ingestPodUID` which toggles appending pod UID to pod names in the costmodel. See associated CM PR for more info.


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
See CM PR


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
See CM PR

## Have you made an update to documentation?

