### PR TITLE
Update chart to use Helm release namespace

### DIFF
--- a/cost-analyzer/charts/grafana/templates/configmap-dashboard-provider.yaml
+++ b/cost-analyzer/charts/grafana/templates/configmap-dashboard-provider.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ template "grafana.fullname" . }}-config-dashboards
+  namespace: {{ .Release.Namespace }}
 data:
   provider.yaml: |-
     apiVersion: 1

--- a/cost-analyzer/charts/grafana/templates/configmap.yaml
+++ b/cost-analyzer/charts/grafana/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/cost-analyzer/charts/grafana/templates/dashboards-json-configmap.yaml
+++ b/cost-analyzer/charts/grafana/templates/dashboards-json-configmap.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" $ }}-dashboards-{{ $provider }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" $ }}
     chart: {{ template "grafana.chart" $ }}

--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/cost-analyzer/charts/grafana/templates/ingress.yaml
+++ b/cost-analyzer/charts/grafana/templates/ingress.yaml
@@ -15,6 +15,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/cost-analyzer/charts/grafana/templates/pvc.yaml
+++ b/cost-analyzer/charts/grafana/templates/pvc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/cost-analyzer/charts/grafana/templates/role.yaml
+++ b/cost-analyzer/charts/grafana/templates/role.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/cost-analyzer/charts/grafana/templates/rolebinding.yaml
+++ b/cost-analyzer/charts/grafana/templates/rolebinding.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/cost-analyzer/charts/grafana/templates/secret.yaml
+++ b/cost-analyzer/charts/grafana/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/cost-analyzer/charts/grafana/templates/service.yaml
+++ b/cost-analyzer/charts/grafana/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/cost-analyzer/charts/grafana/templates/serviceaccount.yaml
+++ b/cost-analyzer/charts/grafana/templates/serviceaccount.yaml
@@ -9,5 +9,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "grafana.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-configmap.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 data:
 {{- $root := . -}}
 {{- range $key, $value := .Values.alertmanagerFiles }}

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-ingress.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-ingress.yaml
@@ -23,6 +23,7 @@ metadata:
     {{ $key }}: {{ $value }}
 {{- end }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   rules:
   {{- range .Values.alertmanager.ingress.hosts }}

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-networkpolicy.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-networkpolicy.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-pdb.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-pdb.yaml
@@ -8,6 +8,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-pvc.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-pvc.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
 {{ toYaml .Values.alertmanager.persistentVolume.accessModes | indent 4 }}

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-service-headless.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-service-headless.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ toYaml .Values.alertmanager.statefulSet.headless.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.alertmanager.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
 spec:
   clusterIP: None
   ports:

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-service.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-service.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ toYaml .Values.alertmanager.service.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.alertmanager.service.clusterIP }}
   clusterIP: {{ .Values.alertmanager.service.clusterIP }}

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-serviceaccount.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-serviceaccount.yaml
@@ -6,5 +6,6 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-statefulset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   serviceName: {{ template "prometheus.alertmanager.fullname" . }}-headless
   selector:

--- a/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   name: {{ template "prometheus.nodeExporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/cost-analyzer/charts/prometheus/templates/node-exporter-role.yaml
+++ b/cost-analyzer/charts/prometheus/templates/node-exporter-role.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}

--- a/cost-analyzer/charts/prometheus/templates/node-exporter-service.yaml
+++ b/cost-analyzer/charts/prometheus/templates/node-exporter-service.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ toYaml .Values.nodeExporter.service.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.nodeExporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.nodeExporter.service.clusterIP }}
   clusterIP: {{ .Values.nodeExporter.service.clusterIP }}

--- a/cost-analyzer/charts/prometheus/templates/node-exporter-serviceaccount.yaml
+++ b/cost-analyzer/charts/prometheus/templates/node-exporter-serviceaccount.yaml
@@ -6,5 +6,6 @@ metadata:
   labels:
     {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/templates/pushgateway-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/pushgateway-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     {{- if .Values.schedulerName }}

--- a/cost-analyzer/charts/prometheus/templates/pushgateway-ingress.yaml
+++ b/cost-analyzer/charts/prometheus/templates/pushgateway-ingress.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   rules:
   {{- range .Values.pushgateway.ingress.hosts }}

--- a/cost-analyzer/charts/prometheus/templates/pushgateway-networkpolicy.yaml
+++ b/cost-analyzer/charts/prometheus/templates/pushgateway-networkpolicy.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/charts/prometheus/templates/pushgateway-pvc.yaml
+++ b/cost-analyzer/charts/prometheus/templates/pushgateway-pvc.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
 {{ toYaml .Values.pushgateway.persistentVolume.accessModes | indent 4 }}

--- a/cost-analyzer/charts/prometheus/templates/pushgateway-service.yaml
+++ b/cost-analyzer/charts/prometheus/templates/pushgateway-service.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ toYaml .Values.pushgateway.service.labels | indent 4}}
 {{- end }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.pushgateway.service.clusterIP }}
   clusterIP: {{ .Values.pushgateway.service.clusterIP }}

