### PR TITLE
Add maxPrometheusQueryDurationMinutes setting

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -543,8 +543,8 @@ spec:
             {{- end }}
             - name: ETL_RESOLUTION_SECONDS
               value: {{ (quote .Values.kubecostModel.etlResolutionSeconds) | default (quote 300) }}
-            - name: ETL_MAX_BATCH_HOURS
-              value: {{ (quote .Values.kubecostModel.etlMaxBatchHours) | default (quote 6) }}
+            - name: ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES
+              value: {{ (quote .Values.kubecostModel.maxPrometheusQueryDurationMinutes) | default (quote 1440) }}
             - name: ETL_DAILY_STORE_DURATION_DAYS
               value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 91) }}
             - name: ETL_HOURLY_STORE_DURATION_HOURS


### PR DESCRIPTION
## What does this PR change?
* Adds `maxPrometheusQueryDurationMinutes` setting for limiting Prometheus query durations

## Does this PR rely on any other PRs?
- https://github.com/kubecost/cost-model/pull/1135
- https://github.com/kubecost/kubecost-cost-model/pull/707

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- See https://github.com/kubecost/cost-model/pull/1135

## How was this PR tested?
- See https://github.com/kubecost/cost-model/pull/1135

## Have you made an update to documentation?
- See https://github.com/kubecost/cost-model/pull/1135
