### PR TITLE
Add cloud run query and cloud refresh rate to helm chart

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -571,8 +571,12 @@ spec:
             {{- end }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}
+            - name: ETL_CLOUD_REFRESH_RATE_HOURS
+              value: {{ (quote .Values.kubecostModel.etlCloudRefreshRateHours) | default (quote 6) }}
             - name: ETL_CLOUD_QUERY_WINDOW_DAYS
               value: {{ (quote .Values.kubecostModel.etlCloudQueryWindowDays) | default (quote 7) }}
+            - name: ETL_CLOUD_RUN_WINDOW_DAYS
+              value: {{ (quote .Values.kubecostModel.etlCloudRunWindowDays) | default (quote 3) }}
             {{- if .Values.persistentVolume.dbPVEnabled }}
             - name: ETL_PATH_PREFIX
               value: "/var/db"


### PR DESCRIPTION
## What does this PR change?
This PR adds variables to to helm template to set values in
https://github.com/kubecost/kubecost-cost-model/pull/914


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/914
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- N/A users should not use unless instructed to


## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/kubecost-cost-model/issues/910
- 


## How was this PR tested?
see https://github.com/kubecost/kubecost-cost-model/pull/914


## Have you made an update to documentation?

