### PR TITLE
Change flat manifest link from master to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ helm upgrade --install kubecost --namespace kubecost --create-namespace \
 While Helm is the [recommended install path](http://kubecost.com/install) for Kubecost, these resources can alternatively be deployed with a single-file manifest using the following command:<a name="manifest"></a>
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/master/kubecost.yaml --namespace kubecost
+kubectl apply -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/develop/kubecost.yaml --namespace kubecost
 ```
 
 <br/><br/>


### PR DESCRIPTION
## What does this PR change?

Title, see also linked issue below.

Realistically, we should link users to specific versions' flat manifests. E.g. https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/v1.99/kubecost.yaml

This is a shortcoming of our release process because (for good reasons) the release process avoids interacting with `develop` after the initial branch off.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A


## Links to Issues or ZD tickets this PR addresses or fixes

- Helps with https://github.com/kubecost/cost-analyzer-helm-chart/issues/1910


## How was this PR tested?

Link coming