### PR TITLE
Fix infinite redirect for users with no rbac roles

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -109,6 +109,9 @@ data:
 
 {{- if .Values.saml.enabled }}
         add_header Cache-Control "max-age=0";
+        location /unauthorized.html {
+            
+        }
         location / {
             auth_request /auth;
             proxy_redirect off;


### PR DESCRIPTION
## What does this PR change?
Fixes an infinite redirect loop for users who are authenticated w/ saml but do not have any rbac roles assigned to them. 

This was caused by the `unauthorized.html` page attempting to authenticate visitors after they were denied access. Users would be served a 401, be sent back to login, be logged back in by the browser cache, be denied access and put back on `unauthorized.html`, served a 401, ad infinitum.

This change stops attempted authentication before accessing `unauthorized.html`.

## Does this PR rely on any other PRs?
No. 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixed a login redirect loop when a user attempted to log in with RBAC roles enabled but with no roles assigned.


## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1351#issuecomment-1139711796
- 


## How was this PR tested?
Tested by recreating the loop conditions (enabling all saml roles but without myself mapped to any one), logging in and observing a redirect loop, then applying the configmap changes and retrying.
![image](https://user-images.githubusercontent.com/32113845/170801071-f98b1f6d-05e4-47cd-be30-9961ae6c4328.png)

Also made sure normal rbac login was unaffected.

## Have you made an update to documentation?
No.
