### PR TITLE
Allow more Prometheus flexibility

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -1,13 +1,18 @@
 {{- if .Values.networkCosts }}
 {{- if .Values.networkCosts.enabled }}
-{{- if .Values.networkCosts.prometheusScrape }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
-{{- if .Values.networkCosts.prometheusScrapeAnnotations }}
+{{- if (or .Values.networkCosts.service.annotations .Values.networkCosts.prometheusScrape) }}
   annotations:
-{{ toYaml .Values.networkCosts.prometheusScrapeAnnotations | indent 4 }}
+{{- if .Values.networkCosts.service.annotations }}
+{{ toYaml .Values.networkCosts.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.networkCosts.prometheusScrape }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
+{{- end }}
 {{- end }}
   labels:
     {{ unset (include "cost-analyzer.commonLabels" . | fromYaml) "app" | toYaml | nindent 4 }}
@@ -22,6 +27,5 @@ spec:
   selector:
     app: {{ template "cost-analyzer.networkCostsName" . }}
   type: ClusterIP
-{{- end }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -5,7 +5,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
-
 {{- if .Values.networkCosts.prometheusScrapeAnnotations }}
   annotations:
 {{ toYaml .Values.networkCosts.prometheusScrapeAnnotations | indent 4 }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -5,9 +5,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
+
+{{- if .Values.networkCosts.prometheusScrapeAnnotations }}
   annotations:
-    prometheus.io/scrape: "{{ .Values.networkCosts.prometheusScrape }}"
-    prometheus.io/port: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
+{{ toYaml .Values.networkCosts.prometheusScrapeAnnotations | indent 4 }}
+{{- end }}
   labels:
     {{ unset (include "cost-analyzer.commonLabels" . | fromYaml) "app" | toYaml | nindent 4 }}
     app: {{ template "cost-analyzer.networkCostsName" . }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -136,6 +136,10 @@ spec:
           imagePullPolicy: Always
         {{- end }}
           name: {{ template "kubecost.kubeMetricsName" . }}
+          ports:
+            - name: tcp-metrics
+              protocol: TCP
+              containerPort: {{ .Values.kubecostMetrics.exporter.port | default 9005 }}
           resources:
 {{ toYaml .Values.kubecostMetrics.exporter.resources | indent 12 }}
           readinessProbe:
@@ -170,7 +174,7 @@ spec:
               mountPath: /var/secrets
             {{- end }}
             {{- end }}
-          args: 
+          args:
             - agent
             {{- if .Values.kubecostMetrics.exporter.extraArgs }}
             {{ toYaml .Values.kubecostMetrics.exporter.extraArgs | nindent 12 }}

--- a/cost-analyzer/templates/kubecost-metrics-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-template.yaml
@@ -13,7 +13,7 @@ metadata:
 {{ toYaml .Values.kubecostMetrics.exporter.service.annotations | indent 4 }}
 {{- end }}
 {{- if .Values.kubecostMetrics.exporter.prometheusScrape }}
-    prometheus.io/scrape: "{{ .Values.kubecostMetrics.exporter.prometheusScrape }}"
+    prometheus.io/scrape: "true"
     prometheus.io/port: {{ quote .Values.kubecostMetrics.exporter.port | default (quote 9005) }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-metrics-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-template.yaml
@@ -6,10 +6,11 @@ kind: Service
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{- if .Values.kubecostMetrics.exporter.service.annotations }}
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: {{ (quote .Values.kubecostMetrics.exporter.port) | default (quote 9005) }}
+{{ toYaml .Values.kubecostMetrics.exporter.service.annotations | indent 4 }}
+{{- end }}
 spec:
   ports:
   - name: tcp-metrics

--- a/cost-analyzer/templates/kubecost-metrics-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-template.yaml
@@ -1,18 +1,19 @@
 {{- if .Values.kubecostMetrics }}
 {{- if .Values.kubecostMetrics.exporter }}
 {{- if .Values.kubecostMetrics.exporter.enabled }}
+{{- $prometheusScrape := ternary .Values.kubecostMetrics.exporter.prometheusScrape true (kindIs "bool" .Values.kubecostMetrics.exporter.prometheusScrape) }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
   labels:
 {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-{{- if (or .Values.kubecostMetrics.exporter.service.annotations .Values.kubecostMetrics.exporter.prometheusScrape) }}
+{{- if (or .Values.kubecostMetrics.exporter.service.annotations $prometheusScrape) }}
   annotations:
 {{- if .Values.kubecostMetrics.exporter.service.annotations }}
 {{ toYaml .Values.kubecostMetrics.exporter.service.annotations | indent 4 }}
 {{- end }}
-{{- if .Values.kubecostMetrics.exporter.prometheusScrape }}
+{{- if $prometheusScrape }}
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ (quote .Values.kubecostMetrics.exporter.port) | default (quote 9005) }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-metrics-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-template.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
 {{- if .Values.kubecostMetrics.exporter.prometheusScrape }}
     prometheus.io/scrape: "true"
-    prometheus.io/port: {{ quote .Values.kubecostMetrics.exporter.port | default (quote 9005) }}
+    prometheus.io/port: {{ (quote .Values.kubecostMetrics.exporter.port) | default (quote 9005) }}
 {{- end }}
 {{- end }}
 spec:

--- a/cost-analyzer/templates/kubecost-metrics-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-template.yaml
@@ -7,9 +7,15 @@ metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
   labels:
 {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-{{- if .Values.kubecostMetrics.exporter.service.annotations }}
+{{- if (or .Values.kubecostMetrics.exporter.service.annotations .Values.kubecostMetrics.exporter.prometheusScrape) }}
   annotations:
+{{- if .Values.kubecostMetrics.exporter.service.annotations }}
 {{ toYaml .Values.kubecostMetrics.exporter.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.kubecostMetrics.exporter.prometheusScrape }}
+    prometheus.io/scrape: "{{ .Values.kubecostMetrics.exporter.prometheusScrape }}"
+    prometheus.io/port: {{ quote .Values.kubecostMetrics.exporter.port | default (quote 9005) }}
+{{- end }}
 {{- end }}
 spec:
   ports:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -234,6 +234,10 @@ kubecostMetrics:
     #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
     affinity: {}
 
+    service:
+      annotations:
+        prometheus.io/scrape: "true"
+
     # Service Monitor for Kubecost Metrics
     serviceMonitor:
       enabled: false
@@ -244,7 +248,6 @@ kubecostMetrics:
     priorityClassName: []
     additionalLabels: {}
     nodeSelector: {}
-    annotations: {}
     extraArgs: []
 
 kubecostModel:
@@ -504,6 +507,9 @@ networkCosts:
   # NOTE: Setting this option to true and leaving the above extraScrapeConfig "job_name: kubecost-networking" configured will cause the
   # NOTE: pods to be scraped twice.
   prometheusScrape: false
+  # Override Prometheus scrape annotations for custom Prometheus setups. Advanced.
+  prometheusScrapeAnnotations:
+    prometheus.io/scrape: "true"
   # Traffic Logging will enable logging the top 5 destinations for each source
   # every 30 minutes.
   trafficLogging: true

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -220,6 +220,9 @@ kubecostMetrics:
   exporter:
     enabled: false
     port: 9005
+    # Adds the default Prometheus scrape annotations to the metrics exporter service.
+    # Set to false and use service.annotations (below) to set custom scrape annotations.
+    prometheusScrape: true
     resources: {}
       # requests:
       #  cpu: "200m"
@@ -235,8 +238,7 @@ kubecostMetrics:
     affinity: {}
 
     service:
-      annotations:
-        prometheus.io/scrape: "true"
+      annotations: {}
 
     # Service Monitor for Kubecost Metrics
     serviceMonitor:
@@ -502,14 +504,11 @@ networkCosts:
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate
-  # For existing Prometheus Installs, create a Service which generates Endpoints for each of the network-costs pods.
-  # This Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.
+  # For existing Prometheus Installs, annotates the Service which generates Endpoints for each of the network-costs pods.
+  # The Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.
   # NOTE: Setting this option to true and leaving the above extraScrapeConfig "job_name: kubecost-networking" configured will cause the
   # NOTE: pods to be scraped twice.
   prometheusScrape: false
-  # Override Prometheus scrape annotations for custom Prometheus setups. Advanced.
-  prometheusScrapeAnnotations:
-    prometheus.io/scrape: "true"
   # Traffic Logging will enable logging the top 5 destinations for each source
   # every 30 minutes.
   trafficLogging: true
@@ -587,6 +586,9 @@ networkCosts:
   #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
   affinity: {}
+
+  service:
+    annotations: {}
 
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
## What does this PR change?
* Add setting `prometheusScrape` for Metrics Exporter (default true) to allow turning off the default set of Prometheus scrape annotations.
* Allow setting custom annotations for Metrics Exporter service.
* Allow setting custom annotations for Network Costs service.
* Create the Network Costs service always, but only add Prometheus annotations if `prometheusScrape` is set to true.
* Remove `kubecostMetrics.exporter.annotations` (not used anywhere).
* Adds `ports` declaration in Metrics Exporter deployment.

## Does this PR rely on any other PRs?
N/A 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
The Network Costs server will always be created but without Prometheus scrape annotations (by default). There should be no change in behaviour.

Everything else should behave as before.

## Links to Issues or ZD tickets this PR addresses or fixes
fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1395

## How was this PR tested?
- `helm template cost-analyzer --values ...`
- `kubectl apply --dry-run=server -f ...`
- `diff --color ... ...`

## Have you made an update to documentation?
No, `README.md` does not contain a complete list of values anyway - infarct it seems miles off.

## Notes
This is a bit of an awkward one because normally Helm charts do not include Prometheus scrape annotations by default, to allow people to specify their own. However the Kubecost situation is different since it ships with Prometheus by default and is trying to be as light touch as possible (I guess).

To accommodate this I have set defaults that match the current behaviour, but advanced users who want to integrate their own monitoring CAN override the defaults should they wish. Example:

```
###############################################################################

  kubecostMetrics:
    exporter:
      enabled: true
      prometheusScrape: false # https://github.com/kubecost/cost-analyzer-helm-chart/pull/1385
      service: # https://github.com/kubecost/cost-analyzer-helm-chart/pull/1385
        annotations:
          prometheus.io/port: "9005"
          prometheus.io/service-scape-slow: "true"
          prometheus.io/kube-state-metrics: "true"

###############################################################################
```
