### PR TITLE
Add support for setting Advanced Reports via values.yaml

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-advanced-reports-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-advanced-reports-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.global.advancedReports }}
+{{- if .Values.global.advancedReports.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{default "advanced-report-configs" .Values.advancedReportConfigmapName }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  advanced-reports.json: '{{ toJson .Values.global.advancedReports.reports }}'
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -97,7 +97,7 @@ global:
       enabled: false # If true, allow kubecost to write to your alertmanager
       fqdn: http://cost-analyzer-prometheus-server.default.svc #example fqdn. Ignored if prometheus.enabled: true
 
-   # Set saved report(s) accessible from reports.html
+   # Set saved Cost Allocation report(s) accessible from /reports
    # Ref: http://docs.kubecost.com/saved-reports
   savedReports:
     enabled: false # If true, overwrites report parameters set through UI
@@ -129,7 +129,7 @@ global:
         accumulate: true # entire window resolution
         filters: [] # if no filters, specify empty array
 
-  # Set saved report(s) accessible from reports.html
+  # Set saved Asset report(s) accessible from /reports
   # Ref: http://docs.kubecost.com/saved-reports
   assetReports:
     enabled: false # If true, overwrites report parameters set through UI
@@ -141,6 +141,20 @@ global:
       filters:
         - property: "cluster"
           value: "cluster-one"
+
+  # Set saved Advanced report(s) accessible from /reports
+  # Ref: http://docs.kubecost.com/saved-reports
+  advancedReports:
+    enabled: false # If true, overwrites report parameters set through UI
+    reports:
+    - title: "Example Advanced Report 0"
+      window: "7d"
+      aggregateBy: "namespace"
+      filters:
+        - property: "cluster"
+          value: "cluster-one"
+      cloudBreakdown: "service"
+      cloudJoin: "label:kubernetes_namespace"
 
   podAnnotations: {}
     # iam.amazonaws.com/role: role-arn


### PR DESCRIPTION
## What does this PR change?
Adds support for setting Advanced Reports via values.yaml


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/1106


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Allows users to configured advanced reports via the helm chart


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?

