### PR TITLE
Added try_files to / for spa to work.

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -99,7 +99,6 @@ data:
         server_name _;
         root /var/www;
         index index.html;
-        try_files $uri $uri/ /index.html;
         large_client_header_buffers 4 32k;
         add_header Cache-Control "must-revalidate";
 
@@ -121,6 +120,7 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
             error_page 401 = /login;
+            try_files $uri $uri/ /index.html;
         }
 {{- else }}
         add_header Cache-Control "max-age=300";

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -99,6 +99,7 @@ data:
         server_name _;
         root /var/www;
         index index.html;
+        try_files $uri $uri/ /index.html;
         large_client_header_buffers 4 32k;
         add_header Cache-Control "must-revalidate";
 


### PR DESCRIPTION
## What does this PR change?
This adds the ```try_files``` directive to the nginx config. This directive allows nginx to take a route such as <kcm_url>/settings and routes it to /index.html while maintaining the url in the browser. From there, the SPA router takes the url and routes to the proper page.


## Does this PR rely on any other PRs?
No. This has been tested with the old .html architecture and functions as expected. 

One side effect, any unknown route will point to /index.html of the front-end.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Allows the user to gain the benefits of the new Kubecost SPA application!


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Manually, but requesting someone smarter than me to test this with SAML/any other oddball nginx situations that we may have. cc: @AjayTripathy  

## Have you made an update to documentation?
No.
