### PR TITLE
Update cluster-controller to v0.1.0

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -22,7 +22,7 @@ metadata:
     app: {{ template "kubecost.clusterControllerName" . }}
 rules:
   - apiGroups:
-      - kubecost.k8s.io
+      - kubecost.com
     resources:
       - turndownschedules
       - turndownschedules/status
@@ -247,106 +247,56 @@ spec:
     app: {{ template "kubecost.clusterControllerName" . }}
 ---
 # TurndownSchedule Custom Resource Definition for persistence
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: turndownschedules.kubecost.k8s.io
+  name: turndownschedules.kubecost.com
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
-  group: kubecost.k8s.io
+  group: kubecost.com
+  names:
+    kind: TurndownSchedule
+    singular: turndownschedule
+    plural: turndownschedules
+    shortNames:
+    - td
+    - tds
+  scope: Cluster
   versions:
     - name: v1alpha1
       served: true
       storage: true
+      subresources:
+        status: {}
       schema:
         openAPIV3Schema:
+          type: object
           properties:
             spec:
               type: object
               properties:
-                start: 
+                start:
                   type: string
                   format: date-time
                 end:
                   type: string
                   format: date-time
-                repeat: 
+                repeat:
                   type: string
                   enum: [none, daily, weekly]
-      subresources:
-        status: {}
       additionalPrinterColumns:
-        - name: State
-          type: string
-          description: The state of the turndownschedule 
-          jsonPath: .status.state
-        - name: Next Turndown
-          type: string
-          description: The next turndown date-time
-          jsonPath: .status.nextScaleDownTime
-        - name: Next Turn Up
-          type: string
-          description: The next turn up date-time
-          jsonPath: .status.nextScaleUpTime
-  names:
-    kind: TurndownSchedule
-    singular: turndownschedule
-    plural: turndownschedules
-    shortNames:
-    - td
-    - tds
-  scope: Cluster
-{{ else }}
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: turndownschedules.kubecost.k8s.io
-  labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-spec:
-  group: kubecost.k8s.io
-  version: v1alpha1
-  names:
-    kind: TurndownSchedule
-    singular: turndownschedule
-    plural: turndownschedules
-    shortNames:
-    - td
-    - tds
-  scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          type: object
-          properties:
-            start: 
-              type: string
-              format: date-time
-            end:
-              type: string
-              format: date-time
-            repeat: 
-              type: string
-              enum: [none, daily, weekly]
-  additionalPrinterColumns:
-  - name: State
-    type: string
-    description: The state of the turndownschedule 
-    JSONPath: .status.state
-  - name: Next Turndown
-    type: string
-    description: The next turndown date-time
-    JSONPath: .status.nextScaleDownTime
-  - name: Next Turn Up
-    type: string
-    description: The next turn up date-time
-    JSONPath: .status.nextScaleUpTime
-{{ end -}}
-  
+      - name: State
+        type: string
+        description: The state of the turndownschedule
+        jsonPath: .status.state
+      - name: Next Turndown
+        type: string
+        description: The next turndown date-time
+        jsonPath: .status.nextScaleDownTime
+      - name: Next Turn Up
+        type: string
+        description: The next turn up date-time
+        jsonPath: .status.nextScaleUpTime
 {{- end }}
 {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -604,7 +604,7 @@ kubecostDeployment:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.0.6
+  image: gcr.io/kubecost1/cluster-controller:v0.1.0
   imagePullPolicy: Always
 #  fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
 


### PR DESCRIPTION
## What does this PR change?

- Updates cluster-controller to v0.1.0, which includes v2 of cluster-turndown
- Updates the turndown CRD to match v2 of cluster-turndown

This includes a BREAKING CHANGE to the cluster-turndown functionality
that is wrapped by cluster-controller. The breaking changes are
summarized in https://github.com/kubecost/cluster-turndown/releases/tag/v2.0.0
and should be featured prominently in release notes.

The breaking change is necessary because we aren't allowed to use `*.k8s.io` to namespace our CRDs. See the notes in https://github.com/kubecost/cluster-turndown/pull/44 for a further explanation and references.

## Does this PR rely on any other PRs?

- https://github.com/kubecost/cluster-controller/pull/7 and the image build of 0.1.0 that follows

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Updates cluster-controller to v0.1.0.
- Removes `apiextensions.k8s.io/v1beta1` CRD `turndownschedules.kubecost.k8s.io`
- Introduces `apiextensions.k8s.io/v1` CRD `turndownschedules.kubecost.com` as replacement.
- :warning: Breaking change for users of the alpha feature "Cluster Turndown" contained in the Cluster Controller. If you have Cluster Controller enabled (`--set clusterController.enabled=true`), please visit the [migration guide](https://github.com/kubecost/docs/blob/main/v1-94-turndown-schedule-migration-guide.md) to check if you have existing resources that must be migrated to maintain expected functionality.

## Links to Issues or ZD tickets this PR addresses or fixes

- Should resolve issues like https://github.com/kubecost/cluster-turndown/issues/40 for those who use turndown through cluster controller. I have not yet seen a report of this, but it can happen.

## How was this PR tested?

Deployed this version of the Helm chart with `--set clusterController.enabled=true`. Saw the `turndownschedules.kubecost.com` CRD with `kubectl get crd`. Saw the cluster-controller Pod start and observed clean logs:
```
→ k logs -n kubecost -l app=kubecost-cluster-controller --tail=-1 -f
W0527 17:34:20.783003 1013105 gcp.go:120] WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
I0527 21:33:57.166819       1 main.go:110] Initializing turndown and cluster editing (nodes) component. Failure will not crash the program.
I0527 21:33:57.167151       1 main.go:115] Running on node: gke-michael-dev-pool-5-1acb2061-g3l8
I0527 21:33:57.194580       1 validator.go:41] Validating Provider...
I0527 21:33:57.198575       1 namedlogger.go:24] [GKEClusterProvider] Loading node pools for: [ProjectID: guestbook-227502, Zone: us-east4-b, ClusterID: michael-dev]
I0527 21:33:57.353038       1 schedulecontroller.go:110] Starting TurndownSchedule controller
```

I did not test using turndown functionality.

## Have you made an update to documentation?

- https://github.com/kubecost/docs/pull/246