### PR TITLE
Move Kubecost deployment strategy configuration to values.yaml

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -19,8 +19,16 @@ spec:
     matchLabels:
 {{ include "cost-analyzer.selectorLabels" . | nindent 8}}
 {{- if .Values.kubecostDeployment }}
+{{- if .Values.kubecostDeployment.deploymentStrategy }}
 {{- with .Values.kubecostDeployment.deploymentStrategy }}
   strategy: {{ toYaml . | nindent 4 }}
+{{- end }}
+{{- else }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
 {{- end }}
 {{- end }}
   template:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -18,11 +18,11 @@ spec:
   selector:
     matchLabels:
 {{ include "cost-analyzer.selectorLabels" . | nindent 8}}
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
+{{- if .Values.kubecostDeployment }}
+{{- with .Values.kubecostDeployment.deploymentStrategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}
   template:
     metadata:
       labels:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -668,6 +668,8 @@ kubecostDeployment:
   replicas: 1
   leaderFollower:
     enabled: false
+  deploymentStrategy:
+    type: RollingUpdate
 
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -668,8 +668,11 @@ kubecostDeployment:
   replicas: 1
   leaderFollower:
     enabled: false
-  deploymentStrategy:
-    type: RollingUpdate
+  # deploymentStrategy:
+  #   rollingUpdate:
+  #     maxSurge: 1
+  #     maxUnavailable: 1
+  #   type: RollingUpdate
 
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:


### PR DESCRIPTION
## What does this PR change?
It changes the cost-analyzer pod to not use a static deployment strategy. Rather, it allows the user to define their own deployment strategy from within the values.yaml. 

**NOTE:** The deployment strategy does slightly differ from what is currently live. This is because I had to leave the following snippet out or you would get an error when trying to use any other `type` than "RollingUpdate". This is still able to be modified manually in the values.yaml.

```
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
```

```
❯ helm upgrade kubecost ./cost-analyzer --set kubecostDeployment.deploymentStrategy.type=Recreate
Error: UPGRADE FAILED: cannot patch "kubecost-cost-analyzer" with kind Deployment: Deployment.apps "kubecost-cost-analyzer" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

## Does this PR rely on any other PRs?
N/a

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Added option to customize the deployment strategy for the cost-analyzer pod.


## Links to Issues or ZD tickets this PR addresses or fixes
- Closes #1615 
- Adds a solution for #1431 

## How was this PR tested?
After installing Kubecost using the default strategy, you can verify the "RollingUpdate" type is defaulted using the following: 

```
❯ kubectl get deploy -l app=cost-analyzer -ojsonpath="{.items[0].spec.strategy}"
{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}% 
```

Next, upgrade using the new set flag and re-check the strategy:

```
❯ helm upgrade kubecost ./cost-analyzer --set kubecostDeployment.deploymentStrategy.type=Recreate
Release "kubecost" has been upgraded. Happy Helming!
NAME: kubecost
LAST DEPLOYED: Mon Oct 17 18:47:27 2022
NAMESPACE: kubecost
STATUS: deployed
REVISION: 9
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed.

Please allow 5-10 minutes for Kubecost to gather metrics.

If you have configured cloud-integrations, it can take up to 48 hours for cost reconciliation to occur.

When using Durable storage (Enterprise Edition), please allow up to 4 hours for data to be collected and the UI to be healthy.

When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090

Next, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install

❯ kubectl get deploy -l app=cost-analyzer -ojsonpath="{.items[0].spec.strategy}"
{"type":"Recreate"}%                        
```

## Have you made an update to documentation?
No
