### PR TITLE
Add support for Amazon managed service for Prometheus

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/server-configmap.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-configmap.yaml
@@ -14,8 +14,13 @@ data:
 {{- if eq $key "prometheus.yml" }}
     global:
 {{ $root.Values.server.global | toYaml | trimSuffix "\n" | indent 6 }}
-{{- if $root.Values.server.remoteWrite }}
     remote_write:
+{{- if $root.Values.global.amp.enabled }}
+    - url: {{ $root.Values.global.amp.remoteWriteService }}
+      sigv4:
+{{ $root.Values.global.amp.sigv4 | toYaml | indent 8 }}
+{{- end }}
+{{- if $root.Values.server.remoteWrite }}
 {{ $root.Values.server.remoteWrite | toYaml | indent 4 }}
 {{- end }}
 {{- if $root.Values.server.remoteRead }}

--- a/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
@@ -14,7 +14,9 @@ data:
   {{ else }}
     prometheus-alertmanager-endpoint: {{ .Values.global.notifications.alertmanager.fqdn }}
   {{- end -}}
-  {{- if .Values.global.prometheus.enabled }}
+  {{if .Values.global.amp.enabled }}
+    prometheus-server-endpoint: {{ .Values.global.amp.prometheusServerEndpoint }}
+  {{- else if .Values.global.prometheus.enabled }}
   {{- if .Values.global.zone }}
     prometheus-server-endpoint: http://{{ template "cost-analyzer.prometheus.server.name" . }}.{{ .Release.Namespace  }}.svc.{{ .Values.global.zone }}
   {{ else }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -248,6 +248,35 @@ spec:
             runAsUser: 0
 {{ end }}
       containers:
+        {{- if .Values.global.amp.enabled }}
+        - name: sigv4proxy
+          image: {{ .Values.sigV4Proxy.image }}
+          {{- if .Values.sigV4Proxy.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.sigV4Proxy.imagePullPolicy }}
+          {{- else }}
+          imagePullPolicy: Always
+          {{- end }}
+          args:
+          - --name
+          - {{ .Values.sigV4Proxy.name }}
+          - --region
+          - {{ .Values.sigV4Proxy.region }}
+          - --host
+          - {{ .Values.sigV4Proxy.host }}
+          {{- if .Values.sigV4Proxy.role_arn }}
+          - --role-arn
+          - {{ .Values.sigV4Proxy.role_arn }}
+          {{- end }}          
+          - --port
+          - :{{ .Values.sigV4Proxy.port }}
+          ports:
+          - name: aws-sigv4-proxy
+            containerPort: {{ .Values.sigV4Proxy.port | int }}
+          {{- if .Values.sigV4Proxy.extraEnv }}
+          env:
+          {{- toYaml .Values.sigV4Proxy.extraEnv | nindent 10 }}
+          {{- end }}
+        {{- end }}
         {{- if .Values.kubecostModel }}
         {{- if .Values.kubecostModel.openSourceOnly }}
         - image: quay.io/kubecost1/kubecost-cost-model:{{ .Values.imageVersion }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -22,6 +22,18 @@ global:
     proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
 #    fqdn: cost-analyzer-grafana.default.svc
 
+  # Amazon Managed Service for Prometheus
+  amp:
+    enabled: false # If true, kubecost will be configured to remote_write and query from Amazon Managed Service for Prometheus.
+    prometheusServerEndpoint: https://localhost:8085/<workspaceId>/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the SigV4Proxy side car to the AMP workspace.
+    remoteWriteService: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspaceId>/api/v1/remote_write # The remote_write endpoint for the AMP workspace.
+    sigv4:
+      region: us-west-2
+      # access_key: ACCESS_KEY # AWS Access key 
+      # secret_key: SECRET_KEY # AWS Secret key
+      # role_arn: ROLE_ARN # AWS role arn
+      # profile: PROFILE # AWS profile
+
   notifications:
     # Kubecost alerting configuration
     # Ref: http://docs.kubecost.com/alerts
@@ -265,6 +277,20 @@ kubecostMetrics:
     additionalLabels: {}
     nodeSelector: {}
     extraArgs: []
+
+sigV4Proxy:
+  image: public.ecr.aws/aws-observability/aws-sigv4-proxy:latest
+  imagePullPolicy: Always
+  name: aps
+  port: 8005
+  region: us-west-2 # The AWS region
+  host: aps-workspaces.us-west-2.amazonaws.com # The hostname for AMP service.
+  # role_arn: arn:aws:iam::<account>:role/role-name # The AWS IAM role to assume.
+  extraEnv: # Pass extra env variables to sigV4Proxy
+  # - name: AWS_ACCESS_KEY_ID
+  #   value: <access_key>
+  # - name: AWS_SECRET_ACCESS_KEY
+  #   value: <secret_key>
 
 kubecostModel:
   image: "gcr.io/kubecost1/cost-model"


### PR DESCRIPTION
## What does this PR change?
This PR adds support for Amazon Managed Service for Prometheus (AMP).
- The bundled Prometheus server can be configured to remote_write to an AMP workspace.
- The cost-model will run queries against the AMP workspace. For SigV4 the calls are forwarded through the SigV4Proxy.


## Does this PR rely on any other PRs?
- No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- If `global.amp` is enabled, the chart will configure the bundled Prometheus server to remote_write to an AMP workspace and the cost-model runs queries against the AMP workspace.

## Links to Issues or ZD tickets this PR addresses or fixes
- N/A

## How was this PR tested?
- The helm chart was deployed in an EKS cluster with the following overrides:

```
global:
  amp:
    enabled: true
    prometheusServerEndpoint: http://localhost:8005/workspaces/<workspace>
    remoteWriteService: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspace>/api/v1/remote_write
    sigv4:
      region: us-west-2

sigV4Proxy:
  region: us-west-2
  host: aps-workspaces.us-west-2.amazonaws.com
```

- Verified that all the kubecost components are running:
```
➜  ~/repos/mocked-eks-metrics k get all -n kubecost
NAME                                              READY   STATUS    RESTARTS   AGE
pod/kubecost-cost-analyzer-7ff5988c4d-84ngn       3/3     Running   0          6m14s
pod/kubecost-grafana-6744d99888-kkvpc             2/2     Running   0          27h
pod/kubecost-kube-state-metrics-99bb8c55b-rwnk2   1/1     Running   0          29h
pod/kubecost-prometheus-server-ddb597d5c-46wb6    2/2     Running   0          4h1m

NAME                                  TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
service/kubecost-cost-analyzer        ClusterIP   172.20.193.188   <none>        9003/TCP,9090/TCP   46h
service/kubecost-grafana              ClusterIP   172.20.17.175    <none>        80/TCP              46h
service/kubecost-kube-state-metrics   ClusterIP   172.20.249.61    <none>        8080/TCP            29h
service/kubecost-prometheus-server    ClusterIP   172.20.40.132    <none>        80/TCP              29h

NAME                                          READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/kubecost-cost-analyzer        1/1     1            1           46h
deployment.apps/kubecost-grafana              1/1     1            1           46h
deployment.apps/kubecost-kube-state-metrics   1/1     1            1           29h
deployment.apps/kubecost-prometheus-server    1/1     1            1           29h

```
- Verified that the bundled Prometheus is sending traffic to AMP.
- Verified that the ETL queries are running against the AMP workspace.

![Kubecost status](https://user-images.githubusercontent.com/842522/185510453-e896aaf5-fa2b-4a1d-b6e9-57a0562c4c94.png)


## Have you made an update to documentation?
No. The docs hasn't been updated yet.

