### PR TITLE
set thanos deployments to recreate by default

### DIFF
--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -56,8 +56,8 @@ store:
   # Add extra selector matchLabels to store deployment
   deploymentMatchLabels: {}
   # Override the default deployment strategy
-  # deploymentStrategy:
-  #   type: RollingUpdate
+  deploymentStrategy:
+    type: Recreate
 
   # Enable metrics collecting for store service
   metrics:
@@ -279,8 +279,8 @@ queryFrontend:
   # Add extra selector matchLabels to query deployment
   deploymentMatchLabels: {}
   # Override the default deployment strategy
-  # deploymentStrategy:
-  #   type: RollingUpdate
+  deploymentStrategy:
+    type: Recreate
 
   # Enable metrics collecting for query service
   metrics:
@@ -445,8 +445,8 @@ query:
   # Add extra selector matchLabels to query deployment
   deploymentMatchLabels: {}
   # Override the default deployment strategy
-  # deploymentStrategy:
-  #   type: RollingUpdate
+  deploymentStrategy:
+    type: Recreate
 
   # Enable metrics collecting for query service
   metrics:
@@ -574,8 +574,8 @@ compact:
   # Add extra selector matchLabels to compact deployment
   deploymentMatchLabels: {}
   # Override the default deployment strategy
-  # deploymentStrategy:
-  #   type: RollingUpdate
+  deploymentStrategy:
+    type: Recreate
 
   # Enable metrics collecting for compact service
   metrics:
@@ -685,8 +685,8 @@ bucket:
   # Add extra selector matchLabels to bucket deployment
   deploymentMatchLabels: {}
   # Override the default deployment strategy
-  # deploymentStrategy:
-  #   type: RollingUpdate
+  deploymentStrategy:
+    type: Recreate
 
   # Enable podDisruptionBudget for bucket component
   podDisruptionBudget:


### PR DESCRIPTION
## What does this PR change?
Sets Thanos deployments to have a default "Recreate" strategy. 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
All Thanos deployments now default to "Recreate" deployment strategy


## Links to Issues or ZD tickets this PR addresses or fixes
Fixes #1613


## How was this PR tested?
Running `helm template kubecost -f ./cost-analyzer/values-thanos.yaml ./cost-analyzer` and verifying that all Thanos deployments have the correct strategy assigned.