### PR TITLE
Add federated s3 env variable / secret mount

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -76,6 +76,12 @@ spec:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.etlBucketConfigSecret }}
         {{- end }}
+        {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+        - name: federated-storage-config
+          secret:
+           defaultMode: 420
+           secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
+        {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if .Values.kubecostProductConfigs.productKey }}
         {{- if .Values.kubecostProductConfigs.productKey.secretname }}
@@ -294,6 +300,11 @@ spec:
             {{- else if and (.Values.kubecostModel.etlToDisk | default true) .Values.persistentVolume.dbPVEnabled }}
             - name: persistent-db
               mountPath: /var/db
+            {{- end }}
+            {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+            - name: federated-storage-config
+              mountPath: /var/configs/etl
+              readOnly: true
             {{- end }}
             {{- if .Values.kubecostProductConfigs }}
             {{- if .Values.kubecostProductConfigs.productKey }}
@@ -558,6 +569,10 @@ spec:
             {{- else }}
             - name: ETL_TO_DISK_ENABLED
               value: {{ (quote .Values.kubecostModel.etlToDisk) | default (quote true) }}
+            {{- end }}
+            {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+            - name: FEDERATED_STORE_CONFIG
+              value: "/var/configs/etl/federated-store.yaml"
             {{- end }}
             - name: ETL_STORE_READ_ONLY
               value: {{ (quote .Values.kubecostModel.etlStoreReadOnly) | default (quote false) }}


### PR DESCRIPTION
## What does this PR change?
Adds logic for reading `federated-store.yaml` in the same vein as the backup store's `object-store.yaml`.

## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
See linked KCCM PR


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
See linked KCCM PR

## Have you made an update to documentation?

