### PR TITLE
FIX prometheus ingress

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -671,7 +671,7 @@ server:
     #   - domain.com/prometheus
 
     ## PathType determines the interpretation of the Path matching
-    pathType: "Exact"
+    pathType: "Prefix"
 
     ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
     extraPaths: []


### PR DESCRIPTION
## What does this PR change?

this PR fixed issue with ingress

when ingress rule use `pathType: "Exact"` we got 
`default backend - 404`
during Prometheus health check 
http://prod-spok-kubecost-prometheus.domain.net/-/healthy

after we change this to `pathType: "Prefix"` we got 
`Prometheus is Healthy.`
during Prometheus health check 
http://prod-spok-kubecost-prometheus.domain.net/-/healthy

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?

With helm update for running cost-analyzer helm release.

## Have you made an update to documentation?

Not needed

