### PR TITLE
Soft Memory Limit Field

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -383,6 +383,10 @@ spec:
             - name: APP_CONFIGMAP_NAME
               value: {{ .Values.appConfigmapName }}
             {{- end }}
+            {{- if .Values.kubecostModel.softMemoryLimit }}
+            - name: GOMEMLIMIT
+              value: {{ .Values.kubecostModel.softMemoryLimit }}
+            {{- end }}
             {{- if .Values.assetReportConfigmapName }}
             - name: ASSET_REPORT_CONFIGMAP_NAME
               value: {{ .Values.assetReportConfigmapName }}


### PR DESCRIPTION
## What does this PR change?
* Adds a `kubecostModel.softMemoryLimit` field which sets the `GOMEMLIMIT` flag for the cost-model backend. 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Users can optionally enable impactful memory thresholds to ensure the Go runtime GC throttles at more aggressive frequencies at or approaching the soft limit. For example, examining that the cost-analyzer pod can reach `1GiB` of memory during high usage periods, but can idle as low as `250MiB`. Setting the `kubecostModel.softMemoryLimit=500MiB` may keep the pod's memory from surpassing 500MiB. 
* There is not a one-size fits all value here, and users looking to tune the parameters should be aware that lower values may reduce overall performance if setting the value too low. If users set the the `resources.requests` memory values appropriately, using the same value for `softMemoryLimit` is advisable, as this will instruct the go runtime to keep it's heap acquisition and release within the same bounds as the expectations of the pod memory use. 
* More on this environment variable can be found here: https://tip.golang.org/doc/gc-guide  

## How was this PR tested?
```
helm3 template kubecost --namespace=kubecost ./cost-analyzer -f ./cost-analyzer/values.yaml --set kubecostModel.softMemoryLimit=40GiB > temp.yaml
```

Output:
```
 - name: GOMEMLIMIT
    value: 40GiB
```
