### PR TITLE
fix Grafana origin not allowed (#1639)

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -115,7 +115,7 @@ data:
 {{- if or .Values.saml.enabled .Values.oidc.enabled }}
         add_header Cache-Control "max-age=0";
         location /unauthorized.html {
-            
+
         }
         location / {
             auth_request /auth;
@@ -266,6 +266,7 @@ data:
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
         }
     {{ end }}
     {{- if or .Values.saml.enabled .Values.oidc.enabled }}


### PR DESCRIPTION
## What does this PR change?

fixes issue #1639

## Does this PR rely on any other PRs?

NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Fixe issue with Grafana origin not allowed on certain ingress configuations.

## Links to Issues or ZD tickets this PR addresses or fixes

[https://github.com/kubecost/cost-analyzer-helm-chart/issues/1639](https://github.com/kubecost/cost-analyzer-helm-chart/issues/1639)

## How was this PR tested?

Several environments- this is a no risk config change for nginx

## Have you made an update to documentation?

NA