### PR TITLE
Removed unauthorized.html route in nginx.

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -114,9 +114,6 @@ data:
 
 {{- if or .Values.saml.enabled .Values.oidc.enabled }}
         add_header Cache-Control "max-age=0";
-        location /unauthorized.html {
-
-        }
         location / {
             auth_request /auth;
             proxy_redirect off;


### PR DESCRIPTION
## What does this PR change? 
Removes the /unauthorized.html route from SAML nginx config. This route isn't necessary with SPA now, and currently returns a broken 401 page.


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will now see the /unauthorized page on Kubecost, as opposed to a broken 401 nginx page.


## Links to Issues or ZD tickets this PR addresses or fixes
None

## How was this PR tested?
Manually

## Have you made an update to documentation?
No
