### PR TITLE
add ports to cost-analyzer deployment

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -278,7 +278,7 @@ spec:
           {{- if .Values.sigV4Proxy.role_arn }}
           - --role-arn
           - {{ .Values.sigV4Proxy.role_arn }}
-          {{- end }}          
+          {{- end }}
           - --port
           - :{{ .Values.sigV4Proxy.port }}
           ports:
@@ -312,6 +312,13 @@ spec:
         {{- else }}
           imagePullPolicy: Always
         {{- end }}
+          ports:
+          - name: tcp-model
+            containerPort: 9090
+            protocol: TCP
+          - name: tcp-frontend
+            containerPort: 9003
+            protocol: TCP
           resources:
 {{ toYaml .Values.kubecostModel.resources | indent 12 }}
           readinessProbe:


### PR DESCRIPTION
## Background

Port definitions for k8s deployments are optional and simply informative. When available, this allows tools like Lens to see the ports from the pods screen and forward from there. 

This was a customer request.

## What does this PR change?

Add port definitions to cost-model container. 
I realize that these ports are for the cost-analyzer-frontend. I put them on cost-model so you don't have to scroll all the way down in Lens to find the ports. 

## Does this PR rely on any other PRs?

NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows certain tools to discover the ports and forward them easily

## How was this PR tested?

helm upgrade with local chart. Verified in Lens that it has the intended effect. 

## Have you made an update to documentation?

NA

# Screenshot
![image](https://user-images.githubusercontent.com/31039225/194930298-a8a00ba7-722a-45e2-a3c4-b3dc16c90ca2.png)
