### PR TITLE
Network Costs 16.2 Upgrade

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -560,7 +560,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v16.0
+  image: gcr.io/kubecost1/kubecost-network-costs:v16.2
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
## What does this PR change?
* Adds new version of network-costs, which addresses an issue with Azure Service tracking and a small parsing error in flag parsing on certain host kernels. 



