### PR TITLE
whitelist PV usage metrics 

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1263,14 +1263,6 @@ serverFiles:
           - source_labels: [ __name__ ]
             regex: (kubelet_volume_stats_used_bytes)
             action: keep
-          - source_labels: [ container ]
-            target_label: container_name
-            regex: (.+)
-            action: replace
-          - source_labels: [ pod ]
-            target_label: pod_name
-            regex: (.+)
-            action: replace
 
       # Scrape config for service endpoints.
       #

--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1261,7 +1261,7 @@ serverFiles:
 
         metric_relabel_configs:
           - source_labels: [ __name__ ]
-            regex: (kubelet_volume_stats_used_bytes)
+            regex: (kubelet_volume_stats_used_bytes) # this metric is in alpha 
             action: keep
 
       # Scrape config for service endpoints.

--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1216,6 +1216,62 @@ serverFiles:
             regex: (.+)
             action: replace
 
+      # A scrape configuration for running Prometheus on a Kubernetes cluster.
+      # This uses separate scrape configs for cluster components (i.e. API server, node)
+      # and services to allow each to use different authentication configs.
+      #
+      # Kubernetes labels will be added as Prometheus labels on metrics via the
+      # `labelmap` relabeling action.
+
+      - job_name: 'kubernetes-nodes'
+
+        # Default to scraping over https. If required, just disable this or change to
+        # `http`.
+        scheme: https
+
+        # This TLS & bearer token file config is used to connect to the actual scrape
+        # endpoints for cluster components. This is separate to discovery auth
+        # configuration because discovery & scraping are two separate concerns in
+        # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+        # the cluster. Otherwise, more config options have to be provided within the
+        # <kubernetes_sd_config>.
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          # If your node certificates are self-signed or use a different CA to the
+          # master CA, then disable certificate verification below. Note that
+          # certificate verification is an integral part of a secure infrastructure
+          # so this should only be disabled in a controlled environment. You can
+          # disable certificate verification by uncommenting the line below.
+          #
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        kubernetes_sd_configs:
+          - role: node
+
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics
+
+        metric_relabel_configs:
+          - source_labels: [ __name__ ]
+            regex: (kubelet_volume_stats_used_bytes)
+            action: keep
+          - source_labels: [ container ]
+            target_label: container_name
+            regex: (.+)
+            action: replace
+          - source_labels: [ pod ]
+            target_label: pod_name
+            regex: (.+)
+            action: replace
+
       # Scrape config for service endpoints.
       #
       # The relabeling allows the actual service scrape endpoint to be configured


### PR DESCRIPTION
## What does this PR change?
Whitelists `kubelet_volume_stats_used_bytes`


## Does this PR rely on any other PRs?

- [OC#1403](https://github.com/opencost/opencost/pull/1403)
- [KCM#963](https://github.com/kubecost/kubecost-cost-model/pull/963)


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Whitelisted PV usage metrics into Prometheus


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Locally

## Have you made an update to documentation?

