### PR TITLE
Updated to have the context name description next to clusterName.

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -760,7 +760,7 @@ awsstore:
 #    daemonset_external_label: "kubernetes_daemonset"
 #    pod_external_label: "kubernetes_pod"
 #  grafanaURL: ""
-#  clusterName: "" # used for display in Kubecost UI
+#  clusterName: "" # clusterName is the default context name in settings.
 #  currencyCode: "USD" # official support for USD, AUD, BRL, CAD, CHF, CNY, DKK, EUR, GBP, INR, JPY, NOK, PLN, SEK
 #  azureBillingRegion: US # Represents 2-letter region code, e.g. West Europe = NL, Canada = CA. ref: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
 #  azureSubscriptionID: 0bd50fdf-c923-4e1e-850c-196dd3dcc5d3


### PR DESCRIPTION
## What does this PR change?
Changes the comment next to clusterName to use the new verbiage of Contexts.


## Does this PR rely on any other PRs?
- https://github.com/kubecost/cost-analyzer-frontend/pull/716


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Kubecost has introduced a concept of contexts. Instead of the confusion around a federated cluster having a single cluster name, you are now able to name a group of clusters as a context. Contexts can contain a single cluster, or a federated cluster that leverages persistent storage (Thanos, etc..). 

## How was this PR tested?
- Manually

## Have you made an update to documentation?
- Not yet - Coming next week.
