### PR TITLE
fix kubecost metrics service wrong app label

### DIFF
--- a/cost-analyzer/templates/kubecost-metrics-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-template.yaml
@@ -7,7 +7,8 @@ kind: Service
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
   labels:
-{{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{ unset (include "cost-analyzer.commonLabels" . | fromYaml) "app" | toYaml | nindent 4 }}
+    app: {{ template "kubecost.kubeMetricsName" . }}
 {{- if (or .Values.kubecostMetrics.exporter.service.annotations $prometheusScrape) }}
   annotations:
 {{- if .Values.kubecostMetrics.exporter.service.annotations }}


### PR DESCRIPTION
## What does this PR change?

Teste 1.98 helm chart and serviceMonitor for metrics service targets `app=cost-analyzer` label and it should target `app=$name-metrics` label.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
If using custom Prometheus with operator it cannot scrape kubecost metrics pod using serviceMonitor.

## How was this PR tested?
Installed helm chart on k8s cluster with existing prometheus operator. Also rendered helm value to test the change.

Before:
```
---
# Source: cost-analyzer/templates/kubecost-metrics-service-template.yaml
apiVersion: v1
kind: Service
metadata:
  name: kubecost-metrics
  labels:

    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.98.0
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer

```
Now:
```
---
# Source: cost-analyzer/templates/kubecost-metrics-service-template.yaml
apiVersion: v1
kind: Service
metadata:
  name: kubecost-metrics
  labels:

    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.98.0
    app: kubecost-metrics

```

## Have you made an update to documentation?
No
