### PR TITLE
Update eks cost monitoring config

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -33,7 +33,9 @@ networkPolicy:
 podSecurityPolicy:
   enabled: false
 
-imageVersion: prod-1.97.0
+# Enable this flag if you need to install with specfic image tags
+# imageVersion: prod-1.97.0
+
 kubecostFrontend:
   image: public.ecr.aws/kubecost/frontend
   imagePullPolicy: Always
@@ -141,7 +143,7 @@ prometheus:
     prometheus:
       ## If false, the configmap-reload container will not be deployed
       ##
-      enabled: true
+      enabled: false
 
       ## configmap-reload container name
       ##


### PR DESCRIPTION
Signed-off-by: Linh Lam <linh@kubecost.com>

## What does this PR change?

1 - Address the issue [1832](https://github.com/kubecost/cost-analyzer-helm-chart/issues/1832) 
2 - Disable configmap-reloader to support ARM CPU seamlessly

## Does this PR rely on any other PRs?
 
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

1. Allow user to install Amazon EKS cost monitoring with image tag match with Helm chart version automatically.
2. Allow user to seamlessly deploy Amazon EKS cost monitoring on the AWS Graviton2 worker nodes by turning off the Prometheus configmap-reloader by default. There are no ARM supported configmap-reloader image on ECR public gallery.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1832

## How was this PR tested?

- Deploy directly on Amazon EKS 1.23 and Amazon EKS 1.24
- Upgrade current deployment using new configs to ensure it has no negative impact on current set up

## Have you made an update to documentation?

N/a
