### PR TITLE
Ndo/v1.99 patch/gracedo/thanos ingress

### DIFF
--- a/cost-analyzer/charts/grafana/templates/ingress.yaml
+++ b/cost-analyzer/charts/grafana/templates/ingress.yaml
@@ -3,7 +3,15 @@
 {{- $fullName := include "grafana.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -35,10 +43,20 @@ spec:
     - host: {{ . }}
       http:
         paths:
+        {{- if $apiV1 }}
+          - path: {{ $ingressPath }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
+        {{- else }}
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
+        {{- end }}
   {{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -67,6 +67,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   labels: {}
   path: /
+  pathType: Prefix
   hosts:
     - chart-example.local
   tls: []

--- a/cost-analyzer/charts/thanos/templates/bucket-ingress.yaml
+++ b/cost-analyzer/charts/thanos/templates/bucket-ingress.yaml
@@ -1,6 +1,14 @@
 {{ if .Values.global.thanos.enabled }}
 {{ if and .Values.bucket.enabled .Values.bucket.http.ingress.enabled }}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "bucket") }}
@@ -18,6 +26,9 @@ metadata:
 {{ toYaml .Values.bucket.http.ingress.labels | indent 4 }}
   {{- end }}
 spec:
+{{- if .Values.bucket.http.ingress.className }}
+  ingressClassName: {{ .Values.ingress.bucket.http.className }}
+{{- end }}
   {{- if .Values.bucket.http.ingress.tls }}
   tls:
     {{- range .Values.bucket.http.ingress.tls }}
@@ -33,10 +44,20 @@ spec:
   - host: {{ . }}
     http:
       paths:
+        {{- if $apiV1 }}
+        - path: {{ $.Values.bucket.http.ingress.path }}
+          pathType: {{ $.Values.bucket.http.ingress.pathType }}
+          backend:
+            service:
+              name: {{ include "thanos.componentname" (list $ "bucket") }}
+              port:
+                number: {{ $.Values.bucket.http.port }}
+        {{- else }}
         - path: {{ $.Values.bucket.http.ingress.path }}
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "bucket") }}
             servicePort: {{ $.Values.bucket.http.port }}
+        {{- end }}
   {{- end }}
 {{ end }}
 {{ end }}

--- a/cost-analyzer/charts/thanos/templates/query-frontend-ingress.yml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-ingress.yml
@@ -1,7 +1,15 @@
 ---
 {{ if .Values.global.thanos.enabled }}
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.http.ingress.enabled }}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
@@ -19,6 +27,9 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+{{- if .Values.queryFrontend.http.ingress.className }}
+  ingressClassName: {{ .Values.ingress.queryFrontend.http.className }}
+{{- end }}
   {{- if .Values.queryFrontend.http.ingress.tls }}
   tls:
     {{- range .Values.queryFrontend.http.ingress.tls }}
@@ -36,10 +47,20 @@ spec:
     - host: {{ . }}
       http:
         paths:
