### PR TITLE
add EBS-CSI warnings

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -12,19 +12,15 @@ Kubecost has been successfully installed.
 
 {{ if (and $isEKS $isGT22) -}}
 
-WARNING: ON EKS v1.23+ INSTALLATION OF EBS-CSI DRIVER IS REQUIRED TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+WARNING: ON EKS v1.23+ INSTALLATION OF EBS-CSI DRIVER IS REQUIRED TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.kubecost.com/install-and-configure/install/provider-installations/aws-eks-cost-monitoring#prerequisites
 
 {{ if (and $EBSCSINotExists $PVNotExists) -}}
 
-ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.kubecost.com/install-and-configure/install/provider-installations/aws-eks-cost-monitoring#prerequisites
 
 {{ else if (and $EBSCSINotExists (not $PVNotExists)) -}}
 
-ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
-
-{{ else if (not $EBSCSINotExists) -}}
-
-We detected a EBS-CSI Driver, but you should check that Kubecost's PersistentVolume has been installed correctly
+ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.kubecost.com/install-and-configure/install/provider-installations/aws-eks-cost-monitoring#prerequisites
 
 {{ end -}}
 {{ end -}}

--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -10,24 +10,24 @@
 {{- $servicePort := .Values.service.port | default 9090 -}}
 Kubecost has been successfully installed.
 
-{{- if (and $isEKS $isGT22) -}}
+{{ if (and $isEKS $isGT22) -}}
 
 WARNING: ON EKS v1.23+ INSTALLATION OF EBS-CSI DRIVER IS REQUIRED TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
 
-{{- if (and $EBSCSINotExists $PVNotExists) }}
+{{ if (and $EBSCSINotExists $PVNotExists) -}}
 
 ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
 
-{{- else if (and $EBSCSINotExists (not $PVNotExists)) -}}
+{{ else if (and $EBSCSINotExists (not $PVNotExists)) -}}
 
 ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
 
-{{- else if (not $EBSCSINotExists) -}}
+{{ else if (not $EBSCSINotExists) -}}
 
 We detected a EBS-CSI Driver, but you should check that Kubecost's PersistentVolume has been installed correctly
 
-{{- end -}}
-{{- end -}}
+{{ end -}}
+{{ end -}}
 
 
 Please allow 5-10 minutes for Kubecost to gather metrics.

--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,8 +1,34 @@
 
 
 --------------------------------------------------
+{{- $node := (lookup "v1" "Node" "" "") }}
+{{- $isEKS := (regexMatch ".*eks.*" (.Capabilities.KubeVersion | quote) )}}
+{{- $isGT22 := (semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- $PVNotExists := (empty (lookup "v1" "PersistentVolume" "" "")) }}
+{{- $EBSCSINotExists := (empty (lookup "apps/v1" "Deployment" "kube-system" "ebs-csi-controller")) }}
+
 {{- $servicePort := .Values.service.port | default 9090 -}}
 Kubecost has been successfully installed.
+
+{{- if (and $isEKS $isGT22) -}}
+
+WARNING: ON EKS v1.23+ INSTALLATION OF EBS-CSI DRIVER IS REQUIRED TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+
+{{- if (and $EBSCSINotExists $PVNotExists) }}
+
+ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+
+{{- else if (and $EBSCSINotExists (not $PVNotExists)) -}}
+
+ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+
+{{- else if (not $EBSCSINotExists) -}}
+
+We detected a EBS-CSI Driver, but you should check that Kubecost's PersistentVolume has been installed correctly
+
+{{- end -}}
+{{- end -}}
+
 
 Please allow 5-10 minutes for Kubecost to gather metrics.
 


### PR DESCRIPTION
## What does this PR change?
Add warnings to notes on 


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Helps users debug EKS PV issues


## How was this PR tested?
Produces the message on an EKS cluster. 
```
atripathy@Ajays-MBP cost-analyzer-helm-chart % helm install kubecost ./cost-analyzer -n ajaytest
NAME: kubecost
LAST DEPLOYED: Sun Jan 22 16:13:03 2023
NAMESPACE: ajaytest
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed.

WARNING: ON EKS v1.23+ INSTALLATION OF EBS-CSI DRIVER IS REQUIRED TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html

We detected a EBS-CSI Driver, but you should check that Kubecost's PersistentVolume has been installed correctly

Please allow 5-10 minutes for Kubecost to gather metrics.

If you have configured cloud-integrations, it can take up to 48 hours for cost reconciliation to occur.

When using Durable storage (Enterprise Edition), please allow up to 4 hours for data to be collected and the UI to be healthy.

When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace ajaytest deployment/kubecost-cost-analyzer 9090

Next, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install
```

## Have you made an update to documentation?
This is documentation, more or less.