### PR TITLE
Reverse patch fixes from v1.92 into develop

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -530,10 +530,10 @@ spec:
               value: {{ (quote .Values.kubecostModel.etlToDisk) | default (quote true) }}
             {{- end }}
             - name : ETL_CLOUD_USAGE_ENABLED
-            {{- if eq .Values.kubecostModel.etlCloudAsset false }}
-              value: "false"
-            {{- else }}
+            {{- if kindIs "bool" .Values.kubecostModel.etlCloudUsage }}
               value: {{ (quote .Values.kubecostModel.etlCloudUsage) | default (quote true) }}
+            {{- else if kindIs "bool" .Values.kubecostModel.etlCloudAsset }}
+              value: {{ (quote .Values.kubecostModel.etlCloudAsset) | default (quote true) }}
             {{- end }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -734,4 +734,29 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 200
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }}
+      {{- if .Values.priority }}
+      {{- if .Values.priority.enabled }}
+      {{- if gt (len .Values.priority.name) 0 }}
+      priorityClassName: {{ .Values.priority.name }}
+      {{- else }}
+      priorityClassName: {{ template "cost-analyzer.fullname" . }}-priority
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?

Reverse patches changes that currently only exist in the `v1.92` branch. The PRs that generated the original changes are:
- #1361 
- #1338

Unfortunately, I couldn't follow a proper `git cherry-pick` process here because the Git history of #1361 was a little tricky. This PR was generated manually, I'd really appreciate a careful eye comparing this change to the PRs its based on.

We don't have to do this for #1339 / #1346 because that change followed the standard release process.

For the future, we can avoid this by following the release process outlined in https://github.com/kubecost/release-scripts#if-you-need-to-patch-the-release-branch -- making patch fixes with a clean Git history first to `develop` and then cherry picking/opening a second PR to the current release branch.

Supercedes and closes https://github.com/kubecost/cost-analyzer-helm-chart/pull/1369.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A, should be captured in impact notes of base PRs.

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

Should be covered by the base PRs.

## Have you made an update to documentation?

N/A