### PR TITLE
Set up OIDC hosted domain check

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -15,7 +15,8 @@ data:
         "secretName" : "{{ .Values.oidc.secretName }}",
         "authURL" : "{{ .Values.oidc.authURL }}",
         "loginRedirectURL" : "{{ .Values.oidc.loginRedirectURL }}",
-        "discoveryURL" : "{{ .Values.oidc.discoveryURL }}"
+        "discoveryURL" : "{{ .Values.oidc.discoveryURL }}",
+        "hostedDomain" : "{{ .Values.oidc.hostedDomain }}"
       }
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -199,6 +199,7 @@ oidc:
   authURL: "https://my.auth.server/authorize" # endpoint for login to auth server
   loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
   discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
+  hostedDomain: "example.com" # blocks access to the auth domain specified in the hd claim of the provider ID token
 
 # Adds an httpProxy as an environment variable. systemProxy.enabled must be `true`to have any effect.
 # Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml


### PR DESCRIPTION
## What does this PR change?
Include domain in helm parameters for OIDC auth.


## Does this PR rely on any other PRs?
https://github.com/kubecost/kubecost-cost-model/pull/951

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can now set a `.Values.oidc.hostedDomain` parameter to block access for users outside of the configured domain.

**Note** Removing a previously set helm domain value is done by setting `.Values.oidc.hostedDomain = ""`, as opposed to simply removing the `hostedDomain` field from the config. 

## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/1605

## How was this PR tested?
Verify that new helm parameter is parsed and loaded correctly in the `OIDCConfigs` object to be used at authentication time.

## Have you made an update to documentation?
Will add domain note to internal OIDC documentation