### PR TITLE
Update cluster-controller to v0.6.0

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -713,7 +713,7 @@ kubecostDeployment:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.5.0
+  image: gcr.io/kubecost1/cluster-controller:v0.6.0
   imagePullPolicy: Always
   kubescaler:
     # If true, will cause all (supported) workloads to be have their requests


### PR DESCRIPTION
## What does this PR change?

Updated Cluster Controller to v0.6.0. Adds "Continuous Request Right-Sizing" support for DaemonSets and CronJobs. See [the documentation](https://docs.kubecost.com/using-kubecost/getting-started/auto-request-sizing/continuous-request-sizing) to learn how to use this functionality.

## Does this PR rely on any other PRs?

- Nope, all relevant Cluster Controller PRs are already merged.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

See "What does this PR change" for release note.

## Links to Issues or ZD tickets this PR addresses or fixes

- Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1926


## How was this PR tested?

- Installed in a k3d/k3s cluster, checked that the Schedule APIs are working for DaemonSet and CronJob workloads. Thorough testing of specific functionality was already achieved in base feature PRs. Also checked that image version was correct with `kubectl describe deployment`.

## Have you made an update to documentation?

N/A, already done as part of other work