### PR TITLE
Remove duplicate 'RELEASE_NAME' env var

### DIFF
--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -205,8 +205,6 @@ spec:
               value: {{ (quote .Values.kubecostMetrics.emitKsmV1Metrics) | default (quote true) }}
             - name: EMIT_KSM_V1_METRICS_ONLY # ONLY emit KSM v1 metrics that do not exist in KSM 2 by default
               value: {{ (quote .Values.kubecostMetrics.emitKsmV1MetricsOnly) | default (quote false) }}
-            - name: RELEASE_NAME
-              value: {{ .Release.Name }}
             - name: MAX_QUERY_CONCURRENCY
               value: {{ (quote .Values.kubecostModel.maxQueryConcurrency) | default (quote 5) }}
             {{- if .Values.global.prometheus.queryServiceBasicAuthSecretName}}


### PR DESCRIPTION
## What does this PR change?

This removes a duplicate environment variable in the Kubecost metrics deployment.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

The duplicate environment variable causes a crash when parsing the rendered Helm manifests with Jsonnet. Removing the duplicated value fixes this.

## How was this PR tested?

Outputted manifests with `helm template`. Ensured that RELEASE_NAME only appears once after this fix.

## Have you made an update to documentation?

N/A