### PR TITLE
Needs-follow-up fix

### DIFF
--- a/.github/workflows/label-comments.yml
+++ b/.github/workflows/label-comments.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Check for non-4XX response"
         id: membership
         run: |
-          echo '${{ steps.response.outputs.MEMBER_RESPONSE }}' && echo "::set-output name=IS_MEMBER::$(grep -E 'HTTP/2 [235]' <<< '${{ steps.response.outputs.MEMBER_RESPONSE }}')"
+          echo '${{ steps.response.outputs.MEMBER_RESPONSE }}' && echo "::set-output name=IS_MEMBER::$(grep 'HTTP/2 [235]' <<< '${{ steps.response.outputs.MEMBER_RESPONSE }}')"
 
       - name: Apply needs-follow-up label if this is a new or reopened issue by user not in the org
         if: ${{ steps.membership.outputs.IS_MEMBER == '' && github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened') }}

--- a/.github/workflows/label-comments.yml
+++ b/.github/workflows/label-comments.yml
@@ -1,24 +1,45 @@
-name: add-label-on-comment
+name: needs-follow-up-label
 
 on:
   issue_comment:
     types: [created]
+  issues:
+    types: [opened, reopened, closed]
 
 jobs:
-  add-followup-label:
+  set-follow-up-label:
     runs-on: ubuntu-latest
     steps:
       - name: Check comment actor org membership
         id: response
         run: |
-          echo ${{ github.actor }} && echo "::set-output name=MEMBER_RESPONSE::$(curl -i -H 'Accept: application/vnd.github+json' -H 'Authorization: token ${{ github.token }}' 'https://api.github.com/orgs/kubecost/members/${{ github.actor }}')"
+          echo "::set-output name=MEMBER_RESPONSE::$(curl -I -H 'Accept: application/vnd.github+json' -H 'Authorization: token ${{ github.token }}' 'https://api.github.com/orgs/kubecost/members/${{ github.actor }}')"
+
       - name: "Check for 204 response"
         id: membership
         run: |
           echo '${{ steps.response.outputs.MEMBER_RESPONSE }}' && echo "::set-output name=IS_MEMBER::$(grep 'HTTP/2 204' <<< '${{ steps.response.outputs.MEMBER_RESPONSE }}')"
-      - name: Apply follow-up label to issues last commented by a user not in the org
-        if: steps.membership.outputs.IS_MEMBER == ''
+
+      - name: Apply needs-follow-up label if this is a new or reopened issue by user not in the org
+        if: ${{ steps.membership.outputs.IS_MEMBER == '' && github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened') }}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: needs-follow-up
 
+      - name: Apply needs-follow-up label if comment by a user not in the org
+        if: ${{ steps.membership.outputs.IS_MEMBER == '' && github.event_name == 'issue_comment' }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: needs-follow-up
+
+      - name: Remove needs-follow-up label if the issue has been closed
+        if: ${{ github.event_name == 'issues' && github.event.action == 'closed' }}
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: needs-follow-up
+
+      - name: Remove needs-follow-up label if comment by a user in the org
+        if: ${{ steps.membership.outputs.IS_MEMBER != '' && github.event_name == 'issue_comment' }}
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: needs-follow-up

--- a/.github/workflows/label-comments.yml
+++ b/.github/workflows/label-comments.yml
@@ -8,11 +8,11 @@ jobs:
   add-followup-label:
     runs-on: ubuntu-latest
     steps:
-      - name: Check developer whitelist
+      - name: Check comment author
         id: author
         run: |
           echo "::set-output name=AUTHOR::$(grep '${{github.event.actor.login}}' 'normsbee teevans michaelmdresser wolfeaustin mbolt35 nikovacevic')"
-      - name: Apply label
+      - name: Apply follow-up label to issues last commented by a user not in the org
         uses: actions-ecosystem/action-add-labels@v1
         if: ${{ steps.author.outputs.AUTHOR }}
         with:

--- a/.github/workflows/label-comments.yml
+++ b/.github/workflows/label-comments.yml
@@ -8,13 +8,17 @@ jobs:
   add-followup-label:
     runs-on: ubuntu-latest
     steps:
-      - name: Check comment author
-        id: author
+      - name: Check comment actor org membership
+        id: response
         run: |
-          echo "::set-output name=AUTHOR::$(grep '${{github.event.actor.login}}' 'normsbee teevans michaelmdresser wolfeaustin mbolt35 nikovacevic')"
+          echo ${{ github.actor }} && echo "::set-output name=MEMBER_RESPONSE::$(curl -i -H 'Accept: application/vnd.github+json' -H 'Authorization: token ${{ github.token }}' 'https://api.github.com/orgs/kubecost/members/${{ github.actor }}')"
+      - name: "Check for 204 response"
+        id: membership
+        run: |
+          echo '${{ steps.response.outputs.MEMBER_RESPONSE }}' && echo "::set-output name=IS_MEMBER::$(grep 'HTTP/2 204' <<< '${{ steps.response.outputs.MEMBER_RESPONSE }}')"
       - name: Apply follow-up label to issues last commented by a user not in the org
+        if: steps.membership.outputs.IS_MEMBER == ''
         uses: actions-ecosystem/action-add-labels@v1
-        if: ${{ steps.author.outputs.AUTHOR }}
         with:
           labels: needs-follow-up
 

--- a/.github/workflows/label-comments.yml
+++ b/.github/workflows/label-comments.yml
@@ -15,10 +15,10 @@ jobs:
         run: |
           echo "::set-output name=MEMBER_RESPONSE::$(curl -I -H 'Accept: application/vnd.github+json' -H 'Authorization: token ${{ github.token }}' 'https://api.github.com/orgs/kubecost/members/${{ github.actor }}')"
 
-      - name: "Check for 204 response"
+      - name: "Check for non-4XX response"
         id: membership
         run: |
-          echo '${{ steps.response.outputs.MEMBER_RESPONSE }}' && echo "::set-output name=IS_MEMBER::$(grep 'HTTP/2 204' <<< '${{ steps.response.outputs.MEMBER_RESPONSE }}')"
+          echo '${{ steps.response.outputs.MEMBER_RESPONSE }}' && echo "::set-output name=IS_MEMBER::$(grep -E 'HTTP/2 [235]' <<< '${{ steps.response.outputs.MEMBER_RESPONSE }}')"
 
       - name: Apply needs-follow-up label if this is a new or reopened issue by user not in the org
         if: ${{ steps.membership.outputs.IS_MEMBER == '' && github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened') }}

--- a/.github/workflows/label-comments.yml
+++ b/.github/workflows/label-comments.yml
@@ -1,0 +1,20 @@
+name: add-label-on-comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  add-followup-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check developer whitelist
+        id: author
+        run: |
+          echo "::set-output name=AUTHOR::$(grep '${{github.event.actor.login}}' 'normsbee teevans michaelmdresser wolfeaustin mbolt35 nikovacevic')"
+      - name: Apply label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.author.outputs.AUTHOR }}
+        with:
+          labels: needs-follow-up
+


### PR DESCRIPTION
## What does this PR change?
The GH action used to apply the `needs-follow-up` label to issues is applying the label to issues when Kubecost org members comment, as well as community members. We actually want to *remove* the label when members from within the org comment.

The issues stems from checking for an HTTP 204 response from the organization membership API. In testing, this was always returned for members. In practice, we have been receiving 3XX responses from the API (redirects), which has lead the Action to believe that members are non-members.

This changes the `grep` for `HTTP/2 204` to a `grep` for `HTTP/2 [235]`, which *checks for the non-presence of a 4XX response*.


## Does this PR rely on any other PRs?

No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
It doesn't -- it just makes this issue housekeeping tool actually useful.


## Links to Issues or ZD tickets this PR addresses or fixes
N/A


## How was this PR tested?
Locally with the `act` tool

## Have you made an update to documentation?
No
