### PR TITLE
Remove `azureStorageSecretName` from values.yaml.

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -888,7 +888,6 @@ federatedETL:
 #  azureTenantID: 72faf3ff-7a3f-4597-b0d9-7b0b201bb23a
 #  azureClientPassword: fake key # Only use if your values.yaml are stored encrypted. Otherwise provide an existing secret via serviceKeySecretName
 #  azureOfferDurableID: "MS-AZR-0003p"
-#  azureStorageSecretName: "azure-storage-config" # Name of Kubernetes Secret where Azure Storage Configuration is stored
 #  discount: "" # percentage discount applied to compute
 #  negotiatedDiscount: "" # custom negotiated cloud provider discount
 #  defaultIdle: false


### PR DESCRIPTION
This is no longer the recommended method for setting up Azure Cloud Integration. We are now recommending `.Values.kubecostProductConfigs.cloudIntegrationSecret`

## What does this PR change?

This is only removing the `azureStorageSecretName` from the `values.yaml`, so that users do not mistakenly begin to use this feature.

To ensure no breaking changes, all the templates which use `.Values.kubecostProductConfigs.azureStorage*` remain unchanged. Those will likely be deprecated in the next release once further testing has been done, and more advanced notice can be provided.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

None

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1430

## How was this PR tested?

None needed

## Have you made an update to documentation?

Yes, we're revamping our docs to remove references to `.Values.kubecostProductConfigs.azureStorageSecretName`. We're adding more clarity about the new `.Values.kubecostProductConfigs.cloudIntegrationSecret` method.

- https://github.com/kubecost/docs/pull/461



