### PR TITLE
Austin/api extensions upgrade

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -247,6 +247,7 @@ spec:
     app: {{ template "kubecost.clusterControllerName" . }}
 ---
 # TurndownSchedule Custom Resource Definition for persistence
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -294,8 +295,55 @@ spec:
     - td
     - tds
   scope: Cluster
-  
-  
+{{ else }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: turndownschedules.kubecost.k8s.io
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+spec:
+  group: kubecost.k8s.io
+  version: v1alpha1
+  names:
+    kind: TurndownSchedule
+    singular: turndownschedule
+    plural: turndownschedules
+    shortNames:
+    - td
+    - tds
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            start: 
+              type: string
+              format: date-time
+            end:
+              type: string
+              format: date-time
+            repeat: 
+              type: string
+              enum: [none, daily, weekly]
+  additionalPrinterColumns:
+  - name: State
+    type: string
+    description: The state of the turndownschedule 
+    JSONPath: .status.state
+  - name: Next Turndown
+    type: string
+    description: The next turndown date-time
+    JSONPath: .status.nextScaleDownTime
+  - name: Next Turn Up
+    type: string
+    description: The next turn up date-time
+    JSONPath: .status.nextScaleUpTime
+{{ end -}}
   
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -247,7 +247,7 @@ spec:
     app: {{ template "kubecost.clusterControllerName" . }}
 ---
 # TurndownSchedule Custom Resource Definition for persistence
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: turndownschedules.kubecost.k8s.io
@@ -255,7 +255,37 @@ metadata:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   group: kubecost.k8s.io
-  version: v1alpha1
+  versions: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            type: object
+            properties:
+              start: 
+                type: string
+                format: date-time
+              end:
+                type: string
+                format: date-time
+              repeat: 
+                type: string
+                enum: [none, daily, weekly]
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+      - name: State
+        type: string
+        description: The state of the turndownschedule 
+        jsonPath: .status.state
+      - name: Next Turndown
+        type: string
+        description: The next turndown date-time
+        jsonPath: .status.nextScaleDownTime
+      - name: Next Turn Up
+        type: string
+        description: The next turn up date-time
+        jsonPath: .status.nextScaleUpTime
   names:
     kind: TurndownSchedule
     singular: turndownschedule
@@ -264,35 +294,8 @@ spec:
     - td
     - tds
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          type: object
-          properties:
-            start: 
-              type: string
-              format: date-time
-            end:
-              type: string
-              format: date-time
-            repeat: 
-              type: string
-              enum: [none, daily, weekly]
-  additionalPrinterColumns:
-  - name: State
-    type: string
-    description: The state of the turndownschedule 
-    JSONPath: .status.state
-  - name: Next Turndown
-    type: string
-    description: The next turndown date-time
-    JSONPath: .status.nextScaleDownTime
-  - name: Next Turn Up
-    type: string
-    description: The next turn up date-time
-    JSONPath: .status.nextScaleUpTime
+  
+  
+  
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -256,37 +256,40 @@ metadata:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   group: kubecost.k8s.io
-  versions: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            type: object
-            properties:
-              start: 
-                type: string
-                format: date-time
-              end:
-                type: string
-                format: date-time
-              repeat: 
-                type: string
-                enum: [none, daily, weekly]
-    subresources:
-      status: {}
-    additionalPrinterColumns:
-      - name: State
-        type: string
-        description: The state of the turndownschedule 
-        jsonPath: .status.state
-      - name: Next Turndown
-        type: string
-        description: The next turndown date-time
-        jsonPath: .status.nextScaleDownTime
-      - name: Next Turn Up
-        type: string
-        description: The next turn up date-time
-        jsonPath: .status.nextScaleUpTime
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              type: object
+              properties:
+                start: 
+                  type: string
+                  format: date-time
+                end:
+                  type: string
+                  format: date-time
+                repeat: 
+                  type: string
+                  enum: [none, daily, weekly]
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: State
+          type: string
+          description: The state of the turndownschedule 
+          jsonPath: .status.state
+        - name: Next Turndown
+          type: string
+          description: The next turndown date-time
+          jsonPath: .status.nextScaleDownTime
+        - name: Next Turn Up
+          type: string
+          description: The next turn up date-time
+          jsonPath: .status.nextScaleUpTime
   names:
     kind: TurndownSchedule
     singular: turndownschedule


### PR DESCRIPTION
## What does this PR change?

Upgrade to apiextensions.k8s.io/v1 to successfully install cluster controller for automated turndown

## Does this PR rely on any other PRs?

- Yes, another PR will needed in the [cluster-turndown](https://github.com/kubecost/cluster-turndown) repo


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Users will be able to successfully install cluster controller for automated turndown on K8s versions < v1.22

## Links to Issues or ZD tickets this PR addresses or fixes

- [#1425 ](https://github.com/kubecost/cost-analyzer-helm-chart/issues/1425)


## How was this PR tested?
helm upgrade with PR tweaks. Schedule automated turndown

## Have you made an update to documentation?
No
