### PR TITLE
Add athena workgroup to config

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -122,6 +122,9 @@ data:
   {{- if .Values.kubecostProductConfigs.athenaTable }}
     athenaTable: "{{ .Values.kubecostProductConfigs.athenaTable }}"
   {{- end -}}
+  {{- if .Values.kubecostProductConfigs.athenaWorkgroup }}
+    athenaWorkgroup: "{{ .Values.kubecostProductConfigs.athenaWorkgroup }}"
+  {{- end -}}
   {{- if .Values.kubecostProductConfigs.masterPayerARN}}
     masterPayerARN: "{{ .Values.kubecostProductConfigs.masterPayerARN }}"
   {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -729,6 +729,7 @@ awsstore:
 #  athenaRegion: us-east-1
 #  athenaDatabase: athenacurcfn_athena_test1
 #  athenaTable: "athena_test1"
+#  athenaWorkgroup: "primary" # The default workgroup in AWS is 'primary'
 #  masterPayerARN: ""
 #  projectID: "123456789"  # Also known as AccountID on AWS -- the current account/project that this instance of Kubecost is deployed on.
 #  gcpSecretName: gcp-secret # Name of a secret representing the gcp service key


### PR DESCRIPTION
## What does this PR change?
Exposes a new config option to set athena workgroups

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
This allows setting the workgroup if required but continues to use the
default of primary if nothing is set.


## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/897
