### PR TITLE
Make cluster controller service key secret optional

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -224,6 +224,11 @@ spec:
       - name: cluster-controller-keys
         secret:
           secretName: {{ .Values.clusterController.secretName | default "cluster-controller-service-key" }}
+          # The secret is optional because not all of cluster controller's
+          # functionality requires this secret. Cluster controller will
+          # partially or fully initialize based on the presence of these keys
+          # and their validity.
+          optional: true
 ---
 apiVersion: v1
 kind: Service

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -604,7 +604,7 @@ kubecostDeployment:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.0.5
+  image: gcr.io/kubecost1/cluster-controller:v0.0.6
   imagePullPolicy: Always
 #  fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
 


### PR DESCRIPTION
## What does this PR change?

This smooths the adoption path for cluster controller features, like
1-click request sizing, that don't require service keys. Cluster
controller will be updated to gracefully handle situations where these
keys don't exist.


## Does this PR rely on any other PRs?

- N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Cluster controller will not require service account key to be set up in a secret for 1-click request sizing to be functional.

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

See https://github.com/kubecost/cluster-controller/pull/6

## Have you made an update to documentation?

Included in https://github.com/kubecost/docs/pull/201