### PR TITLE
Add option to customize Thanos deployment strategies

### DIFF
--- a/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
@@ -23,6 +23,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: bucket
 {{ with .Values.bucket.deploymentMatchLabels }}{{ toYaml . | indent 6 }}{{ end }}
+{{ with .Values.store.deploymentStrategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+{{ end }}
   template:
     metadata:
       labels:

--- a/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
@@ -23,6 +23,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: compact
 {{ with .Values.compact.deploymentMatchLabels }}{{ toYaml . | indent 6 }}{{ end }}
+{{ with .Values.store.deploymentStrategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+{{ end }}
   template:
     metadata:
       labels:

--- a/cost-analyzer/charts/thanos/templates/query-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-deployment.yaml
@@ -25,6 +25,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: query
 {{ with .Values.query.deploymentMatchLabels }}{{ toYaml . | indent 6 }}{{ end }}
+{{ with .Values.store.deploymentStrategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+{{ end }}
   template:
     metadata:
       labels:

--- a/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
@@ -25,6 +25,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: query-frontend
 {{ with .Values.queryFrontend.deploymentMatchLabels }}{{ toYaml . | indent 6 }}{{ end }}
+{{ with .Values.store.deploymentStrategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+{{ end }}
   template:
     metadata:
       labels:

--- a/cost-analyzer/charts/thanos/templates/store-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-deployment.yaml
@@ -23,6 +23,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: store
 {{ with .Values.store.deploymentMatchLabels }}{{ toYaml . | indent 6 }}{{ end }}
+{{ with .Values.store.deploymentStrategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+{{ end }}
   template:
     metadata:
       labels:

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -55,6 +55,10 @@ store:
   #
   # Add extra selector matchLabels to store deployment
   deploymentMatchLabels: {}
+  # Override the default deployment strategy
+  # deploymentStrategy:
+  #   type: RollingUpdate
+
   # Enable metrics collecting for store service
   metrics:
     # This is the Prometheus annotation type scraping configuration
@@ -274,6 +278,9 @@ queryFrontend:
   #
   # Add extra selector matchLabels to query deployment
   deploymentMatchLabels: {}
+  # Override the default deployment strategy
+  # deploymentStrategy:
+  #   type: RollingUpdate
 
   # Enable metrics collecting for query service
   metrics:
@@ -437,6 +444,9 @@ query:
   #
   # Add extra selector matchLabels to query deployment
   deploymentMatchLabels: {}
+  # Override the default deployment strategy
+  # deploymentStrategy:
+  #   type: RollingUpdate
 
   # Enable metrics collecting for query service
   metrics:
@@ -563,7 +573,10 @@ compact:
   #
   # Add extra selector matchLabels to compact deployment
   deploymentMatchLabels: {}
-  #
+  # Override the default deployment strategy
+  # deploymentStrategy:
+  #   type: RollingUpdate
+
   # Enable metrics collecting for compact service
   metrics:
     # This is the Prometheus annotation type scraping configuration
@@ -671,6 +684,9 @@ bucket:
   #
   # Add extra selector matchLabels to bucket deployment
   deploymentMatchLabels: {}
+  # Override the default deployment strategy
+  # deploymentStrategy:
+  #   type: RollingUpdate
 
   # Enable podDisruptionBudget for bucket component
   podDisruptionBudget:


### PR DESCRIPTION
## What does this PR change?
It gives users the ability to customize the Thanos deployment strategies via custom `values.yaml` options.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Added option to customize Thanos deployment strategies.


## Links to Issues or ZD tickets this PR addresses or fixes
- Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1328


## How was this PR tested?
First, I used a GKE cluster with Thanos installed where I was receiving the "Multi-Attach error for volume" error. I confirmed the upgrade could not process and checked the status of the deployment strategies with the following command:

```cmd
❯ kubectl get deploy -l="app.kubernetes.io/name=thanos" -ojsonpath='{.items[*].spec.strategy.type}'
RollingUpdate RollingUpdate RollingUpdate RollingUpdate RollingUpdate
```

I then upgraded the cluster with the values:

```yaml
thanos:
  store:
    deploymentStrategy: 
      type: Recreate
  query:
    deploymentStrategy: 
      type: Recreate
  query-frontend:
    deploymentStrategy: 
      type: Recreate
  compact:
    deploymentStrategy: 
      type: Recreate
  bucket:
    deploymentStrategy: 
      type: Recreate
```

I tested the same command before to confirm the deployment strategy, and I confirmed that the upgrade was now working.

```cmd
❯ kubectl get deploy -l="app.kubernetes.io/name=thanos" -ojsonpath='{.items[*].spec.strategy.type}'
Recreate Recreate Recreate Recreate Recreate
```

## Have you made an update to documentation?
Added value description in `charts/thanos/values.yaml`
