### PR TITLE
Add ability to add 'affinity' value to 'prometheus/node-exporter'

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
@@ -30,6 +30,10 @@ spec:
 {{ toYaml .Values.nodeExporter.pod.labels | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.nodeExporter.affinity }}
+      affinity:
+{{ toYaml .Values.nodeExporter.affinity | indent 8 }}
+{{- end }}
       serviceAccountName: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
 {{- if .Values.nodeExporter.priorityClassName }}
       priorityClassName: "{{ .Values.nodeExporter.priorityClassName }}"

--- a/cost-analyzer/values-windows-node-affinity.yaml
+++ b/cost-analyzer/values-windows-node-affinity.yaml
@@ -1,0 +1,33 @@
+kubecostMetrics:
+  exporter:
+    nodeSelector:
+      kubernetes.io/os: linux
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+networkCosts:
+  nodeSelector:
+    kubernetes.io/os: linux
+
+prometheus:
+  server:
+    nodeSelector:
+      kubernetes.io/os: linux
+  kube-state-metrics:
+    nodeSelector:
+      kubernetes.io/os: linux
+  nodeExporter:
+    enabled: true
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+grafana:
+  nodeSelector:
+    kubernetes.io/os: linux


### PR DESCRIPTION
## What does this PR change?

Adds ability to set affinity and nodeSelectors to run only on Linux nodes via values file.

## Does this PR rely on any other PRs?

No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Adds ability to set affinity and nodeSelectors to run only on Linux nodes.

## Links to Issues or ZD tickets this PR addresses or fixes

-

## How was this PR tested?

Tested by Jesse on EKS with windows nodes. 

## Have you made an update to documentation?

Will be added to this page:
https://guide.kubecost.com/hc/en-us/articles/6152374933655-Windows-Node-Support