--- a/cost-analyzer/charts/prometheus/templates/pushgateway-serviceaccount.yaml
+++ b/cost-analyzer/charts/prometheus/templates/pushgateway-serviceaccount.yaml
@@ -6,5 +6,6 @@ metadata:
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}
 {{ end }}

--- a/cost-analyzer/charts/prometheus/templates/server-configmap.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 data:
 {{- $root := . -}}
 {{- range $key, $value := .Values.serverFiles }}

--- a/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/cost-analyzer/charts/prometheus/templates/server-ingress.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-ingress.yaml
@@ -27,6 +27,7 @@ metadata:
     {{ $key }}: {{ $value }}
 {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   rules:
   {{- range .Values.server.ingress.hosts }}

--- a/cost-analyzer/charts/prometheus/templates/server-networkpolicy.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-networkpolicy.yaml
@@ -5,6 +5,7 @@ apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/charts/prometheus/templates/server-pvc.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-pvc.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
 {{ toYaml .Values.server.persistentVolume.accessModes | indent 4 }}

--- a/cost-analyzer/charts/prometheus/templates/server-service-headless.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-service-headless.yaml
@@ -14,6 +14,7 @@ metadata:
 {{ toYaml .Values.server.statefulSet.headless.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.server.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
 spec:
   clusterIP: None
   ports:

--- a/cost-analyzer/charts/prometheus/templates/server-service.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-service.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ toYaml .Values.server.service.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}

--- a/cost-analyzer/charts/prometheus/templates/server-serviceaccount.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-serviceaccount.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAccounts.server.annotations }}
   annotations:
   {{- . | toYaml | nindent 4 }}

--- a/cost-analyzer/charts/prometheus/templates/server-statefulset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
     {{ toYaml .Values.server.statefulSet.labels | nindent 4 }}
     {{- end}}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   serviceName: {{ template "prometheus.server.fullname" . }}-headless
   selector:

--- a/cost-analyzer/charts/prometheus/templates/server-vpa.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-vpa.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}-vpa
+  namespace: {{ .Release.Namespace }}
 spec:
   targetRef:
 {{- if .Values.server.statefulSet.enabled }}

--- a/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.componentname" (list $ "bucket") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/bucket-ingress.yaml
+++ b/cost-analyzer/charts/thanos/templates/bucket-ingress.yaml
@@ -12,6 +12,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "bucket") }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.bucket.http.ingress.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/cost-analyzer/charts/thanos/templates/bucket-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/bucket-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.componentname" (list $ "bucket") }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.bucket.http.service.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.componentname" (list $ "compact") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/compact-pvc.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-pvc.yaml
@@ -7,6 +7,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Values.compact.dataVolume.persistentVolumeClaim.claimName }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/cost-analyzer/charts/thanos/templates/compact-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.componentname" (list $ "compact") }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.compact.http.service.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/cost-analyzer/charts/thanos/templates/compact-servicemonitor.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.componentname" (list $ "compact") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/query-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/query-frontend-horizontalpodautoscaler.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-horizontalpodautoscaler.yaml
@@ -5,6 +5,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/query-frontend-ingress.yml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-ingress.yml
@@ -13,6 +13,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/query-frontend-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}-http
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.queryFrontend.http.service.annotations }}
   annotations: {{ toYaml .| nindent 4 }}
   {{- end }}

