### PR TITLE
Optional Heap Monitoring for Next Network Costs Release

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -61,8 +61,22 @@ spec:
           value: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
         - name: TRAFFIC_LOGGING_ENABLED
           value: {{ (quote .Values.networkCosts.trafficLogging) | default (quote true) }}
-        - name: GODEBUG
-          value: "madvdontneed=1"
+        {{- if .Values.networkCosts.softMemoryLimit }}
+        - name: GOMEMLIMIT
+          value: {{ .Values.networkCosts.softMemoryLimit }}
+        {{- end }}
+        {{- if .Values.networkCosts.heapMonitor }}
+        {{- if .Values.networkCosts.heapMonitor.enabled }}
+        - name: HEAP_MONITOR_ENABLED
+          value: "true"
+        - name: HEAP_MONITOR_THRESHOLD
+          value: {{ .Values.networkCosts.heapMonitor.threshold }}
+        {{- if .Values.networkCosts.heapMonitor.outFile }}
+        - name: HEAP_MONITOR_OUTPUT
+          value: {{ .Values.networkCosts.heapMonitor.outFile }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.networkCosts.hostProc }}
         - mountPath: {{ .Values.networkCosts.hostProc.mountPath }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -574,7 +574,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v16.2
+  image: gcr.io/kubecost1/kubecost-network-costs:v16.3
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate
@@ -586,6 +586,7 @@ networkCosts:
   # Traffic Logging will enable logging the top 5 destinations for each source
   # every 30 minutes.
   trafficLogging: true
+  
   # Port will set both the containerPort and hostPort to this value.
   # These must be identical due to network-costs being run on hostNetwork
   port: 3001


### PR DESCRIPTION
## What does this PR change?
* Adds a poor man's heap monitoring solution for the network costs pod which will log a warning and write out a heap dump if total heap memory surpasses a specific threshold