### PR TITLE
Don't use eq to default a possibly-nil value

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -530,11 +530,7 @@ spec:
               value: {{ (quote .Values.kubecostModel.etlToDisk) | default (quote true) }}
             {{- end }}
             - name : ETL_CLOUD_USAGE_ENABLED
-            {{- if eq .Values.kubecostModel.etlCloudAsset false }}
-              value: "false"
-            {{- else }}
-              value: {{ (quote .Values.kubecostModel.etlCloudUsage) | default (quote true) }}
-            {{- end }}
+              value: {{ (quote .Values.kubecostModel.etlCloudAsset) | default (quote false) }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}
             {{- if .Values.persistentVolume.dbPVEnabled }}


### PR DESCRIPTION
## What does this PR change?

`kubecostModel.etlCloudAsset` is nil by default. Before this change,
running `helm template` would give the following error:

`
Error: template: cost-analyzer/templates/cost-analyzer-deployment-template.yaml:533:19: executing "cost-analyzer/templates/cost-analyzer-deployment-template.yaml" at <eq .Values.kubecostModel.etlCloudAsset false>: error calling eq: incompatible types for comparison
`

After the change, the error is gone.

cc @Sean-Holcomb does this maintain the default behavior you expect for this env var?

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A (I believe the current release doesn't have this issue, I assume this regressed in between the release and now.)

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

```
→ helm template ./cost-analyzer | grep -A 1 -i ETL_CLOUD
            - name : ETL_CLOUD_USAGE_ENABLED
              value: "false"
```

```
→ helm template ./cost-analyzer --set kubecostModel.etlCloudAsset=true | grep -A 1 -i ETL_CLOUD
            - name : ETL_CLOUD_USAGE_ENABLED
              value: "true"
```

## Have you made an update to documentation?

N/A