### PR TITLE
Set clusterAccountID in configmap

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -47,6 +47,9 @@ data:
   {{- if .Values.kubecostProductConfigs.clusterName }}
     clusterName: "{{ .Values.kubecostProductConfigs.clusterName }}"
   {{- end -}}
+  {{- if .Values.kubecostProductConfigs.clusterAccountID }}
+    clusterAccountID: "{{ .Values.kubecostProductConfigs.clusterAccountID }}"
+  {{- end -}}
   {{- if .Values.kubecostProductConfigs.currencyCode }}
     currencyCode: "{{ .Values.kubecostProductConfigs.currencyCode }}"
   {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -966,6 +966,7 @@ costEventsAudit:
 #    pod_external_label: "kubernetes_pod"
 #  grafanaURL: ""
 #  clusterName: "" # clusterName is the default context name in settings.
+#  clusterAccountID: "" # Manually set Account property for assets
 #  currencyCode: "USD" # official support for USD, AUD, BRL, CAD, CHF, CNY, DKK, EUR, GBP, INR, JPY, NOK, PLN, SEK
 #  azureBillingRegion: US # Represents 2-letter region code, e.g. West Europe = NL, Canada = CA. ref: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
 #  azureSubscriptionID: 0bd50fdf-c923-4e1e-850c-196dd3dcc5d3


### PR DESCRIPTION
## What does this PR change?
Add ClusterAccountID Value and set in config map
see https://github.com/opencost/opencost/pull/1613 for config details

## Does this PR rely on any other PRs?
* https://github.com/opencost/opencost/pull/1613

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
## Links to Issues or ZD tickets this PR addresses or fixes
## - 
## How was this PR tested?
## Have you made an update to documentation?


┆Issue is synchronized with this [Jira Task](https://kubecost.atlassian.net/browse/GIB-21) by [Unito](https://www.unito.io)
