### PR TITLE
Revert Enforcing ClusterID

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Run helm template
         working-directory: ./cost-analyzer
         # Template the chart out for kubeval usage and also validates that it can 'build'
-        run: helm template . --set global.prometheus.enabled=false --set global.grafana.enabled=false --set prometheus.server.global.external_labels.cluster_id=cluster-1 > full.yaml
+        run: helm template . --set global.prometheus.enabled=false --set global.grafana.enabled=false > full.yaml
 
       - name: Kubeval
         uses: instrumenta/kubeval-action@master
@@ -57,7 +57,7 @@ jobs:
         working-directory: ./cost-analyzer
         run: |
           kubectl create ns kubecost
-          helm install kubecost . --namespace kubecost --set global.prometheus.enabled=false --set global.grafana.enabled=false --set prometheus.server.global.external_labels.cluster_id=cluster-1
+          helm install kubecost . --namespace kubecost --set global.prometheus.enabled=false --set global.grafana.enabled=false
 
       - name: Cleanup k3s
         if: always()

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -691,14 +691,15 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            {{- if and (hasKey .Values.prometheus.server.global.external_labels "cluster_id") (not .Values.prometheus.server.clusterIDConfigmap) }}
+            {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.clusterIDConfigmap) }}
             - name: CLUSTER_ID
               value: {{ .Values.prometheus.server.global.external_labels.cluster_id }}
-            {{- else }}
+            {{- end }}
+            {{- if .Values.prometheus.server.clusterIDConfigmap }}
             - name: CLUSTER_ID
               valueFrom:
                 configMapKeyRef:
-                  name: {{ required "A cluster_id OR clusterIDConfigmap is required!" .Values.prometheus.server.clusterIDConfigmap }}
+                  name: {{ .Values.prometheus.server.clusterIDConfigmap }}
                   key: CLUSTER_ID
             {{- end }}
             {{- if .Values.remoteWrite.postgres.installLocal }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -203,16 +203,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        {{- if and (hasKey .Values.prometheus.server.global.external_labels "cluster_id") (not .Values.prometheus.server.clusterIDConfigmap) }}
         - name: CLUSTER_ID
           value: {{ .Values.prometheus.server.global.external_labels.cluster_id }}
-        {{- else }}
-        - name: CLUSTER_ID
-          valueFrom:
-            configMapKeyRef:
-              name: {{ required "A cluster_id OR clusterIDConfigmap is required!" .Values.prometheus.server.clusterIDConfigmap }}
-              key: CLUSTER_ID
-        {{- end }}
         - name: TURNDOWN_NAMESPACE
           value: {{ .Release.Namespace }}
         - name: TURNDOWN_DEPLOYMENT

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -234,14 +234,15 @@ spec:
             - name: INSECURE_SKIP_VERIFY
               value: {{ (quote .Values.global.prometheus.insecureSkipVerify) }}
             {{- end }}
-            {{- if and (hasKey .Values.prometheus.server.global.external_labels "cluster_id") (not .Values.prometheus.server.clusterIDConfigmap) }}
+            {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.clusterIDConfigmap) }}
             - name: CLUSTER_ID
               value: {{ .Values.prometheus.server.global.external_labels.cluster_id }}
-            {{- else }}
+            {{- end }}
+            {{- if .Values.prometheus.server.clusterIDConfigmap }}
             - name: CLUSTER_ID
               valueFrom:
                 configMapKeyRef:
-                  name: {{ required "A cluster_id OR clusterIDConfigmap is required!" .Values.prometheus.server.clusterIDConfigmap }}
+                  name: {{ .Values.prometheus.server.clusterIDConfigmap }}
                   key: CLUSTER_ID
             {{- end }}
             {{- if .Values.kubecostModel.promClusterIDLabel }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -444,8 +444,8 @@ prometheus:
       scrape_interval: 1m
       scrape_timeout: 10s
       evaluation_interval: 1m
-      external_labels: {}
-        # cluster_id: cluster-one # Each cluster should have a unique ID
+      external_labels:
+        cluster_id: cluster-one # Each cluster should have a unique ID
     persistentVolume:
       size: 32Gi
       enabled: true


### PR DESCRIPTION
We need to revert the enforced cluster ID until we have time to document changes (our install instructions would require this addition as well). We should definitely push for following release though:

* Reverts kubecost/cost-analyzer-helm-chart#1505