### PR TITLE
Update securityContext configs to support Openshift cluster.

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -276,11 +276,11 @@ alertmanager:
 
   ## Security context to be added to alertmanager pods
   ##
-  securityContext:
-    runAsUser: 1001
-    runAsNonRoot: true
-    runAsGroup: 1001
-    fsGroup: 1001
+  securityContext: {}
+    # runAsUser: 1001
+    # runAsNonRoot: true
+    # runAsGroup: 1001
+    # fsGroup: 1001
 
   service:
     annotations: {}
@@ -858,11 +858,11 @@ server:
 
   ## Security context to be added to server pods
   ##
-  securityContext:
-    runAsUser: 1001
-    runAsNonRoot: true
-    runAsGroup: 1001
-    fsGroup: 1001
+  securityContext: {}
+    # runAsUser: 1001
+    # runAsNonRoot: true
+    # runAsGroup: 1001
+    # fsGroup: 1001
 
   service:
     annotations: {}
@@ -1018,9 +1018,9 @@ pushgateway:
 
   ## Security context to be added to push-gateway pods
   ##
-  securityContext:
-    runAsUser: 1001
-    runAsNonRoot: true
+  securityContext: {}
+    # runAsUser: 1001
+    # runAsNonRoot: true
 
   service:
     annotations:

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -122,10 +122,10 @@ store:
       #    hosts:
       #      - chart-example.local
   # Optional securityContext
-  securityContext:
-    fsGroup: 1001
-    runAsNonRoot: true
-    runAsUser: 1001
+  securityContext: {}
+    # fsGroup: 1001
+    # runAsNonRoot: true
+    # runAsUser: 1001
 
   resources: {}
   #  limits:
@@ -294,10 +294,10 @@ queryFrontend:
       labels: {}
 
   # Optional securityContext
-  securityContext:
-    fsGroup: 1001
-    runAsNonRoot: true
-    runAsUser: 1001
+  securityContext: {}
+    # fsGroup: 1001
+    # runAsNonRoot: true
+    # runAsUser: 1001
 
   resources: {}
   #  limits:
@@ -460,10 +460,10 @@ query:
       labels: {}
 
   # Optional securityContext
-  securityContext:
-    fsGroup: 1001
-    runAsNonRoot: true
-    runAsUser: 1001
+  securityContext: {}
+    # fsGroup: 1001
+    # runAsNonRoot: true
+    # runAsUser: 1001
 
   resources: {}
   #  limits:
@@ -590,10 +590,10 @@ compact:
   serviceAccount: ""
 
   # Optional securityContext
-  securityContext:
-    fsGroup: 1001
-    runAsNonRoot: true
-    runAsUser: 1001
+  securityContext: {}
+    # fsGroup: 1001
+    # runAsNonRoot: true
+    # runAsUser: 1001
 
   resources: {}
   #  limits:
@@ -696,10 +696,10 @@ bucket:
     #  maxUnavailable: 50%
 
   # Optional securityContext
-  securityContext:
-    fsGroup: 1001
-    runAsNonRoot: true
-    runAsUser: 1001
+  securityContext: {}
+    # fsGroup: 1001
+    # runAsNonRoot: true
+    # runAsUser: 1001
 
   resources: {}
   #  limits:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -42,6 +42,8 @@ spec:
 {{- end }}
 {{- end }}
     spec:
+      {{- if .Values.openshiftDeployment }}
+      securityContext: {}
       {{- if .Values.kubecostFrontend.tls }}
       {{- if .Values.kubecostFrontend.tls.enabled }}
       securityContext:
@@ -55,6 +57,7 @@ spec:
       {{- else if lt $nginxPort 1025 }}
       securityContext:
         runAsUser: 0
+      {{- end }}
       {{- else }}
       securityContext:
         runAsUser: 1001

--- a/cost-analyzer/values-openshift.yaml
+++ b/cost-analyzer/values-openshift.yaml
@@ -1,0 +1,36 @@
+kubecostProductConfigs:
+  clusterName: CLUSTER_NAME
+  projectID: CLUSTER_NAME
+
+prometheus:
+  nodeExporter:
+    enabled: false
+  serviceAccounts:
+    nodeExporter:
+      create: false
+  kube-state-metrics:
+    disabled: true
+  server:
+    global:
+      external_labels:
+        cluster_id: CLUSTER_NAME
+
+networkCosts:
+  enabled: false
+global:
+  grafana:
+    enabled: false
+    proxy: false
+
+
+kubecostFrontend:
+  fullImageName: "linhlamkc/cost-analyzer-frontend:prod-1.96.0"
+openshiftDeployment: true
+
+# Define persistence volume for cost-analyzer
+persistentVolume:
+  size: 32Gi
+  dbSize: 32.0Gi
+  enabled: true # Note that setting this to false means configurations will be wiped out on pod restart.
+  # storageClass: "-" #
+  # existingClaim: kubecost-cost-analyzer # a claim in the same namespace as kubecost


### PR DESCRIPTION
## What does this PR change?
This PR is to update cost-analyzer helmchart to support Openshift. These are required changes:


* Update Security context in Values.yaml of following sub charts to allow Openshift assigns random UIDs:
  * [Prometheus](https://github.com/kubecost/openshift-helm-chart/blob/7ad4e779e621b7daba96fe684c5bfff33fe0429a/cost-analyzer/charts/prometheus/values.yaml)
  * [Thanos](https://github.com/kubecost/openshift-helm-chart/blob/linh-cost-analyzer-195/cost-analyzer/charts/thanos/values.yaml)
* Update [cost-analyzer-deployment-template](https://github.com/kubecost/openshift-helm-chart/blob/linh-cost-analyzer-195/cost-analyzer/templates/cost-analyzer-deployment-template.yaml) to use random UID when Kubecost is installed on Openshift
* Add additional specific Values file for Openshift name `values-openshift.yaml`

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* This PR allows customer to install Kubecost on Openshift easily using our main Helm chart repository. Currently, customer need to clone this Helm chart for Openshift installation https://github.com/kubecost/openshift-helm-chart

## Links to Issues or ZD tickets this PR addresses or fixes
N/A

## How was this PR tested?
* It was tested on Openshift 4.10.25 following instructions at https://github.com/kubecost/openshift-helm-chart/blob/main/README.md

## Have you made an update to documentation?
* Yes and it need to update Helm chart location once this PR is merged.



┆Issue is synchronized with this [Jira Task](https://kubecost.atlassian.net/browse/GIB-162) by [Unito](https://www.unito.io)
