### PR TITLE
[networkcosts] Fix default loopback range to include all loopback...

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -588,8 +588,8 @@ networkCosts:
       # In Zone contains a list of address/range that will be
       # classified as in zone.
       in-zone:
-        # Loopback
-        - "127.0.0.1"
+        # Loopback Addresses in "IANA IPv4 Special-Purpose Address Registry"
+        - "127.0.0.0/8"
         # IPv4 Link Local Address Space
         - "169.254.0.0/16"
         # Private Address Ranges in RFC-1918


### PR DESCRIPTION
… addresses

## What does this PR change?

Updates the loopback address in the `in-zone` classification to include the entire loopback range as registered in IANA.

### Authoritative Sources
IANA IPv4 Address Space Registry: https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml#:~:text=False-,127.0.0.0/8,-Loopback
IANA IPv4 Special-Purpose Address Registry: https://www.iana.org/assignments/ipv4-address-space/ipv4-address-space.xhtml#:~:text=ALLOCATED-,127/8,-IANA%20%2D%20Loopback

## Does this PR rely on any other PRs?

No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Some systems use other loopback addresses such as `127.0.0.53` (for some DNS resolvers), `127.1.0.1`, etc. This change will now classify all addresses in the `127.0.0.0/8` range as `in-zone` by default.

## Links to Issues or ZD tickets this PR addresses or fixes

N/A.

## How was this PR tested?

Not tested. I would like some help testing this. I will also try to run a similar config in the next few days and update here once that is done.

## Have you made an update to documentation?

Yes.