### PR TITLE
Replace deprecated kube_pod_container_resource_requests_memory_bytes metric in Pod Utilization grafana dashboard

### DIFF
--- a/cost-analyzer/pod-utilization.json
+++ b/cost-analyzer/pod-utilization.json
@@ -393,7 +393,7 @@
           "step": 10
         },
         {
-          "expr": "avg(kube_pod_container_resource_requests_memory_bytes{namespace=~\"$namespace\", pod=\"$pod\", container!=\"POD\"}) by (container)",
+          "expr": "avg(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace=~\"$namespace\", pod=\"$pod\", container!=\"POD\"}) by (container)",
           "format": "time_series",
           "hide": false,
           "instant": false,


### PR DESCRIPTION
`kube_pod_container_resource_requests_memory_bytes` not available in new versions of KSM  anymore