### PR TITLE
Grafana Enabled Env Var

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -336,6 +336,18 @@ spec:
             {{- end }}
             {{- end }}
           env:
+            {{- if .Values.global.grafana}}
+            {{- if .Values.global.grafana.enabled }}
+            - name: GRAFANA_ENABLED
+              value: "true"
+            {{- else }}
+            - name: GRAFANA_ENABLED
+              value: "false"
+            {{- end }}
+            {{- else }}
+            - name: GRAFANA_ENABLED
+              value: "false"
+            {{- end }}
             {{- if .Values.kubecostModel.extraEnv -}}
             {{ toYaml .Values.kubecostModel.extraEnv | nindent 12 }}
             {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -336,18 +336,10 @@ spec:
             {{- end }}
             {{- end }}
           env:
-            {{- if .Values.global.grafana}}
-            {{- if .Values.global.grafana.enabled }}
+            {{- if .Values.global.grafana }}
             - name: GRAFANA_ENABLED
-              value: "true"
-            {{- else }}
-            - name: GRAFANA_ENABLED
-              value: "false"
-            {{- end }}
-            {{- else }}
-            - name: GRAFANA_ENABLED
-              value: "false"
-            {{- end }}
+              value: {{ (quote .Values.global.grafana.enabled) | default (quote false) }}
+            {{- end}}
             {{- if .Values.kubecostModel.extraEnv -}}
             {{ toYaml .Values.kubecostModel.extraEnv | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## What does this PR change?
Adds an env var to the cost model indicating whether Grafana is enabled.


## Does this PR rely on any other PRs?
* https://github.com/kubecost/cost-analyzer-frontend/pull/598
* https://github.com/kubecost/kubecost-cost-model/pull/727
* https://github.com/kubecost/docs/pull/220/files


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
It does not.


## Links to Issues or ZD tickets this PR addresses or fixes

N/A


## How was this PR tested?

By Helm upgrading with the local chart, setting `globals.grafana.enabled=false`, and also observing that `grafana.enabled` continues to default to `true`.

## Have you made an update to documentation?
I have not.
