### PR TITLE
remove deprecated server port

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -27,9 +27,6 @@ spec:
   type: ClusterIP
 {{- end }}
   ports:
-    - name: tcp-server
-      port: 9001
-      targetPort: 9001
     - name: tcp-model
       port: 9003
       targetPort: 9003


### PR DESCRIPTION
## What does this PR change?
This PR removes the [deprecated](https://github.com/kubecost/cost-analyzer-helm-chart/pull/1330) 9001 port used for the cost-analyzer-server from the service template. This port will cause service failures on EKS because when you create a service with the type LoadBalancer, it appears to make a health check for `.spec.ports[0]`. Because this port returned an empty response, the LoadBalancer would remain stuck in an `OutOfService` state.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixed bug where cost-analyzer-service health checks could fail


## How was this PR tested?
I ran an upgrade against a cluster in EKS to verify that this would allow the LoadBalancer to enter an `InService` state and upgraded a cluster in GKE to confirm that this wouldn't cause issues in another environment.

## Have you made an update to documentation?
https://github.com/kubecost/docs/pull/212