### PR TITLE
Add Prometheus server ServiceAccount annotations to values.yaml

### DIFF
--- a/cost-analyzer/charts/prometheus/README.md
+++ b/cost-analyzer/charts/prometheus/README.md
@@ -362,6 +362,7 @@ Parameter | Description | Default
 `serviceAccounts.pushgateway.name` | name of the pushgateway service account to use or create | `{{ prometheus.pushgateway.fullname }}`
 `serviceAccounts.server.create` | If true, create the server service account | `true`
 `serviceAccounts.server.name` | name of the server service account to use or create | `{{ prometheus.server.fullname }}`
+`serviceAccounts.server.annotations` | annotations for the server service account | `{}`
 `server.terminationGracePeriodSeconds` | Prometheus server Pod termination grace period | `300`
 `server.retention` | (optional) Prometheus data retention | `"15d"`
 `serverFiles.alerts` | (Deprecated) Prometheus server alerts configuration | `{}`

--- a/cost-analyzer/charts/prometheus/templates/server-serviceaccount.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-serviceaccount.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
+  {{- with .Values.serviceAccounts.server.annotations }}
+  annotations:
+  {{- . | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -22,6 +22,9 @@ serviceAccounts:
   server:
     create: true
     name:
+    ## Prometheus server ServiceAccount annotations.
+    ## Can be used for AWS IRSA annotations when using Remote Write mode with Amazon Managed Prometheus.
+    annotations: {}
 
 alertmanager:
   ## If false, alertmanager will not be installed


### PR DESCRIPTION
## What does this PR change?

This enables annotating the Prometheus server ServiceAccount when using AWS IRSA with Amazon Managed Prometheus

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Support annotating the Prometheus server ServiceAccount for use with AWS IRSA

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

Tested locally

## Have you made an update to documentation?

Updated prometheus chart README