### PR TITLE
Upgrade prometheus to 2.35.0 and node-exporter to 1.3.0

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -411,7 +411,7 @@ nodeExporter:
   ##
   image:
     repository: prom/node-exporter
-    tag: v0.18.1
+    tag: v1.3.0
     pullPolicy: IfNotPresent
 
   ## Specify if a Pod Security Policy for node-exporter must be created
@@ -536,7 +536,7 @@ server:
   ##
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.31.1
+    tag: v2.35.0
     pullPolicy: IfNotPresent
 
   ## prometheus server priorityClassName


### PR DESCRIPTION
## What does this PR change?
We upgraded Prometheus from v2.31.1 to v2.35.0. This picked up golang v1.18 to address known security vulnerabilities.

We upgraded node-exporter from v0.18.1 to v1.3.0 as the previous build was from 2019.

## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
This PR addresses several known vulnerabilities in the gobinary detected by Trivy:  CVE-2021-43816, CVE-2021-41103, CVE-2022-23648, and CVE-2021-38561

![Screenshot 2022-07-01 130246](https://user-images.githubusercontent.com/1526573/176961631-86f926e4-4101-48e3-8646-a2f039fe9f19.png)


## Links to Issues or ZD tickets this PR addresses or fixes
  closes #1443 
  closes #1512


## How was this PR tested?
We used helm to update the cost analyzer on a kubecost cluster and then

1. Verified Prometheus image number was updated to v2.35.0 by calling `kubectl describe deployment kubecost-prometheus-server`:
...
   prometheus-server:
    Image:      quay.io/prometheus/prometheus:v2.35.0
    Port:       9090/TCP
    Host Port:  0/TCP
...

2. Checked the prometheus-node-exporter image was updated by invoking `kubecost describe pod kubecost-prometheus-node-exporter...`:
Containers:
  prometheus-node-exporter:
    Image:      prom/node-exporter:v1.3.0
    Port:       9100/TCP
    Host Port:  9100/TCP

3. Opened the frontend, modified some data, and then triggering a rebuild of the last 7 days of data using the URL `http://35.192.75.47:9090/model/etl/allocation/repair?window=2022-06-23T00:00:00Z,2022-07-02T00:00:00Z`.

4. Monitored rebuild progressing using the etl-status.html page of the frontend

5. Verified data was updated without error:
![Screenshot 2022-07-01 131643](https://user-images.githubusercontent.com/1526573/176962959-33aa5bc0-751e-4244-85bc-53157a4163d3.png)
![Screenshot 2022-07-01 131735](https://user-images.githubusercontent.com/1526573/176963030-461a3bab-986c-4e18-b1f4-997a40ea31d8.png)



## Have you made an update to documentation?
N/A
