### PR TITLE
Bump the default timeout to 60s

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -590,7 +590,7 @@ server:
     scrape_interval: 1m
     ## How long until a scrape request times out
     ##
-    scrape_timeout: 10s
+    scrape_timeout: 60s
     ## How frequently to evaluate rules
     ##
     evaluation_interval: 1m

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -410,7 +410,7 @@ prometheus:
     - job_name: kubecost
       honor_labels: true
       scrape_interval: 1m
-      scrape_timeout: 10s
+      scrape_timeout: 60s
       metrics_path: /metrics
       scheme: http
       dns_sd_configs:


### PR DESCRIPTION
## What does this PR change?
Bumps the prometheus scrape timeout to 60s to avoid issues where at high-scale clusters, kubecost can take additional time to respond to prometheus scrapes.


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Additional stability on large scale clusters


## Links to Issues or ZD tickets this PR addresses or fixes
ZD #2354

## How was this PR tested?
Manual change of scrape timeout on a high scale cluster-- noted that the Prometheus kubecost scrape jobs turned from red to green.

## Have you made an update to documentation?
Not necessary
