### PR TITLE
prometheus considerations + link KSM values

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1,7 +1,7 @@
 global:
   # zone: cluster.local (use only if your DNS server doesn't live in the same zone as kubecost)
   prometheus:
-    enabled: true # If false, Prometheus will not be installed -- only actively supported on paid Kubecost plans
+    enabled: true # If false, Prometheus will not be installed -- please read this before disabling: https://github.com/kubecost/docs/blob/main/custom-prom.md
     fqdn: http://cost-analyzer-prometheus-server.default.svc #example address of a prometheus to connect to. Include protocol (http:// or https://) Ignored if enabled: true
     # insecureSkipVerify : false # If true, kubecost will not check the TLS cert of prometheus
     # queryServiceBasicAuthSecretName: dbsecret # kubectl create secret generic dbsecret -n kubecost --from-file=USERNAME --from-file=PASSWORD
@@ -184,7 +184,7 @@ oidc:
   clientID: "" # application/client client_id paramter obtained from provider, used to make requests to server
   clientSecret: "" # application/client client_secret paramter obtained from provider, used to make requests to server
   secretName: "kubecost-oidc-secret" # k8s secret where clientsecret will be stored
-  authURL: "https://my.auth.server/authorize" # endpoint for login to auth server 
+  authURL: "https://my.auth.server/authorize" # endpoint for login to auth server
   loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
   discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
 
@@ -282,7 +282,7 @@ kubecostModel:
   # Run allocation ETL pipelines
   etl: true
   # Enable the ETL filestore backing storage
-  etlFileStoreEnabled: true 
+  etlFileStoreEnabled: true
   # The total number of days the ETL pipelines will build
   # Set to 0 to disable daily ETL (not recommended)
   etlDailyStoreDurationDays: 91
@@ -462,6 +462,8 @@ prometheus:
     persistentVolume:
       enabled: true
   nodeExporter:
+    enabled: true
+  kubeStateMetrics:
     enabled: true
   pushgateway:
     enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -461,10 +461,14 @@ prometheus:
     enabled: false
     persistentVolume:
       enabled: true
+  # node-export must be disabled if there is an existing daemonset: https://guide.kubecost.com/hc/en-us/articles/4407601830679-Troubleshoot-Install#a-name-node-exporter-a-issue-failedscheduling-kubecost-prometheus-node-exporter
   nodeExporter:
     enabled: true
+  # kubecost emits pre-2.0 KSM metrics, KSM is enabled by default here for backwards compatibity, but can be disabled to save resources without concern to kubecost metrics
   kubeStateMetrics:
     enabled: true
+  kube-state-metrics:
+    disabled: false
   pushgateway:
     enabled: false
     persistentVolume:


### PR DESCRIPTION
## What does this PR change?

Add link to documentation around disabling Prometheus.
Add section for disabling KSM

## Does this PR rely on any other PRs?

- NA



## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Reduces the support issues from users implementing kubecost on existing Prometheus
- Multiple KSM pods are inefficient

## Links to Issues or ZD tickets this PR addresses or fixes

NA

## How was this PR tested?

```
helm template kubecost \
    --repo https://kubecost.github.io/cost-analyzer/ cost-analyzer \
    --namespace kubecost --create-namespace \
    --set prometheus.nodeExporter.enabled=false \
    --set prometheus.serviceAccounts.nodeExporter.create=false \
    --set prometheus.kubeStateMetrics.enabled=false|ag 'statemetric|state-metric'
```
![image](https://user-images.githubusercontent.com/31039225/186249653-cb41d471-9671-46a5-a45e-178e28aa6327.png)


## Have you made an update to documentation?

yes: https://github.com/kubecost/docs/blob/main/custom-prom.md