### PR TITLE
Update cluster-controller to v0.3.0 and fix template problems

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -222,7 +222,7 @@ spec:
           value: {{ $serviceName }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort | default 9090 }}/model
         {{- if .Values.clusterController.kubescaler }}
         - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
-          value: {{ .Values.clusterController.kubescaler.defaultResizeAll | default false }}
+          value: {{ .Values.clusterController.kubescaler.defaultResizeAll | default "false" | quote }}
         {{- end }}
         ports:
         - name: http-server

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -219,7 +219,7 @@ spec:
         - name: CC_LOG_LEVEL
           value: {{ .Values.clusterController.logLevel | default "info" }}
         - name: CC_KUBESCALER_COST_MODEL_PATH
-          value: {{ $serviceName }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort | default 9090 }}/model
+          value: http://{{ $serviceName }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort | default 9090 }}/model
         {{- if .Values.clusterController.kubescaler }}
         - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
           value: {{ .Values.clusterController.kubescaler.defaultResizeAll | default "false" | quote }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -696,7 +696,7 @@ kubecostDeployment:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.2.0
+  image: gcr.io/kubecost1/cluster-controller:v0.3.0
   imagePullPolicy: Always
   kubescaler:
     # If true, will cause all (supported) workloads to be have their requests


### PR DESCRIPTION
## What does this PR change?

- Title.

- Also fixes an error with the cluster-controller template where if `.Values.clusterController.kubescaler.defaultResizeAll` is unset, the `default false` kicks in which is a bool, not a string, so the following error occurs:
`Error: UPGRADE FAILED: cannot patch "kubecost-cluster-controller" with kind Deployment:  "" is invalid: patch: Invalid value: .......(huge json blob)..... json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string`

  Had to "quote" it to make sure.

- Also fixes a problem with the COST_MODEL_PATH env var. Missing the protocol caused the following error: `FTL Kubescaler setup failed error="creating a Kubescaler: recommendation service unavailable: failed to execute request: Get \"kubecost-cost-analyzer.kubecost:9090/model/savings/requestSizingV2\": unsupported protocol scheme \"kubecost-cost-analyzer.kubecost\""`

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A (internal APIs and the bad default false hasn't been shipped yet)

## How was this PR tested?

Updated cluster using this version of the chart. Observed cluster-controller running with the correct image, endpoints (request sizer and new kubescaler) available, and logs for turndown running.