### PR TITLE
Upgrade Thanos subchart v0.24 -> v0.29

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -20,4 +20,4 @@ dependencies:
   - condition: global.thanos.enabled
     name: thanos
     repository: file://./charts/thanos
-    version: "~0.28.1"
+    version: "~0.29.0"

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "1.92.0"
+appVersion: "1.97.0"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer
-version: "1.92.0"
+version: "1.97.0"
 annotations:
   "artifacthub.io/links": |
     - name: Homepage
@@ -20,4 +20,4 @@ dependencies:
   - condition: global.thanos.enabled
     name: thanos
     repository: file://./charts/thanos
-    version: "~0.24.0"
+    version: "~0.28.1"

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "1.97.0"
+appVersion: "1.92.0"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer
-version: "1.97.0"
+version: "1.92.0"
 annotations:
   "artifacthub.io/links": |
     - name: Homepage

--- a/cost-analyzer/charts/thanos/Chart.yaml
+++ b/cost-analyzer/charts/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.24.0
+appVersion: 0.28.1
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.24.0
+version: 0.28.1
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/cost-analyzer/charts/thanos/Chart.yaml
+++ b/cost-analyzer/charts/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.28.1
+appVersion: 0.29.0
 description: Thanos is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 name: thanos
 keywords:
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/thanos-io/thanos
   - https://github.com/banzaicloud/banzai-charts/tree/master/thanos
-version: 0.28.1
+version: 0.29.0
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/website/static/Thanos-logo_full.svg
 maintainers:
 - name: Banzai Cloud

--- a/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
@@ -60,7 +60,6 @@ spec:
         - "--retention.resolution-raw={{ .Values.compact.retentionResolutionRaw }}"
         - "--retention.resolution-5m={{ .Values.compact.retentionResolution5m }}"
         - "--retention.resolution-1h={{ .Values.compact.retentionResolution1h }}"
-        - "--block-sync-concurrency={{ .Values.compact.blockSyncConcurrency }}"
         - "--compact.concurrency={{ .Values.compact.compactConcurrency }}"
 {{- if .Values.compact.disableDownsampling }}
         - "--downsampling.disable"

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: thanosio/thanos
-  tag: v0.24.0
+  tag: v0.28.1
   pullPolicy: IfNotPresent
 
 store:
@@ -530,8 +530,6 @@ compact:
   retentionResolution1h: 1825d
   # Number of goroutines to use when compacting groups.
   compactConcurrency: 1
-  # Number of goroutines to use when syncing block metadata from object storage.
-  blockSyncConcurrency: 20
   # Disables Downsampling data
   disableDownsampling: false
   # Log filtering level.

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: thanosio/thanos
-  tag: v0.28.1
+  tag: v0.29.0
   pullPolicy: IfNotPresent
 
 store:

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -28,7 +28,7 @@ prometheus:
     enableAdminApi: true
     sidecarContainers:
     - name: thanos-sidecar
-      image: thanosio/thanos:v0.28.1
+      image: thanosio/thanos:v0.29.0
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -28,7 +28,7 @@ prometheus:
     enableAdminApi: true
     sidecarContainers:
     - name: thanos-sidecar
-      image: thanosio/thanos:v0.24.0
+      image: thanosio/thanos:v0.28.1
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001


### PR DESCRIPTION
## What does this PR change?

This change primarily bumps the Thanos image version from v0.24 -> v0.29 in our existing Thanos subchart. In the process, there were some additional changes that needed to be made:

- remove the `blockSyncConcurrency` argument for the `thanos-compact` deployment since it was [deprecated in v0.27](https://thanos.io/v0.21/thanos/changelog.md/#removed-2).

It would be good to monitor this change in nightly for an extended amount of time before potentially releasing this change in Kubecost v1.99.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

For most users, there will be minimal impact. If they were setting up special configs for Thanos, it's possible that their configs will not be backwards compatible in this new version of Thanos.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1758

## How was this PR tested?

Deployed to my local Thanos cluster and monitor logs for any outlier error messages.

## Have you made an update to documentation?

Not yet. However I don't believe this requires an addition to https://docs.kubecost.com.