--- a/cost-analyzer/charts/thanos/templates/query-frontend-servicemonitor.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.componentname" (list $ "query-frontend") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/query-horizontalpodautoscaler.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-horizontalpodautoscaler.yaml
@@ -5,6 +5,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/query-ingress.yml
+++ b/cost-analyzer/charts/thanos/templates/query-ingress.yml
@@ -13,6 +13,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}-http
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/query-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}-grpc
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.query.grpc.service.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/cost-analyzer/charts/thanos/templates/query-servicemonitor.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.componentname" (list $ "query") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/sidecar-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/sidecar-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.componentname" (list $ "sidecar") }}-grpc
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.sidecar.grpc.service.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/cost-analyzer/charts/thanos/templates/sidecar-servicemonitor.yaml
+++ b/cost-analyzer/charts/thanos/templates/sidecar-servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.componentname" (list $ "sidecar") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/store-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/store-ingress.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-ingress.yaml
@@ -12,6 +12,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-http
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/charts/thanos/templates/store-pvc.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-pvc.yaml
@@ -7,6 +7,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Values.store.dataVolume.persistentVolumeClaim.claimName }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/cost-analyzer/charts/thanos/templates/store-service.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-grpc
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.store.grpc.service.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -35,6 +36,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}-http
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.store.http.service.annotations }}
   annotations: {{ toYaml .| nindent 4 }}
   {{- end }}

--- a/cost-analyzer/charts/thanos/templates/store-servicemonitor.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "thanos.componentname" (list $ "store") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "thanos.name" . }}
     helm.sh/chart: {{ include "thanos.chart" . }}

--- a/cost-analyzer/templates/alibaba-service-key-secret.yaml
+++ b/cost-analyzer/templates/alibaba-service-key-secret.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-service-key
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque

--- a/cost-analyzer/templates/aws-service-key-secret.yaml
+++ b/cost-analyzer/templates/aws-service-key-secret.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-service-key
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque

--- a/cost-analyzer/templates/awsstore-deployment-template.yaml
+++ b/cost-analyzer/templates/awsstore-deployment-template.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-awsstore
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/templates/awsstore-service-account-template.yaml
+++ b/cost-analyzer/templates/awsstore-service-account-template.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: awsstore-serviceaccount
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 {{- with .Values.awsstore.annotations }}

--- a/cost-analyzer/templates/azure-service-key-secret.yaml
+++ b/cost-analyzer/templates/azure-service-key-secret.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-service-key
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque

--- a/cost-analyzer/templates/azure-storage-config-secret.yaml
+++ b/cost-analyzer/templates/azure-storage-config-secret.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: azure-storage-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque

--- a/cost-analyzer/templates/cost-analyzer-advanced-reports-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-advanced-reports-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{default "advanced-report-configs" .Values.advancedReportConfigmapName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-alerts-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-alerts-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ default "alert-configs" .Values.alertConfigmapName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-asset-reports-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-asset-reports-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ default "asset-report-configs" .Values.assetReportConfigmapName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-cluster-role-binding-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-binding-template.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "cost-analyzer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 roleRef:

--- a/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-db-pvc-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-db-pvc-template.yaml
@@ -7,6 +7,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-db
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 {{- if .Values.kubecostDeployment }}

--- a/cost-analyzer/templates/cost-analyzer-federator-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-federator-config-map-template.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-federator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -10,6 +10,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-conf
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/cost-analyzer/templates/cost-analyzer-metrics-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-metrics-config-map-template.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ default "metrics-config" .Values.metricsConfigmapName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: network-costs-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-network-costs-podmonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-podmonitor-template.yaml
@@ -6,6 +6,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "cost-analyzer.networkCostsName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.networkCosts.podMonitor.additionalLabels }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- if (or .Values.networkCosts.service.annotations .Values.networkCosts.prometheusScrape) }}
   annotations:
 {{- if .Values.networkCosts.service.annotations }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "cost-analyzer.daemonset.apiVersion" . }}
 kind: DaemonSet
 metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 {{- if .Values.networkCosts.additionalLabels }}

--- a/cost-analyzer/templates/cost-analyzer-network-policy.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-policy.yaml
@@ -5,6 +5,7 @@ kind: NetworkPolicy
 {{- if .Values.networkPolicy.denyEgress }}
 metadata:
   name: deny-egress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-oidc
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-pkey-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pkey-configmap.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ default "product-configs" .Values.productConfigmapName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ default "pricing-configs" .Values.pricingConfigmapName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-prometheus-postgres-adapter-deployment.yaml
+++ b/cost-analyzer/templates/cost-analyzer-prometheus-postgres-adapter-deployment.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-adapter
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/templates/cost-analyzer-prometheus-postgres-adapter-service.yaml
+++ b/cost-analyzer/templates/cost-analyzer-prometheus-postgres-adapter-service.yaml
@@ -5,6 +5,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: pgprometheus-adapter
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/templates/cost-analyzer-prometheusrule-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-prometheusrule-template.yaml
@@ -7,6 +7,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "cost-analyzer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.prometheusRule.additionalLabels }}

