### PR TITLE
allow additionnal labels in networkcost

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -17,6 +17,9 @@ metadata:
   labels:
     {{ unset (include "cost-analyzer.commonLabels" . | fromYaml) "app" | toYaml | nindent 4 }}
     app: {{ template "cost-analyzer.networkCostsName" . }}
+{{- if .Values.networkCosts.service.labels }}
+{{ toYaml .Values.networkCosts.service.labels | indent 4 }}
+{{- end }}
 spec:
   clusterIP: None
   ports:

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{- if .Values.networkCosts.additionalLabels }}
+{{ toYaml .Values.networkCosts.additionalLabels | indent 4 }}
+{{- end }}
 spec:
   {{- if .Values.networkCosts.updateStrategy }}
   updateStrategy:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -668,6 +668,7 @@ networkCosts:
 
   service:
     annotations: {}
+    labels: {}
 
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
## What does this PR change?
- we are using gatekeeper that force some labels to be set cross all kubernetes objects(deploy,sts,ds,svc) 
allow additional labels for Network Cost service and daemonset, as it's done for Cost-analyzer Deployment and service 

## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

it will provide them with ability to set custom labels for network cost daemonset and service




## Have you made an update to documentation?
Not Necessary
