### PR TITLE
Add CORS Access-Control-Allow-Methods header for /cluster

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -184,6 +184,7 @@ data:
         location ~ ^/(turndown|cluster)/ {
 
             add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
 {{- if .Values.clusterController }}
 {{- if .Values.clusterController.enabled }}
             {{- if or .Values.saml .Values.oidc }}


### PR DESCRIPTION
## What does this PR change?
Adds CORS allow header for all standard REST verbs targeting cluster-controller (`/cluster`).

Not having this header was causing problems for local UI development against some cluster-controller APIs.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds `Access-Control-Allow-Methods` header for the `/cluster` (cluster-controller) routes.

## How was this PR tested?
Used by @wolfeaustin during local dev. Fixed his problems.