### PR TITLE
Remove duplicate label configurations on service monitor

### DIFF
--- a/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
@@ -9,7 +9,6 @@ metadata:
   name: {{ include "kubecost.kubeMetricsName" . }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-    {{ include "kubecost.chartLabels" . | nindent 4 }}
     {{- if .Values.kubecostMetrics.exporter.serviceMonitor.additionalLabels }}
     {{ toYaml .Values.kubecostMetrics.exporter.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## What does this PR change?

It removes duplicate labels that were being attached to the ServiceMonitor object. It's a similar issue to #1322, but in a different location. The removed set of labels aren't used anywhere other than this one template that I removed them from either.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Tools such as the flux helm controller can install the chart now when `serviceMonitor.enabled` is set to true

## How was this PR tested?

The generated yaml was applied to a cluster and there were a reduction in errors from yamllint.

## Have you made an update to documentation?

No. None was necessary.