### PR TITLE
Allow agent secret to be created manually

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -86,13 +86,6 @@ Network Costs name used to tie autodiscovery of metrics to daemon set pods
 {{- end -}}
 
 {{/*
-Kubecost Agent Secret Name 
-*/}}
-{{- define "kubecost.agentStoreSecretName" -}}
-{{- printf "%s-%s" .Release.Name "object-store" -}}
-{{- end -}}
-
-{{/*
 Create the chart labels.
 */}}
 {{- define "kubecost.chartLabels" -}}

--- a/cost-analyzer/templates/kubecost-agent-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secret-template.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.agent }}
-{{- if not .Values.agentStoreSecretName }}
+{{- if or .Values.createAgentSecret (not (hasKey .Values "createAgentSecret")) }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ template "kubecost.agentStoreSecretName" . }}
+  name: kubecost-agent-object-store
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/kubecost-agent-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secret-template.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.agent }}
+{{- if not .Values.agentStoreSecretName }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -8,4 +9,5 @@ metadata:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   object-store.yaml: {{ .Values.agentKey }}
+{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-agent-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secret-template.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.agent }}
-{{- if or .Values.createAgentSecret (not (hasKey .Values "createAgentSecret")) }}
+{{- if .Values.agentKey }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: kubecost-agent-object-store
+  name: {{ .Values.agentKeySecretName }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   object-store.yaml: {{ .Values.agentKey }}
-{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -44,7 +44,11 @@ spec:
         {{- if .Values.agent }}
         - name: config-store
           secret:
+          {{- if .Values.agentStoreSecretName }}
+            secretName: {{ .Values.agentStoreSecretName }}
+          {{- else }}
             secretName: {{ template "kubecost.agentStoreSecretName" . }}
+          {{- end }}
         {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if .Values.kubecostProductConfigs.gcpSecretName }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -44,11 +44,7 @@ spec:
         {{- if .Values.agent }}
         - name: config-store
           secret:
-          {{- if .Values.agentStoreSecretName }}
-            secretName: {{ .Values.agentStoreSecretName }}
-          {{- else }}
-            secretName: {{ template "kubecost.agentStoreSecretName" . }}
-          {{- end }}
+            secretName: kubecost-agent-object-store
         {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if .Values.kubecostProductConfigs.gcpSecretName }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -44,7 +44,7 @@ spec:
         {{- if .Values.agent }}
         - name: config-store
           secret:
-            secretName: kubecost-agent-object-store
+            secretName: {{ .Values.agentKeySecretName }}
         {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if .Values.kubecostProductConfigs.gcpSecretName }}

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -11,6 +11,10 @@ global:
 # with enhancements designed for external hosting. 
 agent: true 
 
+# If createAgentSecret is set to false, you must manually create a secret with the name 
+# of `kubecost-agent-object-store` with the contents of the agent.key file provided to you
+#createAgentSecret: false
+
 # No Grafana configuration is required.
 grafana:
   sidecar:
@@ -45,8 +49,8 @@ prometheus:
       - name: object-store-volume
         mountPath: /etc/thanos/config 
         readOnly: true
-        secretName: | 
-          {{ template "kubecost.agentStoreSecretName" . }} 
+        secretName: |
+            kubecost-agent-object-store
     enableAdminApi: true
     sidecarContainers:
     - name: thanos-sidecar

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -10,10 +10,7 @@ global:
 # Agent enables specific features designed to enhance the metrics exporter deployment
 # with enhancements designed for external hosting. 
 agent: true 
-
-# If createAgentSecret is set to false, you must manually create a secret with the name 
-# of `kubecost-agent-object-store` with the contents of the agent.key file provided to you
-#createAgentSecret: false
+agentKeySecretName: kubecost-agent-object-store
 
 # No Grafana configuration is required.
 grafana:
@@ -49,8 +46,7 @@ prometheus:
       - name: object-store-volume
         mountPath: /etc/thanos/config 
         readOnly: true
-        secretName: |
-            kubecost-agent-object-store
+        secretName: {{ .Values.agentKeySecretName }}
     enableAdminApi: true
     sidecarContainers:
     - name: thanos-sidecar


### PR DESCRIPTION
## What does this PR change?

Adds additional logic allowing someone to specify an existing agent secret name as opposed to the Helm chart creating one. Defaults to the value calculated by the template if the value is unset.

## Does this PR rely on any other PRs?
Nope!

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Adds the ability to specify an existing agent secret name via the `.Values.agentStoreSecretName` value.

## Links to Issues or ZD tickets this PR addresses or fixes

None.


## How was this PR tested?


## Have you made an update to documentation?
Not yet. Coming soon!
