### PR TITLE
Add value option - 'affinity' for 'prometheus/node-exporter-daemonset'

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
@@ -30,6 +30,10 @@ spec:
 {{ toYaml .Values.nodeExporter.pod.labels | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.nodeExporter.affinity }}
+      affinity:
+{{ toYaml .Values.nodeExporter.affinity | indent 8 }}
+{{- end }}
       serviceAccountName: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
 {{- if .Values.nodeExporter.priorityClassName }}
       priorityClassName: "{{ .Values.nodeExporter.priorityClassName }}"

--- a/cost-analyzer/values-windows-node-affinity.yaml
+++ b/cost-analyzer/values-windows-node-affinity.yaml
@@ -14,6 +14,9 @@ prometheus:
   server:
     nodeSelector:
       kubernetes.io/os: linux
+  kube-state-metrics:
+    nodeSelector:
+      kubernetes.io/os: linux
   nodeExporter:
     enabled: true
     affinity:
@@ -25,3 +28,6 @@ prometheus:
                 operator: In
                 values:
                 - linux
+grafana:
+  nodeSelector:
+    kubernetes.io/os: linux

--- a/cost-analyzer/values-windows-node-affinity.yaml
+++ b/cost-analyzer/values-windows-node-affinity.yaml
@@ -14,15 +14,14 @@ prometheus:
   server:
     nodeSelector:
       kubernetes.io/os: linux
-
-nodeExporter:
-  enabled: true
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-            - key: kubernetes.io/os
-              operator: In
-              values:
-              - linux
+  nodeExporter:
+    enabled: true
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux

--- a/cost-analyzer/values-windows-node-affinity.yaml
+++ b/cost-analyzer/values-windows-node-affinity.yaml
@@ -1,0 +1,28 @@
+kubecostMetrics:
+  exporter:
+    nodeSelector:
+      kubernetes.io/os: linux
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+networkCosts:
+  nodeSelector:
+    kubernetes.io/os: linux
+
+prometheus:
+  server:
+    nodeSelector:
+      kubernetes.io/os: linux
+
+nodeExporter:
+  enabled: false
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+              - linux

--- a/cost-analyzer/values-windows-node-affinity.yaml
+++ b/cost-analyzer/values-windows-node-affinity.yaml
@@ -16,7 +16,7 @@ prometheus:
       kubernetes.io/os: linux
 
 nodeExporter:
-  enabled: false
+  enabled: true
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## What does this PR change?

Adds option to set "Affinity" for NodeExporter DaemonSet via the values file. 

.Values.nodeExporter.affinity | indent 8

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows users to set the "affinity" for the daemonset via the values file.

## Links to Issues or ZD tickets this PR addresses or fixes

## How was this PR tested?

Bolt tested the generation of templates with this code and it properly added affinity to the daemonset.

## Have you made an update to documentation?

Documentation is here - We tell the user to taint the nodes, but this would allow users to set this affinity using the Kubecost values. https://guide.kubecost.com/hc/en-us/articles/6152374933655-Windows-Node-Support