### PR TITLE
additionalLabels added to the grafana deployment

### DIFF
--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
       labels:
         app: {{ template "grafana.name" . }}
         release: {{ .Release.Name }}
+        {{- if .Values.global.additionalLabels }}
+        {{ toYaml .Values.global.additionalLabels | nindent 8 }}
+        {{- end }}
 {{- with .Values.podAnnotations }}
       annotations:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
## What does this PR change?
Adds global.additionalLabels to the grafana deployment


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
The global.additionalLabels will also be in the grafana's pod, like in the release-name-cost-analyzer's pod.


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
```
diff --git a/cost-analyzer/values.yaml b/cost-analyzer/values.yaml
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -158,7 +158,8 @@ global:

   podAnnotations: {}
     # iam.amazonaws.com/role: role-arn
-  additionalLabels: {}
+  additionalLabels:
+    testLabel: testLabelValue`
```
```
helm template .  -f values.yaml
```
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-grafana
....
  template:
    metadata:
      labels:
        app: grafana
        release: release-name

        testLabel: testLabelValue
```

## Have you made an update to documentation?

No