### PR TITLE
Don't install PSPs if PSPs are unavailable (make Kubecost default install work on K8s v1.25+ clusters)

### DIFF
--- a/cost-analyzer/charts/grafana/templates/podsecuritypolicy.yaml
+++ b/cost-analyzer/charts/grafana/templates/podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.global.grafana.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.rbac.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -41,5 +42,6 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{ if not .Values.disabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -37,5 +38,6 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-podsecuritypolicy.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.global.prometheus.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.rbac.create }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
@@ -45,6 +46,7 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
+{{- end }}
 {{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/templates/node-exporter-podsecuritypolicy.yaml
+++ b/cost-analyzer/charts/prometheus/templates/node-exporter-podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.global.prometheus.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if and .Values.nodeExporter.enabled .Values.rbac.create }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
@@ -52,6 +53,7 @@ spec:
   hostPorts:
     - min: 1
       max: 65535
+{{- end }}
 {{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/templates/pushgateway-podsecuritypolicy.yaml
+++ b/cost-analyzer/charts/prometheus/templates/pushgateway-podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.global.prometheus.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.rbac.create }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
@@ -41,6 +42,7 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
+{{- end }}
 {{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/templates/server-podsecuritypolicy.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.global.prometheus.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.rbac.create }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
@@ -50,6 +51,7 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/templates/cost-analyzer-psp.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp.template.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.podSecurityPolicy }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ include "cost-analyzer.podSecurityPolicy.apiVersion" . }}
@@ -18,5 +19,6 @@ spec:
         rule: RunAsAny
     volumes:
         - '*'
+{{- end }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/network-costs-psp.template.yaml
+++ b/cost-analyzer/templates/network-costs-psp.template.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.networkCosts }}
 {{- if .Values.networkCosts.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.networkCosts.podSecurityPolicy }}
 {{- if .Values.networkCosts.podSecurityPolicy.enabled }}
 apiVersion: {{ include "cost-analyzer.podSecurityPolicy.apiVersion" . }}
@@ -32,6 +33,7 @@ spec:
         rule: RunAsAny
     volumes:
         - '*'
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
Only installs PSPs if they are availability according to `.Capabilities`.

This makes the Kubecost installation work by default on versions of K8s >= 1.25. This does not replace them with "Security Context Constraints", which is the recommended replacement:
https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/

Other notes:
- Grafana has an open issue for their Helm charts for this same problem: https://github.com/grafana/helm-charts/issues/1006
- I modeled this PR after https://github.com/aquasecurity/trivy/pull/1315
- I used ripgrep to check for all instances of `PodSecurityPolicy` definitions in this repo to add the necessary `if` block. `rg -C 5 -i 'kind: PodSecurityPolicy'`


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Fixes Helm chart install breaking on K8s versions v1.25+ (https://github.com/kubecost/cost-analyzer-helm-chart/issues/1773). PSPs will no longer be installed if the API is unavailable in your version of Kubernetes.


## Links to Issues or ZD tickets this PR addresses or fixes

- Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1773


## How was this PR tested?
Made a K8s v1.25 test cluster using k3d:
```
k3d cluster create --image rancher/k3s:v1.25.3-rc3-k3s1

kubectl version --short
Client Version: v1.25.3
Kustomize Version: v4.5.7
Server Version: v1.25.3-rc3+k3s1
```

Installed the Helm chart with this change:
```sh
helm upgrade \
    -i \
    --create-namespace kubecost \
    -n kubecost \
    "/path/to/cost-analyzer-helm-chart/cost-analyzer"
```

Observed successful, no-error install. Contrast with errors described in https://github.com/kubecost/cost-analyzer-helm-chart/issues/1773.