### PR TITLE
Upgrade Grafana sidecar from v1.19.2 -> v1.21.0

### DIFF
--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -256,7 +256,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:1.19.2
+  image: kiwigrid/k8s-sidecar:1.21.0
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -18531,7 +18531,7 @@ spec:
         runAsUser: 472
       containers:
         - name: grafana-sc-dashboard
-          image: "kiwigrid/k8s-sidecar:1.19.2"
+          image: "kiwigrid/k8s-sidecar:1.21.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: LABEL


### PR DESCRIPTION
This commit was previously merged into the "develop" branch. Now it needs to be cherry-picked into v1.99. Notes here:

- https://github.com/kubecost/cost-analyzer-helm-chart/pull/1855

## What does this PR change?

Upgrades Grafana sidecar image version from 1.19.2 -> 1.21.0.

Images of /kiwigrid/k8s-sidecar listed [here on DockerHub](https://hub.docker.com/r/kiwigrid/k8s-sidecar/tags). It may also be worthwhile to note that the upstream Grafana Helm Chart is still using /kiwigrid/k8s-sidecar:1.19.2 as shown [here](https://github.com/grafana/helm-charts/blob/a4d950b30180002c20b7e47cdfc3401613054a45/charts/grafana/values.yaml#L752-L759).

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

No impact

## Links to Issues or ZD tickets this PR addresses or fixes

Reports that the /kiwigrid/k8s-sidecar:1.19.2 was affected by CVEs

## How was this PR tested?

Deployed to my cluster without any errors. Grafana's logs look healthy. I don't anticipate any compatibility issues by upgrading this sidecar since it's only responsible for watching configmaps in the cluster. I will continue to monitor my deployment.

## Have you made an update to documentation?

No