### PR TITLE
Added in Customer Google Tag to values and environment variables

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -673,6 +673,10 @@ spec:
             - name: PROM_CLUSTER_ID_LABEL
               value: {{ .Values.kubecostModel.promClusterIDLabel }}
             {{- end }}
+            {{- if .Values.kubecostFrontend.customerGoogleTag }}
+            - name: CUSTOMER_GOOGLE_TAG
+              value: {{ .Values.kubecostFrontend.customerGoogleTag }}
+            {{- end }}
             - name: RELEASE_NAME
               value: {{ .Release.Name }}
             - name: KUBECOST_NAMESPACE

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -198,6 +198,8 @@ kubecostFrontend:
     #limits:
     #  cpu: "100m"
     #  memory: "256Mi"
+#  customerGoogleTag allows you to embed your Google Global Site Tag to track usage of Kubecost.
+#  customerGoogleTag: G-XXXXXXXXX
 #  api:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:


### PR DESCRIPTION
## What does this PR change?
This add the GoogleCustomerTag value to the Values file in the helm chart under kubecostFrontend, and adds the GoogleCustomerTag as an environment variable to be returned by /getConfigs


## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
This allows users to use their own Google Global Tag to track the utilization of their Kubecost frontend! 


## Links to Issues or ZD tickets this PR addresses or fixes
- #1358 


## How was this PR tested?
Manually by deploying to my GKE cluster.

## Have you made an update to documentation?
No - Will do prior to closing after we find out if I did this right. 
