### PR TITLE
If Thanos is enabled, then enable ETL backups by default

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -87,18 +87,21 @@ spec:
             items:
               - key: nginx.conf
                 path: default.conf
+        {{- /*
+          If Thanos is enabled, then enable ETL backups by default.
+          To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret=""
+        */}}
+        {{- $etlBackupBucketSecret := "" }}
         {{- if .Values.kubecostModel.etlBucketConfigSecret }}
-        - name: etl-bucket-config
-          secret:
-           defaultMode: 420
-           secretName: {{ .Values.kubecostModel.etlBucketConfigSecret }}
+            {{- $etlBackupBucketSecret = .Values.kubecostModel.etlBucketConfigSecret }}
         {{- else if and .Values.global.thanos.enabled (ne .Values.kubecostModel.etlBucketConfigSecret "") }}
-        {{- /* If Thanos is enabled, then enable ETL backups by default. */}}
-        {{- /* To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret="" */}}
+            {{- $etlBackupBucketSecret = .Values.thanos.storeSecretName }}
+        {{- end }}
+        {{- if $etlBackupBucketSecret }}
         - name: etl-bucket-config
           secret:
            defaultMode: 420
-           secretName: {{ .Values.thanos.storeSecretName }}
+           secretName: {{ $etlBackupBucketSecret }}
         {{- end }}
         {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
         - name: federated-storage-config
@@ -369,9 +372,7 @@ spec:
             # Extra volume mount(s)
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
-            {{- if or .Values.kubecostModel.etlBucketConfigSecret (and .Values.global.thanos.enabled (ne .Values.kubecostModel.etlBucketConfigSecret "")) }}
-            {{- /* If Thanos is enabled, then enable ETL backups by default. */}}
-            {{- /* To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret="" */}}
+            {{- if $etlBackupBucketSecret }}
             - name: etl-bucket-config
               mountPath: /var/configs/etl
               readOnly: true
@@ -654,9 +655,7 @@ spec:
             - name: ETL_READ_ONLY
               value: "true"
             {{- end }}
-            {{- if or .Values.kubecostModel.etlBucketConfigSecret (and .Values.global.thanos.enabled (ne .Values.kubecostModel.etlBucketConfigSecret "")) }}
-            {{- /* If Thanos is enabled, then enable ETL backups by default. */}}
-            {{- /* To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret="" */}}
+            {{- if $etlBackupBucketSecret }}
             - name: ETL_TO_DISK_ENABLED
               value: "false"
             - name: ETL_BUCKET_CONFIG

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -92,6 +92,12 @@ spec:
           secret:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.etlBucketConfigSecret }}
+        {{- else if .Values.global.thanos.enabled }}
+        # ETL backups are default enabled if the user has configured Thanos
+        - name: etl-bucket-config
+          secret:
+           defaultMode: 420
+           secretName: {{ .Values.thanos.storeSecretName }}
         {{- end }}
         {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
         - name: federated-storage-config
@@ -362,7 +368,7 @@ spec:
             # Extra volume mount(s)
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.kubecostModel.etlBucketConfigSecret }}
+            {{- if or .Values.kubecostModel.etlBucketConfigSecret .Values.global.thanos.enabled }}
             - name: etl-bucket-config
               mountPath: /var/configs/etl
               readOnly: true
@@ -645,7 +651,7 @@ spec:
             - name: ETL_READ_ONLY
               value: "true"
             {{- end }}
-            {{- if .Values.kubecostModel.etlBucketConfigSecret }}
+            {{- if or .Values.kubecostModel.etlBucketConfigSecret .Values.global.thanos.enabled }}
             - name: ETL_TO_DISK_ENABLED
               value: "false"
             - name: ETL_BUCKET_CONFIG

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -92,8 +92,9 @@ spec:
           secret:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.etlBucketConfigSecret }}
-        {{- else if .Values.global.thanos.enabled }}
-        # ETL backups are default enabled if the user has configured Thanos
+        {{- else if and .Values.global.thanos.enabled (ne .Values.kubecostModel.etlBucketConfigSecret "") }}
+        {{- /* If Thanos is enabled, then enable ETL backups by default. */}}
+        {{- /* To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret="" */}}
         - name: etl-bucket-config
           secret:
            defaultMode: 420
