### PR TITLE
Update values.yaml

### DIFF
--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -25,7 +25,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.3.2
+  tag: 9.0.2
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.
@@ -255,7 +255,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:1.15.4
+  image: kiwigrid/k8s-sidecar:1.19.2
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:


### PR DESCRIPTION
## What does this PR change?
Update grafana and k8s-sidecar to keep up with versions


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Automatically bundles the latest grafana and k8s sidecar with kubecost, though long-term we're moving away from this bundling strategy


## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/1549
https://github.com/kubecost/cost-analyzer-helm-chart/issues/1550


## How was this PR tested?
Install grafana via helm

## Have you made an update to documentation?

