### PR TITLE
Add values for kubescaler

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -209,9 +209,11 @@ spec:
           value: {{ .Release.Namespace }}
         - name: TURNDOWN_DEPLOYMENT
           value: {{ template "kubecost.clusterControllerName" . }}
+        {{- if .Values.kubecostProductConfigs }}
         {{- if .Values.kubecostProductConfigs.gcpSecretName }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/keys/service-key.json
+        {{- end }}
         {{- end }}
         ports:
         - name: http-server

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.clusterController }}
 {{- if .Values.clusterController.enabled }}
+{{- $serviceName := include "cost-analyzer.serviceName" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -214,6 +215,14 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/keys/service-key.json
         {{- end }}
+        {{- end }}
+        - name: CC_LOG_LEVEL
+          value: {{ .Values.clusterController.logLevel | default "info" }}
+        - name: CC_KUBESCALER_COST_MODEL_PATH
+          value: {{ $serviceName }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort | default 9090 }}/model
+        {{- if .Values.clusterController.kubescaler }}
+        - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
+          value: {{ .Values.clusterController.kubescaler.defaultResizeAll | default false }}
         {{- end }}
         ports:
         - name: http-server

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -691,7 +691,7 @@ kubecostDeployment:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.1.0
+  image: gcr.io/kubecost1/cluster-controller:v0.2.0
   imagePullPolicy: Always
 #  fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -693,6 +693,10 @@ clusterController:
   enabled: false
   image: gcr.io/kubecost1/cluster-controller:v0.2.0
   imagePullPolicy: Always
+  kubescaler:
+    # If true, will cause all (supported) workloads to be have their requests
+    # automatically right-sized on a regular basis.
+    defaultResizeAll: false
 #  fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
 
 reporting:


### PR DESCRIPTION
## What does this PR change?

Adds Helm values to configure the new "Kubescaler" component of cluster-controller. See linked PR and issue.

## Does this PR rely on any other PRs?
- Requires https://github.com/kubecost/cluster-controller/pull/14


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Introduces the "Kubescaler" component to cluster-controller. Visit the official docs (TODO) to learn more about how to use this feature!


## Links to Issues or ZD tickets this PR addresses or fixes

- Capstone of the "Necessary" steps of https://github.com/kubecost/kubecost-cost-model/issues/1063


## How was this PR tested?

```
→ helm template kubecost ./cost-analyzer --set clusterController.enabled=true | grep -A 1 'CC_'
```
```
        - name: CC_LOG_LEVEL
          value: info
        - name: CC_KUBESCALER_COST_MODEL_PATH
          value: kubecost-cost-analyzer.default:9090/model
        - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
          value: false
```

```
→ helm template kubecost ./cost-analyzer \
    --set clusterController.enabled=true \
    --set clusterController.logLevel='debug' \
    --set clusterController.kubescaler.defaultResizeAll=true \
    | grep -A 1 'CC_'
```
```
        - name: CC_LOG_LEVEL
          value: debug
        - name: CC_KUBESCALER_COST_MODEL_PATH
          value: kubecost-cost-analyzer.default:9090/model
        - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
          value: true
```

## Have you made an update to documentation?

- https://github.com/kubecost/docs/pull/446
