### PR TITLE
Enable ContainerStats pipeline by default

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -650,6 +650,8 @@ spec:
               value: {{ (quote .Values.kubecostModel.etlAssetReconciliationEnabled) | default (quote true) }}
             - name: ETL_USE_UNBLENDED_COST
               value: {{ (quote .Values.kubecostModel.etlUseUnblendedClost) | default (quote false) }}
+            - name: CONTAINER_STATS_ENABLED
+              value: {{ (quote .Values.kubecostModel.containerStatsEnabled) | default (quote true) }}
             - name: RECONCILE_NETWORK
               value: {{ (quote .Values.kubecostModel.reconcileNetwork) | default (quote true) }}
             {{- if .Values.systemProxy.enabled }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -319,6 +319,11 @@ kubecostModel:
   etlHourlyStoreDurationHours: 49
   # For deploying kubecost in a cluster that does not self-monitor
   etlReadOnlyMode: false
+
+  # Enables or disables the ContainerStats pipeline, used for quantile-based
+  # queries like for request sizing recommendations.
+  # containerStatsEnabled: true
+
   # max number of concurrent Prometheus queries
   maxQueryConcurrency: 5
   resources:


### PR DESCRIPTION
## What does this PR change?

Enables the ContainerStats pipeline by default. This is necessary for all users to have access to quantile-based request sizing recommendations while also providing a safety valve (disabling) in case of problems at scale.


## Does this PR rely on any other PRs?

- Pipeline introduced in https://github.com/kubecost/kubecost-cost-model/pull/958
- Relates to https://github.com/kubecost/kubecost-cost-model/pull/968

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Enables the new "container stats" pipeline, used for quantile-based request sizing recommendations. If you need to disable it for any reason, set `kubecostModel.containerStatsEnabled=false`.

## How was this PR tested?
With `helm template`:

```
→ helm template ./cost-analyzer | grep -A 1 'CONTAINER'             - name: CONTAINER_STATS_ENABLED
              value: "true"
```

```
→ helm template ./cost-analyzer --set kubecostModel.containerStatsEnabled=true | grep -A 1 'CONTAINER'
            - name: CONTAINER_STATS_ENABLED
              value: "true"
```

```
→ helm template ./cost-analyzer --set kubecostModel.containerStatsEnabled=false | grep -A 1 'CONTAINER'
            - name: CONTAINER_STATS_ENABLED
              value: "false"
```
