### PR TITLE
Fix thanos deployment strategy values key

### DIFF
--- a/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: bucket
 {{ with .Values.bucket.deploymentMatchLabels }}{{ toYaml . | indent 6 }}{{ end }}
-{{ with .Values.store.deploymentStrategy }}
+{{ with .Values.bucket.deploymentStrategy }}
   strategy: {{ toYaml . | nindent 4 }}
 {{ end }}
   template:

--- a/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: compact
 {{ with .Values.compact.deploymentMatchLabels }}{{ toYaml . | indent 6 }}{{ end }}
-{{ with .Values.store.deploymentStrategy }}
+{{ with .Values.compact.deploymentStrategy }}
   strategy: {{ toYaml . | nindent 4 }}
 {{ end }}
   template:

--- a/cost-analyzer/charts/thanos/templates/query-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: query
 {{ with .Values.query.deploymentMatchLabels }}{{ toYaml . | indent 6 }}{{ end }}
-{{ with .Values.store.deploymentStrategy }}
+{{ with .Values.query.deploymentStrategy }}
   strategy: {{ toYaml . | nindent 4 }}
 {{ end }}
   template:

--- a/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: query-frontend
 {{ with .Values.queryFrontend.deploymentMatchLabels }}{{ toYaml . | indent 6 }}{{ end }}
-{{ with .Values.store.deploymentStrategy }}
+{{ with .Values.queryFrontend.deploymentStrategy }}
   strategy: {{ toYaml . | nindent 4 }}
 {{ end }}
   template:


### PR DESCRIPTION
## What does this PR change?
It fixes the problem where a user can only customize the Thanos deployment strategies with the `.Values.thanos.store.deploymentStrategy` value.
 
_Originally posted by @dwbrown2 in https://github.com/kubecost/cost-analyzer-helm-chart/pull/1331#discussion_r836985042_


## How was this PR tested?
Because the overall functionality of upgrading the strategy is already known to work, I focussed on verifying that I could specify each service with different values. I then confirmed that the deployment objects created had matching fields. 
```
❯ helm upgrade -n kubecost kubecost ~/gh/kubecost/cost-analyzer-helm-chart/cost-analyzer -f values.yaml -f values-thanos.yaml -f values-test1.yaml
W0329 12:27:58.336011    3489 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:27:58.390053    3489 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:27:58.449311    3489 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:27:58.504967    3489 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:27:58.544220    3489 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:27:58.584281    3489 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Release "kubecost" has been upgraded. Happy Helming!
NAME: kubecost
LAST DEPLOYED: Tue Mar 29 12:27:56 2022
NAMESPACE: kubecost
STATUS: deployed
REVISION: 126
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed. When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090

Next, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install

❯ cat values-test1.yaml
thanos:
  bucket:
    deploymentStrategy:
      type: RollingUpdate
  compact:
    deploymentStrategy:
      type: Recreate
  query:
    deploymentStrategy:
      type: Recreate
  queryFrontend:
    deploymentStrategy:
      type: RollingUpdate
  store:
    deploymentStrategy:
      type: Recreate

❯ kubectl get deploy -l="app.kubernetes.io/name=thanos" -ojsonpath='{range .items[*]}{@.metadata.name}{": "}{@.spec.strategy.type}{"\n"}'
kubecost-thanos-bucket: RollingUpdate
kubecost-thanos-compact: Recreate
kubecost-thanos-query: Recreate
kubecost-thanos-query-frontend: RollingUpdate
kubecost-thanos-store: Recreate
```
```
❯ helm upgrade -n kubecost kubecost ~/gh/kubecost/cost-analyzer-helm-chart/cost-analyzer -f values.yaml -f values-thanos.yaml -f values-test2.yaml
W0329 12:28:52.290428    3521 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:28:52.342803    3521 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:28:52.403944    3521 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:28:52.464716    3521 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:28:52.502029    3521 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0329 12:28:52.564507    3521 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Release "kubecost" has been upgraded. Happy Helming!
NAME: kubecost
LAST DEPLOYED: Tue Mar 29 12:28:50 2022
NAMESPACE: kubecost
STATUS: deployed
REVISION: 127
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed. When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090

Next, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install

❯ cat values-test2.yaml
thanos:
  bucket:
    deploymentStrategy:
      type: Recreate
  compact:
    deploymentStrategy:
      type: RollingUpdate
  query:
    deploymentStrategy:
      type: RollingUpdate
  queryFrontend:
    deploymentStrategy:
      type: Recreate
  store:
    deploymentStrategy:
      type: RollingUpdate

❯ kubectl get deploy -l="app.kubernetes.io/name=thanos" -ojsonpath='{range .items[*]}{@.metadata.name}{": "}{@.spec.strategy.type}{"\n"}'
kubecost-thanos-bucket: Recreate
kubecost-thanos-compact: RollingUpdate
kubecost-thanos-query: RollingUpdate
kubecost-thanos-query-frontend: Recreate
kubecost-thanos-store: RollingUpdate
```