### PR TITLE
Add auto-label-new-issues workflow

### DIFF
--- a/.github/workflows/auto_label_issues.yml
+++ b/.github/workflows/auto_label_issues.yml
@@ -1,0 +1,14 @@
+name: auto-label-new-issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label new issues with 'needs-triage'
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "needs-triage"


### PR DESCRIPTION
## What does this PR change?
Adds workflow to auto-label all newly-opened issues with "needs-triage" label.

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A

## Links to Issues or ZD tickets this PR addresses or fixes
N/A

## How was this PR tested?
N/A

## Have you made an update to documentation?
N/A
