### PR TITLE
disable cloud usage if cloud assets was disabled

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -530,7 +530,11 @@ spec:
               value: {{ (quote .Values.kubecostModel.etlToDisk) | default (quote true) }}
             {{- end }}
             - name : ETL_CLOUD_USAGE_ENABLED
+            {{- if eq .Values.kubecostModel.etlCloudAsset false }}
+              value: "false"
+            {{- else }}
               value: {{ (quote .Values.kubecostModel.etlCloudUsage) | default (quote true) }}
+            {{- end }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}
             {{- if .Values.persistentVolume.dbPVEnabled }}


### PR DESCRIPTION
## What does this PR change?
This PR makes it so that users who had cloudAssets disabled will seamlessly continue to have cloud usage disabled.


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users should notice no change


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Tested with all variations of values for `.Values.kubecostModel.etlCloudAsset` and `.Values.kubecostModel.etlCloudUsage`. If either are disabled Cloud Usage was disabled.
![Screen Shot 2022-03-29 at 12 42 54 PM](https://user-images.githubusercontent.com/12225425/160698034-6fca0c01-e7e4-4f46-890c-4b7b4ac41adb.png)


## Have you made an update to documentation?

