### PR TITLE
Update kubecost-metrics-deployment-template.yaml due to missing condition

### DIFF
--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -187,9 +187,11 @@ spec:
                   key: prometheus-server-endpoint
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
+            {{- if .Values.kubecostProductConfigs }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/configs/key.json
+            {{- end }}
             {{- end }}
             - name: CONFIG_PATH
               value: /var/configs/


### PR DESCRIPTION
## What does this PR change?
Fix bug caused by missing condition on kubecost-metrics-deployment-template.yaml

## Does this PR rely on any other PRs?
No

## How was this PR tested?
With `helm template`.

## Have you made an update to documentation?
Not necessary.
