### PR TITLE
add etl cloud query window days var to chart

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -569,6 +569,8 @@ spec:
             {{- end }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}
+            - name: ETL_CLOUD_QUERY_WINDOW_DAYS
+              value: {{ (quote .Values.kubecostModel.etlCloudQueryWindowDays) | default (quote 7) }}
             {{- if .Values.persistentVolume.dbPVEnabled }}
             - name: ETL_PATH_PREFIX
               value: "/var/db"


### PR DESCRIPTION
## What does this PR change?
This PR allows you to set a new env variable to change the number of days that the ETL will query out-of-cluster data at a time.


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/875
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Tested by setting in values.yaml and checking env variables in pod 
![Screen Shot 2022-07-20 at 1 15 48 PM](https://user-images.githubusercontent.com/12225425/180073830-8fe72fe4-4e63-415a-b91f-e319f6e0c68c.png)

Then testing to see the query windows on a cloud usage rebuild which resulted in this log.
```
2022-07-20T20:16:23.369368159Z INF Azure Storage: retrieving most recent reports from: 2022-07-14 00:00:00 +0000 UTC - 2022-07-17 00:00:00 +0000 UTC
```

## Have you made an update to documentation?

