### PR TITLE
Upgrade Grafana image from 9.0.2 -> 9.3.1

### DIFF
--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -25,7 +25,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 9.0.2
+  tag: 9.3.1
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -18546,7 +18546,7 @@ spec:
             - name: sc-dashboard-volume
               mountPath: "/tmp/dashboards"
         - name: grafana
-          image: "grafana/grafana:9.0.2"
+          image: "grafana/grafana:9.3.1"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config


### PR DESCRIPTION
## What does this PR change?

This updates our Helm chart to use the `grafana/grafana:9.3.1` image. Note, that this PR does not upgrade the [Grafana subchart](https://artifacthub.io/packages/helm/grafana/grafana), it’s only updating the image used in the subchart.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

The default configuration of Kubecost will now come bundled with an upgraded version of Grafana. No impact anticipated.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1550

## How was this PR tested?

Successfully deployed Kubecost with the upgraded version of Grafana. The test instance is available [here](http://ab363e6d5b6a44f3a92201038be253b4-268768399.us-west-1.elb.amazonaws.com:9090/grafana/dashboards). @jessegoodier , could you help to verify that all dashboards look to be working as expected?

## Have you made an update to documentation?

Not needed.