### PR TITLE
Fix for sleep error when using Grafana Sidecar with Datasources

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -664,6 +664,7 @@ grafana:
     datasources:
       # dataSourceFilename: foo.yml # If you need to change the name of the datasource file
       enabled: false
+      error_throttle_sleep: 0
 #  For grafana to be accessible, add the path to root_url. For example, if you run kubecost at www.foo.com:9090/kubecost
 #  set root_url to "%(protocol)s://%(domain)s:%(http_port)s/kubecost/grafana". No change is necessary here if kubecost runs at a root URL
   grafana.ini:


### PR DESCRIPTION
## What does this PR change?
Sets `error_throttle_sleep` to `0`

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Defaults `error_throttle_sleep` to `0` for users that are enabling the datasources feature of the Grafana Sidecar.

## Links to Issues or ZD tickets this PR addresses or fixes
#1412 

## How was this PR tested?
Against 1.92 in dev cluster

## Have you made an update to documentation?
Not needed
