### PR TITLE
Fix issue in the helm chart to run multiple kubecost

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-cluster-role-binding-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-binding-template.yaml
@@ -3,13 +3,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "cost-analyzer.serviceAccountName" . }}
+  name: {{ .Release.Name }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "cost-analyzer.serviceAccountName" . }}
+  name: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "cost-analyzer.serviceAccountName" . }}
@@ -20,13 +20,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "cost-analyzer.serviceAccountName" . }}
+  name: {{ .Release.Name }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "cost-analyzer.serviceAccountName" . }}
+  name: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "cost-analyzer.serviceAccountName" . }}

--- a/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "cost-analyzer.serviceAccountName" . }}
+  name: {{ .Release.Name }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 rules:
@@ -20,7 +20,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "cost-analyzer.serviceAccountName" . }}
+  name: {{ .Release.Name }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 rules:

--- a/cost-analyzer/templates/network-costs-psp.template.yaml
+++ b/cost-analyzer/templates/network-costs-psp.template.yaml
@@ -5,7 +5,7 @@
 apiVersion: {{ include "cost-analyzer.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
-    name: kubecost-network-costs
+    name: {{ template "cost-analyzer.fullname" . }}-network-costs
     labels:
       {{ include "cost-analyzer.commonLabels" . | nindent 6 }}
 spec:

--- a/cost-analyzer/templates/network-costs-role.template.yaml
+++ b/cost-analyzer/templates/network-costs-role.template.yaml
@@ -5,7 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kubecost-network-costs
+  name: {{ template "cost-analyzer.fullname" . }}-network-costs
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
   annotations:
@@ -17,7 +17,7 @@ rules:
   resources: ['podsecuritypolicies']
   verbs: ['use']
   resourceNames:
-  - kubecost-network-costs
+  - {{ template "cost-analyzer.fullname" . }}-network-costs
 {{- end }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/network-costs-rolebinding.template.yaml
+++ b/cost-analyzer/templates/network-costs-rolebinding.template.yaml
@@ -5,13 +5,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-    name: kubecost-network-costs
+    name: {{ template "cost-analyzer.fullname" . }}-network-costs
     labels:
       {{ include "cost-analyzer.commonLabels" . | nindent 6 }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
-    name: kubecost-network-costs
+    name: {{ template "cost-analyzer.fullname" . }}-network-costs
 subjects:
 - kind: ServiceAccount
   name: {{ template "cost-analyzer.serviceAccountName" . }}


### PR DESCRIPTION
## What does this PR change?

We want to run multiple kubecost on the same K8S/EKS to test new Versions.
This was not possible with the existing helm chart.

I changed the following:

- Fixed some helm chart templates to run multiple kubecost for Testing
  - Release Name instead of ServiceAccount Name for Role, ClusterRole and Bindings.
  - The Name of the Kubecost-network PSP was changed to use variables like it is in the Kubecost PSP

It's not really practical to change for any new Kubecost on the same k8s the serviceAccount Name. Instead, I changed it to use the Chart.Name. It's also possible to use the "fullname", but this caused changes for existing deployments. 

## Does this PR rely on any other PRs?

- No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- No Breacking changes for existing Installations


## Links to Issues or ZD tickets this PR addresses or fixes

- [#1108](https://github.com/kubecost/cost-model/issues/1108)


## How was this PR tested?
- It was tested on several EKS with new and existing kubecost deployments.

## Have you made an update to documentation?
- No