@@ -368,7 +369,9 @@ spec:
             # Extra volume mount(s)
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
-            {{- if or .Values.kubecostModel.etlBucketConfigSecret .Values.global.thanos.enabled }}
+            {{- if or .Values.kubecostModel.etlBucketConfigSecret (and .Values.global.thanos.enabled (ne .Values.kubecostModel.etlBucketConfigSecret "")) }}
+            {{- /* If Thanos is enabled, then enable ETL backups by default. */}}
+            {{- /* To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret="" */}}
             - name: etl-bucket-config
               mountPath: /var/configs/etl
               readOnly: true
@@ -651,7 +654,9 @@ spec:
             - name: ETL_READ_ONLY
               value: "true"
             {{- end }}
-            {{- if or .Values.kubecostModel.etlBucketConfigSecret .Values.global.thanos.enabled }}
+            {{- if or .Values.kubecostModel.etlBucketConfigSecret (and .Values.global.thanos.enabled (ne .Values.kubecostModel.etlBucketConfigSecret "")) }}
+            {{- /* If Thanos is enabled, then enable ETL backups by default. */}}
+            {{- /* To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret="" */}}
             - name: ETL_TO_DISK_ENABLED
               value: "false"
             - name: ETL_BUCKET_CONFIG


### PR DESCRIPTION
## What does this PR change?

If the user has enabled Thanos in their config, this change will automatically enable [ETL backups](https://docs.kubecost.com/install-and-configure/install/etl-backup) as well. This helps to prevent against data loss, and also enables users to view historical Kubecost data in the frontend beyond their configured `.Values.kubecostModel.etlDailyStoreDurationDays`.

If the user would like to opt out of this default ETL backup config, they will need to set the following config to an empty string: `.Values.kubecostModel.etlBucketConfigSecret=""`.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

If Thanos is enabled in the user's configuration, then ETL Backups will be enabled by default as well. This will push all Asset and Allocation ETLStores to the same cloud storage bucket they have configured for Thanos.

To opt out of ETL backups, set `.Values.kubecostModel.etlBucketConfigSecret=""`.

## Links to Issues or ZD tickets this PR addresses or fixes

None

## How was this PR tested?

Tested changes using Helm templating engine:

```bash
# 1) Thanos enabled. Expect to see ETL Backups enabled.
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer -n kubecost \
    -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/master/cost-analyzer/values-thanos.yaml

# 2) Thanos and ETL Backup enabled. Expect to see ETL Backups enabled using the specified etlBucketConfigSecret.
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer -n kubecost \
    --set kubecostModel.etlBucketConfigSecret="kubecost-etl-backup" \
    -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/master/cost-analyzer/values-thanos.yaml

# 3) Thanos not enabled. Expect to see ETL Backups disabled.
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer -n kubecost

# 4) Opt out of ETL Backup using empty string. Expect to see ETL Backups disabled.
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer -n kubecost \
    --set kubecostModel.etlBucketConfigSecret="" \
    -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/master/cost-analyzer/values-thanos.yaml
```

Also deployed the change and verified that ETLStores were uploaded to the configured cloud storage bucket

```bash
$ kubectl create secret generic kubecost-thanos -n kubecost --from-file=./object-store.yaml

# 1) Thanos enabled. Expect to see ETL Backups enabled
$ helm upgrade -i kubecost ./cost-analyzer-helm-chart/cost-analyzer -n kubecost \
    -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/master/cost-analyzer/values-thanos.yaml

# 2) Deploy without Thanos. Expect to see ETL Backups disabled
$ helm upgrade -i kubecost ~/kubecost/cost-analyzer-helm-chart/cost-analyzer -n kubecost

# 3) Thanos enabled, but opted out of ETL Backups. Expect to see ETL Backups disabled.
$ helm upgrade -i kubecost ~/kubecost/cost-analyzer-helm-chart/cost-analyzer -n kubecost \
    -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/master/cost-analyzer/values-thanos.yaml \
    --set kubecostModel.etlBucketConfigSecret=""
```

## Have you made an update to documentation?

Yes