### PR TITLE
Prevent duplicate "app" labels when enabling cluster controller

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -5,8 +5,11 @@ kind: ServiceAccount
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     app: {{ template "kubecost.clusterControllerName" . }}
+    app.kubernetes.io/name: {{ template "kubecost.clusterControllerName" . }}
+    helm.sh/chart: {{ include "cost-analyzer.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 ---
 #
 # NOTE: 
@@ -18,8 +21,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     app: {{ template "kubecost.clusterControllerName" . }}
+    app.kubernetes.io/name: {{ template "kubecost.clusterControllerName" . }}
+    helm.sh/chart: {{ include "cost-analyzer.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
   - apiGroups:
       - kubecost.com
@@ -155,8 +161,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     app: {{ template "kubecost.clusterControllerName" . }}
+    app.kubernetes.io/name: {{ template "kubecost.clusterControllerName" . }}
+    helm.sh/chart: {{ include "cost-analyzer.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -5,11 +5,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
-    app: {{ template "kubecost.clusterControllerName" . }}
-    app.kubernetes.io/name: {{ template "kubecost.clusterControllerName" . }}
-    helm.sh/chart: {{ include "cost-analyzer.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 ---
 #
 # NOTE: 
@@ -21,11 +17,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
-    app: {{ template "kubecost.clusterControllerName" . }}
-    app.kubernetes.io/name: {{ template "kubecost.clusterControllerName" . }}
-    helm.sh/chart: {{ include "cost-analyzer.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 rules:
   - apiGroups:
       - kubecost.com
@@ -161,11 +153,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
-    app: {{ template "kubecost.clusterControllerName" . }}
-    app.kubernetes.io/name: {{ template "kubecost.clusterControllerName" . }}
-    helm.sh/chart: {{ include "cost-analyzer.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## What does this PR change?

Stop using `commonLabels` in some parts of the `clusterController` template that were leading to entries with duplicate `app: ` label metadata. Also ensure that `app: ` and `app.kubernetes.io/name: ` labels match for said entries.

Some definition in the template continue to use `cost-analyzer` for their app name, as they did before. Definitions which had conflicting labels `app: cost-analyzer` and `app: Release.name-cluster-controller` are consolidated on the latter name. I'm unsure whether all definitions in the file should be changed to consolidate on one name or another; please advise.


## Does this PR rely on any other PRs?

No.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Fixes a bug where enabling `clusterController` produced a Helm template with non-unique label metadata


## Links to Issues or ZD tickets this PR addresses or fixes

- Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1542


## How was this PR tested?
By running

```
helm template test ./cost-analyzer --set clusterController.enabled=true > out.yaml
```

locally and observing that duplicate `app: ` labels no longer appear for clusterContorller items.

## Have you made an update to documentation?
No
