### PR TITLE
Fixed Google Analytics Tag Name

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -673,9 +673,9 @@ spec:
             - name: PROM_CLUSTER_ID_LABEL
               value: {{ .Values.kubecostModel.promClusterIDLabel }}
             {{- end }}
-            {{- if .Values.kubecostFrontend.customerGoogleTag }}
-            - name: CUSTOMER_GOOGLE_TAG
-              value: {{ .Values.kubecostFrontend.customerGoogleTag }}
+            {{- if .Values.reporting.googleAnalyticsTag }}
+            - name: GOOGLE_ANALYTICS_TAG
+              value: {{ .Values.reporting.googleAnalyticsTag }}
             {{- end }}
             - name: RELEASE_NAME
               value: {{ .Release.Name }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -198,8 +198,6 @@ kubecostFrontend:
     #limits:
     #  cpu: "100m"
     #  memory: "256Mi"
-#  customerGoogleTag allows you to embed your Google Global Site Tag to track usage of Kubecost.
-#  customerGoogleTag: G-XXXXXXXXX
 #  api:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:
@@ -614,9 +612,12 @@ reporting:
   logCollection: true
   # Basic frontend analytics
   productAnalytics: true
+
   # Report Javascript errors
   errorReporting: true
   valuesReporting: true
+  # googleAnalyticsTag allows you to embed your Google Global Site Tag to track usage of Kubecost.
+  # googleAnalyticsTag: G-XXXXXXXXX
 
 serviceMonitor:
   enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -617,6 +617,7 @@ reporting:
   errorReporting: true
   valuesReporting: true
   # googleAnalyticsTag allows you to embed your Google Global Site Tag to track usage of Kubecost.
+  # googleAnalyticsTag is only included in our Enterprise offering.
   # googleAnalyticsTag: G-XXXXXXXXX
 
 serviceMonitor:


### PR DESCRIPTION
## What does this PR change?
Changes the Google Analytics Tag environment variable name


## Does this PR rely on any other PRs?
- https://github.com/kubecost/kubecost-cost-model/pull/729


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Changes the name Users use to attach their Google Analytics Tag


## Links to Issues or ZD tickets this PR addresses or fixes
None

## How was this PR tested?
Manually

## Have you made an update to documentation?
No