+        {{- if $apiV1 }}
+          - path: {{ $.Values.queryFrontend.http.ingress.path }}
+            pathType: {{ $.Values.queryFrontend.http.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
+                port:
+                  number: {{ $.Values.queryFrontend.http.port }}
+        {{- else }}
           - path: {{ $.Values.queryFrontend.http.ingress.path }}
             backend:
               serviceName: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
               servicePort: {{ $.Values.queryFrontend.http.port }}
+        {{- end }}
   {{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/thanos/templates/query-ingress.yml
+++ b/cost-analyzer/charts/thanos/templates/query-ingress.yml
@@ -1,7 +1,15 @@
 ---
 {{ if .Values.global.thanos.enabled }}
 {{- if and .Values.query.enabled .Values.query.http.ingress.enabled }}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}-http
@@ -19,6 +27,9 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+{{- if .Values.query.http.ingress.className }}
+  ingressClassName: {{ .Values.ingress.query.http.className }}
+{{- end }}
   {{- if .Values.query.http.ingress.tls }}
   tls:
     {{- range .Values.query.http.ingress.tls }}
@@ -36,16 +47,34 @@ spec:
     - host: {{ . }}
       http:
         paths:
+          {{- if $apiV1 }}
+          - path: {{ $.Values.query.http.ingress.path }}
+            pathType: {{ $.Values.query.http.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "thanos.componentname" (list $ "query") }}-http
+                port:
+                  number: {{ $.Values.query.http.port }}
+          {{- else }}
           - path: {{ $.Values.query.http.ingress.path }}
             backend:
               serviceName: {{ include "thanos.componentname" (list $ "query") }}-http
               servicePort: {{ $.Values.query.http.port }}
+          {{- end }}
   {{- end }}
 {{- end }}
 
 {{- if and .Values.query.enabled .Values.query.grpc.ingress.enabled }}
 ---
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}-grpc
@@ -63,6 +92,9 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+{{- if .Values.query.grpc.ingress.className }}
+  ingressClassName: {{ .Values.ingress.query.grpc.className }}
+{{- end }}
   {{- if .Values.query.grpc.ingress.tls }}
   tls:
     {{- range .Values.query.grpc.ingress.tls }}
@@ -80,10 +112,20 @@ spec:
     - host: {{ . }}
       http:
         paths:
+          {{- if $apiV1 }}
+          - path: {{ $.Values.query.grpc.ingress.path }}
+            pathType: {{ $.Values.query.grpc.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "thanos.componentname" (list $ "query") }}-grpc
+                port:
+                  number: {{ $.Values.query.grpc.port }}
+          {{- else }}
           - path: {{ $.Values.query.grpc.ingress.path }}
             backend:
               serviceName: {{ include "thanos.componentname" (list $ "query") }}-grpc
-              servicePort: {{ $.Values.query.http.port }}
+              servicePort: {{ $.Values.query.grpc.port }}
+          {{- end }}
   {{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/thanos/templates/store-ingress.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-ingress.yaml
@@ -1,6 +1,14 @@
 {{ if .Values.global.thanos.enabled }}
 {{- if and .Values.store.enabled .Values.store.http.ingress.enabled }}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-http
@@ -18,6 +26,9 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.store.http.ingress.className }}
+  ingressClassName: {{ .Values.ingress.store.http.className }}
+{{- end }}
   {{- if .Values.store.http.ingress.tls }}
   tls:
     {{- range .Values.store.http.ingress.tls }}
@@ -33,17 +44,35 @@ spec:
   - host: {{ . }}
     http:
       paths:
+        {{- if $apiV1 }}
+        - path: {{ $.Values.store.http.ingress.path }}
+          pathType: {{ .Values.store.http.ingress.pathType }}
+          backend:
+            service:
+              name: {{ include "thanos.componentname" (list $ "store") }}-http
+              port:
+                number: {{ $.Values.store.http.port }}
+        {{- else }}
         - path: {{ $.Values.store.http.ingress.path }}
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "store") }}-http
             servicePort: {{ $.Values.store.http.port }}
+        {{- end }}
   {{- end }}
 {{- end }}
 
 ---
 
   {{- if and .Values.store.enabled .Values.store.grpc.ingress.enabled }}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-grpc
@@ -61,6 +90,9 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.store.grpc.ingress.className }}
+  ingressClassName: {{ .Values.ingress.store.grpc.className }}
+{{- end }}
   {{- if .Values.store.grpc.ingress.tls }}
   tls:
     {{- range .Values.store.grpc.ingress.tls }}
@@ -76,10 +108,20 @@ spec:
   - host: {{ . }}
     http:
       paths:
+        {{- if $apiV1 }}
+        - path: {{ $.Values.store.grpc.ingress.path }}
+          pathType: {{ $.Values.store.grpc.ingress.pathType }}
+          backend:
+            service:
+              name: {{ include "thanos.componentname" (list $ "store") }}-grpc
+              port:
+                number: {{ $.Values.store.grpc.port }}
+        {{- else }}
         - path: {{ $.Values.store.grpc.ingress.path }}
           backend:
             serviceName: {{ include "thanos.componentname" (list $ "store") }}-grpc
-            servicePort: {{ $.Values.store.http.port }}
+            servicePort: {{ $.Values.store.grpc.port }}
+        {{- end }}
   {{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -418,6 +418,7 @@ query:
         # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -509,6 +510,7 @@ query:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -650,6 +652,7 @@ bucket:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -754,6 +757,7 @@ sidecar:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []
@@ -781,6 +785,7 @@ sidecar:
       # kubernetes.io/tls-acme: "true"
       labels: {}
       path: "/"
+      pathType: ImplementationSpecific
       hosts:
         - "/"
       tls: []


### PR DESCRIPTION
Patching this into our v1.99 release! Thanks a million for the contribution @gracedo 🎉 

## What does this PR change?
Adds support for ingresses in the thanos and grafana subcharts that are running in more recent kubernetes versions in which the original `extensions/v1beta1` version has been deprecated and removed


## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Thanos and Grafana ingresses can now be deployed in newer versions of Kubernetes (1.22+) using the chart


## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1262
- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1349


## How was this PR tested?
Tested installing local version of the chart with the Thanos Query ingress defined in values (on k8s 1.24)

## Have you made an update to documentation?
No
