### PR TITLE
update eks integration values to 1.97.0

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -33,7 +33,7 @@ networkPolicy:
 podSecurityPolicy:
   enabled: false
 
-imageVersion: prod-1.96.0
+imageVersion: prod-1.97.0
 kubecostFrontend:
   image: public.ecr.aws/kubecost/frontend
   imagePullPolicy: Always


### PR DESCRIPTION
## What does this PR change?

Update values-eks-monitoring.yaml to support version prod-1.97.0

## Does this PR rely on any other PRs?

N/A


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Enable AWS users to use 1.97.0 and support AMP integration launch

## Links to Issues or ZD tickets this PR addresses or fixes

https://github.com/kubecost/docs/issues/333
https://github.com/kubecost/docs/pull/334


## How was this PR tested?
End to end test on EKS cluster following the doc in https://github.com/kubecost/docs/pull/334

## Have you made an update to documentation?
Yes
