### PR TITLE
Update app label of exporter service, ServiceMonitor missmatch.

### DIFF
--- a/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
@@ -8,7 +8,8 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "kubecost.kubeMetricsName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{ include "kubecost.chartLabels" . | nindent 4 }}
+    app: {{ template "kubecost.kubeMetricsName" . }}
     {{- if .Values.kubecostMetrics.exporter.serviceMonitor.additionalLabels }}
     {{ toYaml .Values.kubecostMetrics.exporter.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/kubecost-metrics-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-template.yaml
@@ -7,7 +7,8 @@ kind: Service
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
   labels:
-{{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{ include "kubecost.chartLabels" . | nindent 4 }}
+    app: {{ template "kubecost.kubeMetricsName" . }}
 {{- if (or .Values.kubecostMetrics.exporter.service.annotations $prometheusScrape) }}
   annotations:
 {{- if .Values.kubecostMetrics.exporter.service.annotations }}


### PR DESCRIPTION
## What does this PR change?
ServiceMonitor pointing to https://github.com/kubecost/cost-analyzer-helm-chart/blob/v1.93.2/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml#L29
And app label: https://github.com/kubecost/cost-analyzer-helm-chart/blob/v1.93.2/cost-analyzer/templates/_helpers.tpl#L132
