### PR TITLE
bump default values.yaml prometheus scrape_timeout

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -492,7 +492,7 @@ prometheus:
     #   memory: 512Mi
     global:
       scrape_interval: 1m
-      scrape_timeout: 10s
+      scrape_timeout: 60s
       evaluation_interval: 1m
       external_labels:
         cluster_id: cluster-one # Each cluster should have a unique ID


### PR DESCRIPTION
## What does this PR change?
A previous [PR](https://github.com/kubecost/cost-analyzer-helm-chart/pull/1633) bumped the scrape_timeout in the Prometheus sub chart, but it was still set in the primary values.yaml, causing it to be overwritten. This updates the default values.yaml, as well.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Bump default Prometheus scrape timeout to 60s.