### PR TITLE
Update helm chart to default to ETL file store

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -560,7 +560,7 @@ spec:
             - name: ETL_HOURLY_STORE_DURATION_HOURS
               value: {{ (quote .Values.kubecostModel.etlHourlyStoreDurationHours) | default (quote 49) }}
             - name: ETL_FILE_STORE_ENABLED
-              value: {{ (quote .Values.kubecostModel.etlFileStoreEnabled) | default (quote false) }}
+              value: {{ (quote .Values.kubecostModel.etlFileStoreEnabled) | default (quote true) }}
             - name: ETL_ASSET_RECONCILIATION_ENABLED
               value: {{ (quote .Values.kubecostModel.etlAssetReconciliationEnabled) | default (quote true) }}
             - name: ETL_USE_UNBLENDED_COST

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -267,6 +267,8 @@ kubecostModel:
   warmSavingsCache: true
   # Run allocation ETL pipelines
   etl: true
+  # Enable the ETL filestore backing storage
+  etlFileStoreEnabled: true 
   # The total number of days the ETL pipelines will build
   # Set to 0 to disable daily ETL (not recommended)
   etlDailyStoreDurationDays: 91


### PR DESCRIPTION
## What does this PR change?
* Enables ETL FileStore (Virtual memory solution backed by disk) by default. 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Users which have enabled a disk based backup for MemoryStore will seamlessly change to FileStore (unless it is explicitly disabled). 

## How was this PR tested?
```
helm template kubecost --namespace=kubecost ./cost-analyzer -f ./cost-analyzer/values.yaml  > k.yaml
```

```
# Source: cost-analyzer/templates/cost-analyzer-deployment-template.yaml
...
            - name: ETL_DAILY_STORE_DURATION_DAYS
              value: "91"
            - name: ETL_HOURLY_STORE_DURATION_HOURS
              value: "49"
            - name: ETL_FILE_STORE_ENABLED
              value: "true"
            - name: ETL_ASSET_RECONCILIATION_ENABLED
              value: "true"
            - name: ETL_USE_UNBLENDED_COST
              value: "false"
...
```


## Have you made an update to documentation?
In the works
