### PR TITLE
add systemProxy for networkCosts Daemonset

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -63,6 +63,20 @@ spec:
           value: {{ (quote .Values.networkCosts.trafficLogging) | default (quote true) }}
         - name: GODEBUG
           value: "madvdontneed=1"
+        {{- if .Values.systemProxy.enabled }}
+        - name: HTTP_PROXY
+          value: {{ .Values.systemProxy.httpProxyUrl }}
+        - name: http_proxy
+          value: {{ .Values.systemProxy.httpProxyUrl }}
+        - name: HTTPS_PROXY
+          value:  {{ .Values.systemProxy.httpsProxyUrl }}
+        - name: https_proxy
+          value:  {{ .Values.systemProxy.httpsProxyUrl }}
+        - name: NO_PROXY
+          value:  {{ .Values.systemProxy.noProxy }}
+        - name: no_proxy
+          value:  {{ .Values.systemProxy.noProxy }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.networkCosts.hostProc }}
         - mountPath: {{ .Values.networkCosts.hostProc.mountPath }}


### PR DESCRIPTION
## What does this PR change?
This PR adds possibility to add systemProxy for kubecost-network-costs Daemonset.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Not a release-facing feature

## Links to Issues or ZD tickets this PR addresses or fixes
N/A

## How was this PR tested?
## Have you made an update to documentation?
No



┆Issue is synchronized with this [Jira Task](https://kubecost.atlassian.net/browse/GIB-126) by [Unito](https://www.unito.io)
