### PR TITLE
Set remote_write conditionally in server-configmap.yaml - fix issue 1784

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/server-configmap.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-configmap.yaml
@@ -14,13 +14,14 @@ data:
 {{- if eq $key "prometheus.yml" }}
     global:
 {{ $root.Values.server.global | toYaml | trimSuffix "\n" | indent 6 }}
-    remote_write:
 {{- if $root.Values.global.amp.enabled }}
+    remote_write:
     - url: {{ $root.Values.global.amp.remoteWriteService }}
       sigv4:
 {{ $root.Values.global.amp.sigv4 | toYaml | indent 8 }}
 {{- end }}
 {{- if $root.Values.server.remoteWrite }}
+    remote_write:
 {{ $root.Values.server.remoteWrite | toYaml | indent 4 }}
 {{- end }}
 {{- if $root.Values.server.remoteRead }}


### PR DESCRIPTION
## What does this PR change?

Fix the bug that is described in https://github.com/kubecost/cost-analyzer-helm-chart/issues/1784
This PR is to set `remote_write:` conditionally in [server_configmap.yaml version: 1.98](https://github.com/kubecost/cost-analyzer-helm-chart/blob/releasebot/master-release-v1.98.0/cost-analyzer/charts/prometheus/templates/server-configmap.yaml#L17-L25)

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

It helps to set `remote_write:` conditionally in [server_configmap.yaml version: 1.98](https://github.com/kubecost/cost-analyzer-helm-chart/blob/releasebot/master-release-v1.98.0/cost-analyzer/charts/prometheus/templates/server-configmap.yaml#L17-L25) to fix this bug [server_configmap.yaml version: 1.98](https://github.com/kubecost/cost-analyzer-helm-chart/blob/releasebot/master-release-v1.98.0/cost-analyzer/charts/prometheus/templates/server-configmap.yaml#L17-L25) 

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1784

## How was this PR tested?

- `Helm template` to verify the generated manifests
- Deployment test with AMP integration using the following script:

```
export YOUR_CLUSTER_NAME=<CLUSTER_NAME>
export AWS_REGION=us-west-2
export AMP_WORKSPACE_ID=<WS_ID>
export REMOTEWRITEURL="https://aps-workspaces.us-west-2.amazonaws.com/workspaces/${AMP_WORKSPACE_ID}/api/v1/remote_write"
export QUERYURL="http://localhost:8005/workspaces/${AMP_WORKSPACE_ID}"

helm install kubecost https://github.com/linhlam-kc/cost-analyzer/raw/gh-pages/cost-analyzer-1.98.0-issue-1784 -n kubecost

eksctl create iamserviceaccount \
    --name kubecost-cost-analyzer \
    --namespace kubecost \
    --cluster ${YOUR_CLUSTER_NAME} --region ${AWS_REGION} \
    --attach-policy-arn arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess \
    --attach-policy-arn arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess \
    --override-existing-serviceaccounts \
    --approve

eksctl create iamserviceaccount \
    --name kubecost-prometheus-server \
    --namespace kubecost \
    --cluster ${YOUR_CLUSTER_NAME} --region ${AWS_REGION} \
    --attach-policy-arn arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess \
    --attach-policy-arn arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess \
    --override-existing-serviceaccounts \
    --approve

helm upgrade -i kubecost \
https://github.com/linhlam-kc/cost-analyzer/raw/gh-pages/cost-analyzer-1.98.0-issue-1784 \
--namespace kubecost --create-namespace \
-f https://tinyurl.com/kubecost-amp \
--set global.amp.prometheusServerEndpoint=${QUERYURL} \
--set global.amp.remoteWriteService=${REMOTEWRITEURL} \
--set kubecostProductConfigs.clusterName=${YOUR_CLUSTER_NAME} \
--set prometheus.server.global.external_labels.cluster_id=${YOUR_CLUSTER_NAME}


kubectl rollout restart deployment/kubecost-prometheus-server -n kubecost
```

## Have you made an update to documentation?

- N/A - Documentation is not required to be updated

cc @AjayTripathy 