### PR TITLE
add detail to helm install notes

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -4,16 +4,16 @@
 {{- $servicePort := .Values.service.port | default 9090 -}}
 Kubecost has been successfully installed.
 
-Please allow 5-10 minutes for Kubecost to gather metrics and report accurate health status in the UI and data to appear.
+Please allow 5-10 minutes for Kubecost to gather metrics.
 
 If you have configured cloud-integrations, it can take up to 48 hours for cost reconciliation to occur.
 
-When using Durable storage (Enterprise Edition) please allow up to 4 hours for data to be collected and the UI to be healthy.
+When using Durable storage (Enterprise Edition), please allow up to 4 hours for data to be collected and the UI to be healthy.
 
 When pods are Ready, you can enable port-forwarding with the following command:
 
-    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090
+    kubectl port-forward --namespace {{ .Release.Namespace }} deployment/{{ template "cost-analyzer.fullname" . }} {{ $servicePort }}
 
-Next, navigate to http://localhost:9090 in a web browser.
+Next, navigate to http://localhost:{{ $servicePort }} in a web browser.
 
 Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install

--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -2,10 +2,18 @@
 
 --------------------------------------------------
 {{- $servicePort := .Values.service.port | default 9090 -}}
-Kubecost has been successfully installed. When pods are Ready, you can enable port-forwarding with the following command:
-    
-    kubectl port-forward --namespace {{ .Release.Namespace }} deployment/{{ template "cost-analyzer.fullname" . }} {{ $servicePort }}
-    
-Next, navigate to http://localhost:{{ $servicePort }} in a web browser.
+Kubecost has been successfully installed.
+
+Please allow 5-10 minutes for Kubecost to gather metrics and report accurate health status in the UI and data to appear.
+
+If you have configured cloud-integrations, it can take up to 48 hours for cost reconciliation to occur.
+
+When using Durable storage (Enterprise Edition) please allow up to 4 hours for data to be collected and the UI to be healthy.
+
+When pods are Ready, you can enable port-forwarding with the following command:
+
+    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090
+
+Next, navigate to http://localhost:9090 in a web browser.
 
 Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install


### PR DESCRIPTION
## What does this PR change?

Adds additional detail to helm install notes.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Helm installation now sets expectations for how long an initial deployment of Kubecost will take.

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

local helm chart

## Have you made an update to documentation?

N/A