### PR TITLE
fix grafana pod utilization dashboard query

### DIFF
--- a/cost-analyzer/pod-utilization.json
+++ b/cost-analyzer/pod-utilization.json
@@ -274,7 +274,7 @@
         },
         {
           "exemplar": true,
-          "expr": "avg(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"}) by (container)",
+          "expr": "avg(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace=~\"$namespace\", pod=~\"$pod\", container!=\"POD\"}) by (container)",
           "legendFormat": "{{ container}} (request)",
           "refId": "B"
         }


### PR DESCRIPTION
## What does this PR change?
Fixes a bad Grafana dashboard query that was preventing data from appearing.

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixes "CPU Usage vs Requested" graph on "Pod cost & utilization metrics" Grafana dashboard


## Links to Issues or ZD tickets this PR addresses or fixes
- Fixes #1494

## How was this PR tested?
1. Run local helm upgrade
`helm upgrade kubecost ./cost-analyzer/ --reuse-values`
2. Check "Pod cost & utilization metrics" dashboard for corrected graph
`http://localhost:9090/grafana/d/at-cost-analysis-pod/pod-cost-and-utilization-metrics?var-namespace=kube-system&var-pod=gke-metrics-agent-4dp7q&var-cluster=&var-datasource=Prometheus&orgId=1`
![image](https://user-images.githubusercontent.com/43491549/175376637-8dee05a6-dbfd-4f70-9df3-b3319ee33ac7.png)
