### PR TITLE
Set Cloud Usage to true, remove cloud assets

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -522,9 +522,7 @@ spec:
               value: {{ (quote .Values.kubecostModel.etlToDisk) | default (quote true) }}
             {{- end }}
             - name : ETL_CLOUD_USAGE_ENABLED
-              value: {{ (quote .Values.kubecostModel.etlCloudUsage) | default (quote false) }}
-            - name : ETL_CLOUD_ASSETS_ENABLED
-              value: {{ (quote .Values.kubecostModel.etlCloudAssets) | default (quote true) }}
+              value: {{ (quote .Values.kubecostModel.etlCloudUsage) | default (quote true) }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}
             {{- if .Values.persistentVolume.dbPVEnabled }}


### PR DESCRIPTION
## What does this PR change?
Defaults Cloud Usage to true and removes cloud assets flag. Cloud Assets flag is no longer connected to anything so it is okay to be removed. Cloud Usage replaces any functionality that Cloud Assets implemented so it should be set to true.


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/690
- https://github.com/kubecost/cost-model/pull/1104


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users should not see the impact of this PR. However users that had Cloud Assets disabled will want to disable Cloud Usage in future helm rebuilds


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?

https://github.com/kubecost/docs/pull/207