### PR TITLE
 A note to google's API key 

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -463,7 +463,7 @@ spec:
                   key: prometheus-server-endpoint
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
-                                                               # This GCP api key is expected to be there and is limited to accessing googles billing API. 
+                                                               # This GCP api key is expected to be here and is limited to accessing google's billing API. 
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/configs/key.json
             - name: CONFIG_PATH

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -463,6 +463,7 @@ spec:
                   key: prometheus-server-endpoint
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
+                                                               # This GCP api key is expected to be there and is limited to accessing googles billing API. 
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/configs/key.json
             - name: CONFIG_PATH

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -462,9 +462,7 @@ spec:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: prometheus-server-endpoint
             - name: CLOUD_PROVIDER_API_KEY
-              value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
-
-                                                               # This GCP api key is expected to be here and is limited to accessing google's billing API. 
+              value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API key.This GCP api key is expected to be here and is limited to accessing google's billing API.
             {{- if .Values.kubecostProductConfigs }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
 


### PR DESCRIPTION
## What does this PR change?
Added note to google's API that it is intentional and limited only to googles API billing


## Does this PR rely on any other PRs?
NO
- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

This will avoid confusion for the users and they will be noted the google API key is hardcoded intentionally not a mistake

## Links to Issues or ZD tickets this PR addresses or fixes
https://kubecost.zendesk.com/agent/tickets/2703
- 
- 


## How was this PR tested?


## Have you made an update to documentation?
Not yet, this note has to be added newly to our documentation
