### PR TITLE
Jesse readonlyfilesystem

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -78,8 +78,8 @@ spec:
             defaultMode: 420
             secretName: kubecost-thanos
       {{- end }}
-        - emptyDir: {}
-          name: tmp
+        - name: tmp
+          emptyDir: {}
         - name: nginx-conf
           configMap:
             name: nginx-conf
@@ -324,6 +324,10 @@ spec:
           args:
           {{- toYaml .Values.kubecostModel.extraArgs | nindent 12 }}
         {{- end }}
+          securityContext:
+          {{- if .Values.kubecostModel.securityContext -}}
+          {{ toYaml .Values.kubecostModel.securityContext | nindent 12 }}
+          {{- end }}
         {{- if .Values.kubecostModel.imagePullPolicy }}
           imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}
         {{- else }}
@@ -923,7 +927,9 @@ spec:
             {{- end }}
           name: cost-analyzer-frontend
           securityContext:
-            readOnlyRootFilesystem: true
+          {{- if .Values.kubecostFrontend.securityContext -}}
+          {{ toYaml .Values.kubecostFrontend.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -78,6 +78,8 @@ spec:
             defaultMode: 420
             secretName: kubecost-thanos
       {{- end }}
+        - emptyDir: {}
+          name: tmp
         - name: nginx-conf
           configMap:
             name: nginx-conf
@@ -920,7 +922,11 @@ spec:
             {{ toYaml .Values.kubecostFrontend.extraEnv | nindent 12 }}
             {{- end }}
           name: cost-analyzer-frontend
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: nginx-conf
               mountPath: /etc/nginx/conf.d/
             {{- if .Values.kubecostFrontend.tls }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -324,10 +324,10 @@ spec:
           args:
           {{- toYaml .Values.kubecostModel.extraArgs | nindent 12 }}
         {{- end }}
+        {{- if .Values.kubecostModel.securityContext }}
           securityContext:
-          {{- if .Values.kubecostModel.securityContext -}}
-          {{ toYaml .Values.kubecostModel.securityContext | nindent 12 }}
-          {{- end }}
+            {{- toYaml .Values.kubecostModel.securityContext | nindent 12 -}}
+        {{ end }}
         {{- if .Values.kubecostModel.imagePullPolicy }}
           imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}
         {{- else }}
@@ -926,10 +926,10 @@ spec:
             {{ toYaml .Values.kubecostFrontend.extraEnv | nindent 12 }}
             {{- end }}
           name: cost-analyzer-frontend
+        {{- if .Values.kubecostFrontend.securityContext }}
           securityContext:
-          {{- if .Values.kubecostFrontend.securityContext -}}
-          {{ toYaml .Values.kubecostFrontend.securityContext | nindent 12 }}
-          {{- end }}
+            {{- toYaml .Values.kubecostFrontend.securityContext | nindent 12 }}
+        {{ end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -218,6 +218,8 @@ kubecostFrontend:
   # extraEnv:
   # - name: NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE
   #   value: "1"
+  # securityContext:
+  #   readOnlyRootFilesystem: true
   resources:
     requests:
       cpu: "10m"
@@ -304,6 +306,8 @@ kubecostModel:
   # extraEnv:
   # - name: SOME_VARIABLE
   #   value: "some_value"
+  # securityContext:
+  #   readOnlyRootFilesystem: true
   # Enables the emission of the kubecost_cloud_credit_total and
   # kubecost_cloud_expense_total metrics
   outOfClusterPromMetricsEnabled: false
@@ -760,12 +764,12 @@ awsstore:
 
 federatedETL:
   # federatedCluster indicates whether this cluster should push data to the Federated store
-  federatedCluster: false 
+  federatedCluster: false
   # primaryCluster indicates whether this cluster should load data from the combined section of the Federated store
-  primaryCluster: false 
+  primaryCluster: false
   # redirectS3Backup changes the dir of S3 backup to the Federated combined store, for using Thanos-federated data in the Federated ETL
   # Note S3 backup should be enabled separately for this.
-  redirectS3Backup: false 
+  redirectS3Backup: false
   # useExistingS3Config will attempt to use existing object-store.yaml configs for S3 backup/Thanos as config for the Federated store
   useExistingS3Config: false
   federator:


### PR DESCRIPTION
## What does this PR change?

Add ability to set pod securityContext for cost-model and cost-analyzer-frontend

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Added ability to set pod securityContext for cost-model and cost-analyzer-frontend via helm template.
Added helm values to enable readOnlyRootFilesystem for both kubecostFrontend and kubecostModel

```
--set kubecostModel.securityContext.readOnlyRootFilesystem=true
--set kubecostFrontend.securityContext.readOnlyRootFilesystem=true
```

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1403

## How was this PR tested?
```
helm upgrade kubecost ~/git/cost-analyzer-helm-chart/cost-analyzer -n kubecost \
 --set imageVersion=prod-1.97.0 \
 --set kubecostFrontend.securityContext.readOnlyRootFilesystem=true \
 --set kubecostModel.securityContext.readOnlyRootFilesystem=true
```

## Have you made an update to documentation?

Not yet, is this needed?