### PR TITLE
fixed SecretProviderClass for non-agent deploy

### DIFF
--- a/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.agentCsi.enabled}}
+{{- if .Values.agent }}
+{{- if .Values.agentCsi.enabled }}
 {{- if .Capabilities.APIVersions.Has "secrets-store.csi.x-k8s.io/v1" }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 {{- else }}
@@ -15,4 +16,5 @@ spec:
   parameters:
     {{-  .Values.agentCsi.secretProvider.parameters | toYaml | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
Fixed an issue with the SecretProviderClass being enabled for non-agent deployments which causes an error. The 


## Does this PR rely on any other PRs?
- #1904 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixes the referenced PR so non-agent deployment does not fail without explicitly disabling the agentCsi flag.

## How was this PR tested?
Local helm rendering

## Have you made an update to documentation?
No.
