### PR TITLE
fix cloud usage defaulting

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -535,9 +535,11 @@ spec:
             {{- end }}
             - name : ETL_CLOUD_USAGE_ENABLED
             {{- if kindIs "bool" .Values.kubecostModel.etlCloudUsage }}
-              value: {{ (quote .Values.kubecostModel.etlCloudUsage) | default (quote true) }}
+              value: {{ (quote .Values.kubecostModel.etlCloudUsage) }}
             {{- else if kindIs "bool" .Values.kubecostModel.etlCloudAsset }}
-              value: {{ (quote .Values.kubecostModel.etlCloudAsset) | default (quote true) }}
+              value: {{ (quote .Values.kubecostModel.etlCloudAsset) }}
+            {{- else }}
+              value: "true"
             {{- end }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}


### PR DESCRIPTION
## What does this PR change?
Fixes default value for ETL_CLOUD_USAGE_ENABLED environment variable. Previous defaults failed because they were depended on values.yaml values being of type boolean, ie having a value, which means that the default was never used. I have removed this type of defaulting and replaced it with a base case else clause.


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will see ETL_CLOUD_USAGE_ENABLED=true in their env variables. No product impact.


## Links to Issues or ZD tickets this PR addresses or fixes

- closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1382
- 


## How was this PR tested?
This PR was tested by using the helm chart with none of the relevant values set, and ensuring that a default value was set.
![Screen Shot 2022-04-26 at 12 04 33 PM](https://user-images.githubusercontent.com/12225425/165375070-9a20e6b1-3d74-4abd-b25b-cbe340e87aba.png)


## Have you made an update to documentation?

