### PR TITLE
secret store CSI driver for agent key

### DIFF
--- a/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.agentCsi.enabled}}
+{{- if .Capabilities.APIVersions.Has "secrets-store.csi.x-k8s.io/v1" }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+{{- else }}
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+{{- end }}
+kind: SecretProviderClass
+metadata:
+  name: {{ .Values.agentCsi.secretProvider.name }}
+  labels: {{ unset (include "cost-analyzer.commonLabels" . | fromYaml) "app" | toYaml | nindent 4 }}
+    app: {{ template "kubecost.kubeMetricsName" . }}
+spec:
+  provider: {{ required "Specify a valid provider." .Values.agentCsi.secretProvider.provider }}
+  {{- if .Values.agentCsi.secretProvider.parameters }}
+  parameters:
+    {{-  .Values.agentCsi.secretProvider.parameters | toYaml | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -43,8 +43,16 @@ spec:
       volumes:
         {{- if .Values.agent }}
         - name: config-store
+          {{- if .Values.agentCsi.enabled }}
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "{{ .Values.agentCsi.secretProvider.name }}"
+          {{- else }}
           secret:
             secretName: {{ .Values.agentKeySecretName }}
+          {{- end }}
         {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if .Values.kubecostProductConfigs.gcpSecretName }}

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -11,6 +11,12 @@ global:
 # with enhancements designed for external hosting.
 agent: true
 # agentKeySecretName: kubecost-agent-object-store
+agentCsi:
+  enabled: false
+  secretProvider:
+    name: kubecost-agent-object-store-secretprovider
+    provider:
+    parameters: {}
 
 # No Grafana configuration is required.
 grafana:


### PR DESCRIPTION
## What does this PR change?
A SecretProviderClass manifest can be deployed for the agent key (when deploying the chart in the kubecost-agent configuration) that can be used to retrieve the agent key from a secret store (e.g. Azure Key Vault).
In case this option is used the no agent key has to be specified explicitly and no secret is created in Kubernetes.

## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users have now the option to retrieve the agent key from a secret store that supports the SecretProviderClass manifest.

## How was this PR tested?
Deployed on one of our clusters and tested against Kubecost Cloud.

## Have you made an update to documentation?
No. What would be the right place?
