### PR TITLE
Fix duplicate app labels and expose Grafana PSP config

### DIFF
--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{ include "kubecost.chartLabels" . | nindent 4 }}
     app: {{ template "kubecost.kubeMetricsName" . }}
 {{- with .Values.kubecostMetrics.exporter.labels }}
 {{ toYaml . | indent 4 }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -653,6 +653,9 @@ initChownData:
 grafana:
   # namespace_datasources: kubecost # override the default namespace here
   # namespace_dashboards: kubecost # override the default namespace here
+  rbac:
+    # Manage the Grafana Pod Security Policy
+    pspEnabled: true
   sidecar:
     dashboards:
       enabled: true


### PR DESCRIPTION
## What does this PR change?

### Duplicate app label
The Kubecost metric deployment template uses the `cost-analyzer.commonLabels` template that includes the label `app: cost-analyzer`. However, in the kubecost-metric-deployment-template we also specify:
```
app: {{ template "kubecost.kubeMetricsName" . }}
```

Subsequently leaving us with two app labels. This fix uses the `kubecost.chartLabels` template instead which is the exact same thing without the `app` label.

### Grafana PSP Config
Exposes the PSP configuration for the Grafana Helm chart. It's nice to have this visible if you're trying to get rid of those pesky deprecation warnings.


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
```
fix: Fixed duplicate `app` label on Kubecost Metric Exporter or Agent deployments.
docs: Exposed Grafana Pod Security Policy (PSP) configuration in chart config
```

## Links to Issues or ZD tickets this PR addresses or fixes
N/A


## How was this PR tested?
Locally

## Have you made an update to documentation?
This isn't necessary.
