### PR TITLE
Add OIDC config params in Values

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -172,6 +172,18 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if .Values.oidc }}
+        {{- if .Values.oidc.enabled }}
+        - name: oidc-config
+          configMap:
+            name: {{ template "cost-analyzer.fullname" . }}-oidc
+        {{- if .Values.oidc.secretName }}
+        - name: oidc-client-secret
+          secret:
+            secretName: {{ .Values.oidc.secretName }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
         {{- toYaml .Values.extraVolumes | nindent 8 }}
@@ -332,6 +344,16 @@ spec:
             {{- if .Values.saml.rbac.enabled }}
             - name: saml-roles
               mountPath: /var/configs/saml
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.oidc }}
+            {{- if .Values.oidc.enabled }}
+            - name: oidc-config
+              mountPath: /var/configs/oidc
+            {{- if .Values.oidc.secretName }}
+            - name: oidc-client-secret
+              mountPath: /var/configs/oidc-client-secret
             {{- end }}
             {{- end }}
             {{- end }}
@@ -627,6 +649,10 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- if .Values.oidc.enabled }}
+            - name: OIDC_ENABLED
+              value: "true"
+            {{- end}}
             {{- if .Values.saml }}
             {{- if .Values.saml.enabled }}
             - name: SAML_ENABLED

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1,6 +1,11 @@
 {{- if not .Values.agent }}
 {{- $serviceName := include "cost-analyzer.serviceName" . -}}
 {{- $nginxPort := .Values.service.targetPort | default 9090 -}}
+{{- if .Values.saml.enabled }}
+{{- if .Values.oidc.enabled }}
+{{- fail "SAML and OIDC cannot both be enabled" }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -107,7 +112,7 @@ data:
             internal;
         }
 
-{{- if .Values.saml.enabled }}
+{{- if or .Values.saml.enabled .Values.oidc.enabled }}
         add_header Cache-Control "max-age=0";
         location /unauthorized.html {
             
@@ -147,7 +152,7 @@ data:
         listen [::]:{{ $nginxPort }};
 {{- end }}
         location /api/ {
-            {{- if .Values.saml.enabled }}
+            {{- if or .Values.saml.enabled .Values.oidc.enabled }}
             auth_request /auth;
             {{- end }}
             proxy_pass http://api/;
@@ -174,8 +179,8 @@ data:
             add_header 'Access-Control-Allow-Origin' '*' always;
 {{- if .Values.clusterController }}
 {{- if .Values.clusterController.enabled }}
-            {{- if .Values.saml }}
-            {{- if .Values.saml.enabled }}
+            {{- if or .Values.saml .Values.oidc }}
+            {{- if or .Values.saml.enabled .Values.oidc.enabled }}
             auth_request /auth;
             {{- else if .Values.saml.rbac.enabled}}
             auth_request /authrbac;
@@ -199,6 +204,17 @@ data:
 {{- else }}
             return 404;
 {{- end }}
+        }
+        location /oidc/ {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://model/oidc/;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location /saml/ {
             proxy_connect_timeout       180;
@@ -248,7 +264,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     {{ end }}
-    {{- if .Values.saml.enabled }}
+    {{- if or .Values.saml.enabled .Values.oidc.enabled }}
         location /auth {
             proxy_pass http://model/isAuthenticated;
         }

--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.oidc }}
+{{- if .Values.oidc.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cost-analyzer.fullname" . }}-oidc
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+{{- $root := . }}
+    oidc.json: |-
+      {
+        "enabled" : {{ .Values.oidc.enabled }},
+        "clientID" : "{{ .Values.oidc.clientID }}",
+        "secretName" : "{{ .Values.oidc.secretName }}",
+        "authURL" : "{{ .Values.oidc.authURL }}",
+        "loginRedirectURL" : "{{ .Values.oidc.loginRedirectURL }}",
+        "discoveryURL" : "{{ .Values.oidc.discoveryURL }}"
+      }
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.oidc }}
+{{- if .Values.oidc.secretName }}
+{{- if .Values.oidc.clientSecret }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.oidc.secretName }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+stringData:
+  clientSecret: {{ .Values.oidc.clientSecret }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -179,6 +179,15 @@ saml:
         assertionValues:
           - "editor"
 
+oidc:
+  enabled: false
+  clientID: "" # application/client client_id paramter obtained from provider, used to make requests to server
+  clientSecret: "" # application/client client_secret paramter obtained from provider, used to make requests to server
+  secretName: "kubecost-oidc-secret" # k8s secret where clientsecret will be stored
+  authURL: "https://my.auth.server/authorize" # endpoint for login to auth server 
+  loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
+  discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
+
 # Adds an httpProxy as an environment variable. systemProxy.enabled must be `true`to have any effect.
 # Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml
 systemProxy:


### PR DESCRIPTION
## What does this PR change?
Adds config values for OIDC, as well as the template(s) to handle them. Creates a secret that stores the OIDC client secret key, as well as a configmap used for the OIDC integration.

Further information on testing/behavior in linked KCCM PR

## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?

