### PR TITLE
Quote the projectID to avoid exponential notation in Helm

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -102,7 +102,7 @@ data:
     spotDataPrefix: "{{ .Values.kubecostProductConfigs.awsSpotDataPrefix }}"
   {{- end -}}
   {{- if .Values.kubecostProductConfigs.projectID }}
-    projectID: "{{ .Values.kubecostProductConfigs.projectID }}"
+    projectID: "{{ .Values.kubecostProductConfigs.projectID | quote }}"
   {{- end -}}
   {{- if .Values.kubecostProductConfigs.bigQueryBillingDataDataset }}
     billingDataDataset: "{{ .Values.kubecostProductConfigs.bigQueryBillingDataDataset }}"


### PR DESCRIPTION
## What does this PR change?
It quotes the `projectID` string in Helm to avoid conversion to exponential notation when templating.

## Does this PR rely on any other PRs?
N/A
- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
It should be a bug fix for users.


## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/1210
- 
- 


## How was this PR tested?
N/A

## Have you made an update to documentation?
N/A
