### PR TITLE
Add editor role to SAML RBAC

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -173,6 +173,11 @@ saml:
         assertionName:  "http://schemas.auth0.com/userType"
         assertionvalues:
           - "readonly"
+      - name: editor
+        enabled: true # if editor is enabled, editors will be allowed to edit reports/alerts scoped to them, and act as readers otherwise. Users will never default to editor.
+        assertionName: "http://schemas.auth0.com/userType"
+        assertionValues:
+          - "editor"
 
 # Adds an httpProxy as an environment variable. systemProxy.enabled must be `true`to have any effect.
 # Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml


### PR DESCRIPTION
## What does this PR change?
Adds the editor role to `values.saml.rbac.groups`. More information on the behavior of this role can be found in the linked KCCM PR.

## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?

