### PR TITLE
network-costs serviceMonitor

### DIFF
--- a/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.serviceMonitor.networkCosts.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cost-analyzer.networkCostsName" . }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.networkCosts.additionalLabels }}
+    {{ toYaml .Values.serviceMonitor.networkCosts.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      honorLabels: true
+      interval: 1m
+      scrapeTimeout: {{ .Values.serviceMonitor.networkCosts.scrapeTimeout }}
+      path: /metrics
+      scheme: http
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "cost-analyzer.networkCostsName" . }}
+{{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -29,7 +29,7 @@ global:
     remoteWriteService: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspaceId>/api/v1/remote_write # The remote_write endpoint for the AMP workspace.
     sigv4:
       region: us-west-2
-      # access_key: ACCESS_KEY # AWS Access key 
+      # access_key: ACCESS_KEY # AWS Access key
       # secret_key: SECRET_KEY # AWS Secret key
       # role_arn: ROLE_ARN # AWS role arn
       # profile: PROFILE # AWS profile
@@ -272,6 +272,9 @@ kubecostMetrics:
     serviceMonitor:
       enabled: false
       additionalLabels: {}
+      networkCosts:
+        enabled: false
+        additionalLabels: {}
 
     ## PriorityClassName
     ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
@@ -685,6 +688,10 @@ reporting:
 serviceMonitor:
   enabled: false
   additionalLabels: {}
+  networkCosts:
+    enabled: false
+    scrapeTimeout: 10s
+    additionalLabels: {}
 
 prometheusRule:
   enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -269,13 +269,13 @@ kubecostMetrics:
       annotations: {}
 
     # Service Monitor for Kubecost Metrics
-    serviceMonitor:
+    serviceMonitor: # the kubecost included prometheus uses scrapeConfigs and does not support service monitors. The following options assume an existing prometheus that supports serviceMonitors.
       enabled: false
       additionalLabels: {}
       networkCosts:
         enabled: false
+        scrapeTimeout: 10s
         additionalLabels: {}
-
     ## PriorityClassName
     ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
     priorityClassName: []
@@ -685,7 +685,7 @@ reporting:
   # googleAnalyticsTag is only included in our Enterprise offering.
   # googleAnalyticsTag: G-XXXXXXXXX
 
-serviceMonitor:
+serviceMonitor: # the kubecost included prometheus uses scrapeConfigs and does not support service monitors. The following options assume an existing prometheus that supports serviceMonitors.
   enabled: false
   additionalLabels: {}
   networkCosts:


### PR DESCRIPTION
## What does this PR change?

Add a serviceMonitor for network-costs

## Does this PR rely on any other PRs?

- NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Created serviceMonitor for the network-costs daemonset for users with Prometheus Operator

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1709

## How was this PR tested?

helm install against a test cluster with prometheus operator

## Have you made an update to documentation?

Probably should update https://guide.kubecost.com/hc/en-us/articles/4407595941015-Custom-Prometheus
but have an example here for now: https://github.com/kubecost/poc-common-configurations/blob/main/custom-tsdb/values-primary.yaml#L12