### PR TITLE
NGINX changes to open node port and container port to serve grpc request

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -303,6 +303,10 @@ spec:
         - image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
         {{ end }}
           name: cost-model
+          ports:
+          - containerPort: 50052
+            name: grpcserver
+            protocol: TCP
         {{- if .Values.kubecostModel.extraArgs }}
           args:
           {{- toYaml .Values.kubecostModel.extraArgs | nindent 12 }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -196,7 +196,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        location /pkg.service.allocation.v1/ {
+        location /services/ {
             grpc_pass grpc://grpcserver;
         }
 

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -62,6 +62,17 @@ data:
 {{- end }}
     }
 
+    upstream grpcserver {
+{{- if.Values.kubecostFrontend.grpcserver }}
+{{- if.Values.kubecostFrontend.grpcserver.fqdn }}
+        server {{ .Values.kubecostFrontend.grpc.fqdn }};
+{{- else }}
+        server {{ $serviceName }}.{{ .Release.Namespace }}:50052;
+{{- end }}
+{{- else }}
+        server {{ $serviceName }}.{{ .Release.Namespace }}:50052;
+{{- end }}
+    }
     upstream model {
 {{- if.Values.kubecostFrontend.model }}
 {{- if.Values.kubecostFrontend.model.fqdn }}
@@ -101,6 +112,7 @@ data:
 {{- end }}
 
     server {
+        listen 50051 http2;
         server_name _;
         root /var/www;
         index index.html;
@@ -182,6 +194,10 @@ data:
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /kubecost.service.allocation.allocationsummary.AllocationSummary/ {
+            grpc_pass grpc://grpcserver;
         }
 
         location ~ ^/(turndown|cluster)/ {

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -196,7 +196,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        location /kubecost.service.allocation.allocationsummary.AllocationSummary/ {
+        location /pkg.service.allocation.v1/ {
             grpc_pass grpc://grpcserver;
         }
 

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -30,6 +30,10 @@ spec:
     - name: tcp-model
       port: 9003
       targetPort: 9003
+    - name: tcp-grpc
+      port: 50051
+      targetPort: grpcserver
+      protocol: TCP
     - name: tcp-frontend
       {{- if .Values.kubecostFrontend.tls }}
       {{- if .Values.kubecostFrontend.tls.enabled }}


### PR DESCRIPTION
## What does this PR change?
Opens Node port 50051 to serve GRPC request and port forwards grpc request to cost-model container port running grpc server on 50052 


## Does this PR rely on any other PRs?

- Will open a KCM PR soon!
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Hopefully none , i dont think changes to this would impact regular http calls.


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Applying changes to helm deployment and running GRPC calls along with regular HTTP calls.

## Have you made an update to documentation?
Don't know where to update the documentation for this.
