### PR TITLE
Add try_files directive to non-SAML installs. Required for SPA

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -124,6 +124,9 @@ data:
         }
 {{- else }}
         add_header Cache-Control "max-age=300";
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
 {{- end }}
 {{- if .Values.imageVersion }}
         add_header ETag "{{ $.Values.imageVersion }}";


### PR DESCRIPTION
## What does this PR change?
Adds a try_files directive to non-SAML nginx configs


## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Enables SPA path rendering for non-SAML users


## Links to Issues or ZD tickets this PR addresses or fixes

N/A


## How was this PR tested?
Manually

## Have you made an update to documentation?
No
