### PR TITLE
helm option to disable ipv6 on frontend

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -146,14 +146,20 @@ data:
         ssl_certificate     /etc/ssl/certs/kc.crt;
         ssl_certificate_key /etc/ssl/certs/kc.key;
         listen 443 ssl;
+{{- if .Values.kubecostFrontend.ipv6.enabled }}
         listen [::]:443 ssl;
-{{- else }}
-        listen {{ $nginxPort }};
-        listen [::]:{{ $nginxPort }};
 {{- end }}
 {{- else }}
         listen {{ $nginxPort }};
+{{- if .Values.kubecostFrontend.ipv6.enabled }}
         listen [::]:{{ $nginxPort }};
+{{- end }}
+{{- end }}
+{{- else }}
+        listen {{ $nginxPort }};
+{{- if .Values.kubecostFrontend.ipv6.enabled }}
+        listen [::]:{{ $nginxPort }};
+{{- end }}
 {{- end }}
         location /api/ {
             {{- if or .Values.saml.enabled .Values.oidc.enabled }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -184,7 +184,7 @@ oidc:
   clientID: "" # application/client client_id paramter obtained from provider, used to make requests to server
   clientSecret: "" # application/client client_secret paramter obtained from provider, used to make requests to server
   secretName: "kubecost-oidc-secret" # k8s secret where clientsecret will be stored
-  authURL: "https://my.auth.server/authorize" # endpoint for login to auth server 
+  authURL: "https://my.auth.server/authorize" # endpoint for login to auth server
   loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
   discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
 
@@ -212,6 +212,8 @@ kubecostFrontend:
     #limits:
     #  cpu: "100m"
     #  memory: "256Mi"
+  ipv6:
+    enabled: true # disable if the cluster does not support ipv6
 #  api:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:
@@ -282,7 +284,7 @@ kubecostModel:
   # Run allocation ETL pipelines
   etl: true
   # Enable the ETL filestore backing storage
-  etlFileStoreEnabled: true 
+  etlFileStoreEnabled: true
   # The total number of days the ETL pipelines will build
   # Set to 0 to disable daily ETL (not recommended)
   etlDailyStoreDurationDays: 91


### PR DESCRIPTION
## What does this PR change?

helm option to disable ipv6 on nginx frontend

## Does this PR rely on any other PRs?

- NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

A handful of users have cost-analyzer pods with 1/2 ready due to ipv6 being disabled on the cluster

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1491

## How was this PR tested?

default to on:
>helm template kubecost ./cost-analyzer --namespace kubecost | grep ::
        regex: ([^:]+)(?::\d+)?;(\d+)
        regex: ([^:]+)(?::\d+)?;(\d+)
        listen [::]:9090;

true still works:
>helm template kubecost ./cost-analyzer --namespace kubecost --set kubecostFrontend.ipv6.enabled=true| grep ::                                                                                 
        regex: ([^:]+)(?::\d+)?;(\d+)
        regex: ([^:]+)(?::\d+)?;(\d+)
        listen [::]:9090;

false removes it
>helm template kubecost ./cost-analyzer --namespace kubecost --set kubecostFrontend.ipv6.enabled=false| grep ::
        regex: ([^:]+)(?::\d+)?;(\d+)
        regex: ([^:]+)(?::\d+)?;(\d+)

did a helm install on a test cluster. 

Also have manually edited user nginx-conf configmaps that has fixed the issue

## Have you made an update to documentation?

Will add to troubleshooting.