### PR TITLE
Disable ContainerStats pipeline by default

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -707,7 +707,7 @@ spec:
             - name: ETL_USE_UNBLENDED_COST
               value: {{ (quote .Values.kubecostModel.etlUseUnblendedClost) | default (quote false) }}
             - name: CONTAINER_STATS_ENABLED
-              value: {{ (quote .Values.kubecostModel.containerStatsEnabled) | default (quote true) }}
+              value: {{ (quote .Values.kubecostModel.containerStatsEnabled) | default (quote false) }}
             - name: RECONCILE_NETWORK
               value: {{ (quote .Values.kubecostModel.reconcileNetwork) | default (quote true) }}
             {{- if .Values.systemProxy.enabled }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -326,7 +326,16 @@ kubecostModel:
 
   # Enables or disables the ContainerStats pipeline, used for quantile-based
   # queries like for request sizing recommendations.
-  # containerStatsEnabled: true
+  # ContainerStats provides support for quantile-based request right-sizing
+  # recommendations.
+  #
+  # It is disabled by default to avoid problems in extremely high-scale Thanos
+  # environments. If you would like to try quantile-based request-sizing
+  # recommendations, enable this! If you are in a high-scale environment,
+  # please monitor Kubecost logs, Thanos query logs, and Thanos load closely.
+  # We hope to make major improvements at scale here soon!
+  #
+  # containerStatsEnabled: false
 
   # max number of concurrent Prometheus queries
   maxQueryConcurrency: 5


### PR DESCRIPTION
## What does this PR change?
Access to the scale cluster, combined with a last-minute discovery fix for ContainerStats's multi-cluster support, lead to us discovering that standard ContainerStats build logic is untenable at scale because it loads all CPU and RAM data points for all containers over a 24h period. While we work on improving this, we are disabling it by default.

## Relates to other PRs
- Pairs with: https://github.com/kubecost/cost-analyzer-frontend/pull/1296
- Docs update: https://github.com/kubecost/docs/pull/430


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- NA/Modification to v1.98 release notes about ContainerStats. Will consult w/ buildmaster directly.


## How was this PR tested?

Default
```
→ helm template ./cost-analyzer | grep -A 1 'CONTAINER'
            - name: CONTAINER_STATS_ENABLED
              value: "false"
```

Override
```
→ helm template ./cost-analyzer --set kubecostModel.containerStatsEnabled=true | grep -A 1 'CONTAINER'
            - name: CONTAINER_STATS_ENABLED
              value: "true"
```


## Have you made an update to documentation?
Documentation is in this PR