### PR TITLE
Update cluster-controller to v0.5.0

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -696,7 +696,7 @@ kubecostDeployment:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.3.0
+  image: gcr.io/kubecost1/cluster-controller:v0.5.0
   imagePullPolicy: Always
   kubescaler:
     # If true, will cause all (supported) workloads to be have their requests


### PR DESCRIPTION
## What does this PR change?
Updates cluster-controller to the just-released v0.5.0.

## How was this PR tested?
Custom image upgrading. This version of cluster-controller is already being used to develop https://github.com/kubecost/cost-analyzer-frontend/pull/1360.