### PR TITLE
feat: add support to Workload Identity

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -412,8 +412,10 @@ spec:
                   key: prometheus-server-endpoint
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
+            {{- if .Values.kubecostProductConfigs.gcpSecretName }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/configs/key.json
+            {{- end }}
             - name: CONFIG_PATH
               value: /var/configs/
             - name: DB_PATH

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -8,9 +8,9 @@ metadata:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 ---
 #
-# NOTE: 
-# The following ClusterRole permissions are only created and assigned for the 
-# cluster controller feature. They will not be added to any clusters by default. 
+# NOTE:
+# The following ClusterRole permissions are only created and assigned for the
+# cluster controller feature. They will not be added to any clusters by default.
 #
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -70,7 +70,7 @@ rules:
       - events
       - services
     verbs:
-      - get 
+      - get
       - list
       - watch
   - apiGroups:
@@ -95,7 +95,7 @@ rules:
       - daemonsets
       - replicasets
     verbs:
-      - get 
+      - get
       - list
       - watch
       - create
@@ -131,9 +131,9 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - storage.k8s.io
-    resources: 
+    resources:
       - storageclasses
     verbs:
       - get
@@ -217,8 +217,10 @@ spec:
           value: {{ .Release.Namespace }}
         - name: TURNDOWN_DEPLOYMENT
           value: {{ template "kubecost.clusterControllerName" . }}
+        {{- if .Values.kubecostProductConfigs.gcpSecretName }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/keys/service-key.json
+        {{- end }}
         ports:
         - name: http-server
           containerPort: 9731

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -187,8 +187,10 @@ spec:
                   key: prometheus-server-endpoint
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
+            {{- if .Values.kubecostProductConfigs.gcpSecretName }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/configs/key.json
+            {{- end }}
             - name: CONFIG_PATH
               value: /var/configs/
             - name: KUBECOST_METRICS_PORT


### PR DESCRIPTION
When using Workload Identity on the GKE cluster, we don't provide a secret with the
credentials (GOOGLE_APPLICATION_CREDENTIALS). Therefore, we should only try to
use them if the GPC secret is supplied.

Addresses https://github.com/kubecost/cost-analyzer-helm-chart/issues/986

## What does this PR change?

I add support for Workload Identity.

## Does this PR rely on any other PRs?

- https://github.com/kubecost/cost-analyzer-helm-chart/pull/1260.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Add support to Workload Identity in GCP

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/986


## How was this PR tested?

I forked the repository and deployed it in my Testing and Staging clusters.

## Have you made an update to documentation?

No.