--- a/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-psp
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
   annotations:

--- a/cost-analyzer/templates/cost-analyzer-psp-rolebinding.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp-rolebinding.template.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
     name: {{ template "cost-analyzer.fullname" . }}-psp
+    namespace: {{ .Release.Namespace }}
     labels:
       {{ include "cost-analyzer.commonLabels" . | nindent 6 }}
 roleRef:

--- a/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/templates/cost-analyzer-saml-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-saml-config-map-template.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-saml
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-saved-reports-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-saved-reports-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{default "saved-report-configs" .Values.savedReportConfigmapName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-server-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-server-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ default "app-configs" .Values.appConfigmapName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-service-account-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-account-template.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "cost-analyzer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 {{- with .Values.serviceAccount.annotations }}

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -5,6 +5,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ template "cost-analyzer.serviceName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 {{- if .Values.service.labels }}

--- a/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cost-analyzer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.additionalLabels }}

--- a/cost-analyzer/templates/external-grafana-config-map-template.yaml
+++ b/cost-analyzer/templates/external-grafana-config-map-template.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: external-grafana-config-map
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/kubecost-agent-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secret-template.yaml
@@ -4,6 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ .Values.agentKeySecretName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
@@ -8,6 +8,7 @@ apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
   name: {{ .Values.agentCsi.secretProvider.name }}
+  namespace: {{ .Release.Namespace }}
   labels: {{ unset (include "cost-analyzer.commonLabels" . | fromYaml) "app" | toYaml | nindent 4 }}
     app: {{ template "kubecost.kubeMetricsName" . }}
 spec:

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 ---
@@ -168,6 +169,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
@@ -244,6 +246,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}-service
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:

--- a/cost-analyzer/templates/kubecost-cluster-manager-configmap-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-manager-configmap-template.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubecost-clusters
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ unset (include "cost-analyzer.commonLabels" . | fromYaml) "app" | toYaml | nindent 4 }}
     app: {{ template "kubecost.kubeMetricsName" . }}

--- a/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
@@ -7,6 +7,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "kubecost.kubeMetricsName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.kubecostMetrics.exporter.serviceMonitor.additionalLabels }}

--- a/cost-analyzer/templates/kubecost-metrics-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-template.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kubecost.kubeMetricsName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 {{- if (or .Values.kubecostMetrics.exporter.service.annotations $prometheusScrape) }}

--- a/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
@@ -6,6 +6,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ .Values.oidc.secretName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 stringData:

--- a/cost-analyzer/templates/network-costs-role.template.yaml
+++ b/cost-analyzer/templates/network-costs-role.template.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-network-costs
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
   annotations:

--- a/cost-analyzer/templates/network-costs-rolebinding.template.yaml
+++ b/cost-analyzer/templates/network-costs-rolebinding.template.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
     name: {{ template "cost-analyzer.fullname" . }}-network-costs
+    namespace: {{ .Release.Namespace }}
     labels:
       {{ include "cost-analyzer.commonLabels" . | nindent 6 }}
 roleRef:

--- a/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cost-analyzer.networkCostsName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.networkCosts.additionalLabels }}


### PR DESCRIPTION
Signed-off-by: Linh Lam <linh@kubecost.com>

## What does this PR change?

Update chart to use helm release namespace to support the deployment method that utilizes Helm engine to generate manifests such as Amazon EKS add-on. Without these changes, the generated manifests have no metadata.namespace, which results in deploying resources to the `default` namespace

## Does this PR rely on any other PRs?

N/A


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Update chart to use helm release namespace to support the deployment method that utilizes Helm engine to generate manifests such as Amazon EKS add-on. Without these changes, the generated manifests have no metadata.namespace, which results in deploying resources to the `default` namespace

## Links to Issues or ZD tickets this PR addresses or fixes

https://github.com/kubecost/cost-analyzer-helm-chart/issues/1629

## How was this PR tested?

- command: `helm template kubecost cost-analyzer/ -n kubecost > /tmp/default-namespace-test`
- Results:
```yaml
# Source: cost-analyzer/templates/cost-analyzer-deployment-template.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: kubecost-cost-analyzer
  namespace: kubecost
....
```

## Have you made an update to documentation?

N/A
