### PR TITLE
Remove GOGC tuning from Cost-Model

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -416,10 +416,6 @@ spec:
             - name: REMOTE_WRITE_ENABLED
               value: "true"
             {{- end }}
-            - name: GOGC
-              value: "60"
-            - name: GODEBUG
-              value: "madvdontneed=1"
             {{- if .Values.global.thanos.queryServiceBasicAuthSecretName}}
             - name: MC_BASIC_AUTH_USERNAME
               valueFrom:


### PR DESCRIPTION
## What does this PR change?
* Removes GOGC=60 from cost model as well as legacy go flags for memory release.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Should speed up cost-model performance on lower CPU core nodes.

## How was this PR tested?
* As part of a performance audit


