### PR TITLE
Network costs resource limits 2

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -45,15 +45,7 @@ spec:
         imagePullPolicy: Always
 {{- end }}
 {{- if .Values.networkCosts.resources }}
-        resources:
-{{ toYaml .Values.networkCosts.resources | indent 10 }}
-{{- else }}
-        resources:
-          limits:
-            cpu: 500m
-          requests:
-            cpu: 50m
-            memory: 20Mi
+        resources: {{- toYaml .Values.networkCosts.resources | nindent 8 }}
 {{- end }}
         env:
         {{- if .Values.networkCosts.hostProc }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -592,7 +592,7 @@ networkCosts:
   port: 3001
   # this daemonset can use significant resources on large clusters: https://guide.kubecost.com/hc/en-us/articles/4407595973527-Network-Traffic-Cost-Allocation
   resources:
-    limits:
+    limits: # remove the limits by setting limits: null
       cpu: 500m # can be less, will depend on cluster size
       # memory: it is not recommended to set a memory limit
     requests:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -592,7 +592,7 @@ networkCosts:
   port: 3001
   # this daemonset can use significant resources on large clusters: https://guide.kubecost.com/hc/en-us/articles/4407595973527-Network-Traffic-Cost-Allocation
   resources:
-    limits: # remove the limits by setting limits: null
+    limits: # remove the limits by setting limits: {}
       cpu: 500m # can be less, will depend on cluster size
       # memory: it is not recommended to set a memory limit
     requests:


### PR DESCRIPTION
## What does this PR change?

remove extra else statement from network-costs DS template
add comment for howto remove limit in values.yaml

## Testing:
helm template kubecost2 --namespace kubecost2 ./cost-analyzer -n kubecost --create-namespace --set networkCosts.enabled=true |grep 500m -B4
```
image: gcr.io/kubecost1/kubecost-network-costs:v16.3
        imagePullPolicy: Always
        resources:
        limits:
          cpu: 500m
```

helm template kubecost2 --namespace kubecost2 ./cost-analyzer -n kubecost --create-namespace --set networkCosts.enabled=true --set networkCosts.resources.limits=null |ag 500m -B4
```
<null>
```