### PR TITLE
Wrap nested call for gcpSecretName

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -463,9 +463,11 @@ spec:
                   key: prometheus-server-endpoint
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
+            {{- if .Values.kubecostProductConfigs }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/configs/key.json
+            {{- end }}
             {{- end }}
             - name: CONFIG_PATH
               value: /var/configs/


### PR DESCRIPTION
## What does this PR change?
Minor bug fix - wrap nested call for `.Values.kubecostProductConfigs.gcpSecretName`

## Does this PR rely on any other PRs?
No 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Bug fix

## Links to Issues or ZD tickets this PR addresses or fixes
N/A

## How was this PR tested?
Introducing the modification stopped error `nil pointer evaluating interface {}.gcpSecretName` from appearing

## Have you made an update to documentation?
N/A