### PR TITLE
CPU limit on network-cost DS

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -47,6 +47,13 @@ spec:
 {{- if .Values.networkCosts.resources }}
         resources:
 {{ toYaml .Values.networkCosts.resources | indent 10 }}
+{{- else }}
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 50m
+            memory: 20Mi
 {{- end }}
         env:
         {{- if .Values.networkCosts.hostProc }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -586,14 +586,18 @@ networkCosts:
   # Traffic Logging will enable logging the top 5 destinations for each source
   # every 30 minutes.
   trafficLogging: true
-  
+
   # Port will set both the containerPort and hostPort to this value.
   # These must be identical due to network-costs being run on hostNetwork
   port: 3001
-  resources: {}
-    #requests:
-    #  cpu: "50m"
-    #  memory: "20Mi"
+  # this daemonset can use significant resources on large clusters: https://guide.kubecost.com/hc/en-us/articles/4407595973527-Network-Traffic-Cost-Allocation
+  resources:
+    limits:
+      cpu: 500m # can be less, will depend on cluster size
+      # memory: it is not recommended to set a memory limit
+    requests:
+     cpu: 50m
+     memory: 20Mi
   extraArgs: []
   config:
     # Configuration for traffic destinations, including specific classification


### PR DESCRIPTION
## What does this PR change?

Add default request and limits to network costs daemonset to reduce CPU usage under load. 

See discussion here: https://github.com/kubecost/docs/pull/447

## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Add default 500m CPU limit to reduce CPU usage on network cost daemonset

## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Helm install on test cluster, 
```
k describe ds kubecost2-network-costs |grep Limit -A4
    Limits:
      cpu:  500m
    Requests:
      cpu:     50m
      memory:  20Mi
```
## Have you made an update to documentation?

https://github.com/kubecost/docs/pull/447