### PR TITLE
Ensure k8s best practices

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -92,6 +92,12 @@ spec:
           To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret=""
         */}}
         {{- $etlBackupBucketSecret := "" }}
+        {{- if .Values.global.containerSecuritycontext }}
+        - name: tmp
+          emptyDir: { }
+        - name: cache
+          emptyDir: { }
+        {{- end }}
         {{- if .Values.kubecostModel.etlBucketConfigSecret }}
             {{- $etlBackupBucketSecret = .Values.kubecostModel.etlBucketConfigSecret }}
         {{- else if and .Values.global.thanos.enabled (ne (typeOf .Values.kubecostModel.etlBucketConfigSecret) "string") }}
@@ -360,6 +366,19 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 200
+          {{- if .Values.kubecostFrontend.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 200
+          {{- end }}
+          {{- if .Values.global.containerSecuritycontext }}
+          securityContext:
+          {{- toYaml .Values.global.containerSecuritycontext | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if .Values.hosted }}
             - name: config-store
@@ -971,6 +990,12 @@ spec:
               mountPath: /tmp
             - name: nginx-conf
               mountPath: /etc/nginx/conf.d/
+            {{- if .Values.global.containerSecuritycontext }}
+            - mountPath: /var/cache/nginx
+              name: cache
+            - mountPath: /var/run
+              name: tmp
+            {{- end }}
             {{- if .Values.kubecostFrontend.tls }}
             {{- if .Values.kubecostFrontend.tls.enabled }}
             - name: tls
@@ -991,6 +1016,19 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 200
+          {{- if .Values.kubecostFrontend.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: {{ .Values.kubecostFrontend.livenessProbe.initialDelaySeconds  }}
+            periodSeconds: {{ .Values.kubecostFrontend.livenessProbe.periodSeconds  }}
+            failureThreshold: {{ .Values.kubecostFrontend.livenessProbe.failureThreshold  }}
+          {{- end }}
+          {{- if .Values.global.containerSecuritycontext }}
+          securityContext:
+          {{- toYaml .Values.global.containerSecuritycontext | nindent 12 }}
+          {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -162,6 +162,9 @@ global:
     # iam.amazonaws.com/role: role-arn
   additionalLabels: {}
 
+  containerSecuritycontext: {}
+    # readOnlyRootFilesystem: true
+
 # generated at http://kubecost.com/install, used for alerts tracking and free trials
 kubecostToken: # ""
 
@@ -243,6 +246,11 @@ kubecostFrontend:
     #limits:
     #  cpu: "100m"
     #  memory: "256Mi"
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 200
   ipv6:
     enabled: true # disable if the cluster does not support ipv6
 #  api:
@@ -374,6 +382,11 @@ kubecostModel:
     #limits:
     #  cpu: "800m"
     #  memory: "256Mi"
+  livenessProbe:
+    enabled: false
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 200
   extraArgs: []
 
 # Basic Kubecost ingress, more examples available at https://github.com/kubecost/docs/blob/master/ingress-examples.md


### PR DESCRIPTION
## What does this PR change?
* helm chart now have an option to add livenessprobes and container securitycontext, Frontend nginx is tuned to run with `readonlyrootfilesystem: true` and have the emptydir as a volumemounts.
* this PR by default it have the flag disabled and nothing will change. Users can customise the value from the end if needed.

## Does this PR rely on any other PRs?
* No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Improve Container securitycontext and ensure the k8s best practices

## Links to Issues or ZD tickets this PR addresses or fixes
## - 
## How was this PR tested?
* By deploying the helm chart locally

## Have you made an update to documentation?
-



┆Issue is synchronized with this [Jira Task](https://kubecost.atlassian.net/browse/GIB-180) by [Unito](https://www.unito.io)
