### PR TITLE
Adjust bundled Prometheus to scrape for only essential metrics

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1284,6 +1284,9 @@ serverFiles:
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
             action: keep
             regex: true
+          - source_labels: [__meta_kubernetes_endpoints_name]
+            action: keep
+            regex: (kubecost-kube-state-metrics|kubecost-prometheus-node-exporter|kubecost-network-costs)
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
             action: replace
             target_label: __scheme__


### PR DESCRIPTION
## What does this PR change?

The `scrape_config` titled `kubernetes-service-endpoints` currently attempts to scrape all service endpoints available in the cluster which include the `prometheus.io/scrape: true` annotation

Because Kubecost only needs metrics from `kubecost-kube-state-metrics`, `kubecost-prometheus-node-exporter`, and `kubecost-network-costs` ... Prometheus is scraping more than it needs to. This results in duplicate metrics, and errors when attempting to scrape a service endpoint which it doesn't have permissions to scrape.

This PR adds a filter in the `kubernetes-service-endpoints` `scrape_config` so that it is only scraping for the metrics required by Kubecost.

<img width="1469" alt="prometheus" src="https://user-images.githubusercontent.com/11251627/201805023-4c47d87a-9f65-4ae6-8a5b-f160fc31e3d3.png">

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

If users were querying any metrics from Kubecost’s bundled prometheus that are not listed here: [https://github.com/kubecost/docs/blob/main/user-metrics.md](https://github.com/kubecost/docs/blob/main/user-metrics.md), they will be affected.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1742

## How was this PR tested?

Using the following `values.yaml`, I verified on the Prometheus server that all metrics endpoints required by Kubecost were still being scraped, while all excess metrics endpoints (e.g. `kube-dns`) were no longer scraped.

`kubectl port-forward svc/kubecost-prometheus-server 8080:80`

```yaml
# values.yaml
kube-state-metrics:
  enabled: true
nodeExporter:
  enabled: true
networkCosts:
  enabled: true
```

## Have you made an update to documentation?

No
