### PR TITLE
Update Cluster Controller to v0.6.1

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -721,7 +721,7 @@ kubecostDeployment:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.6.0
+  image: gcr.io/kubecost1/cluster-controller:v0.6.1
   imagePullPolicy: Always
   kubescaler:
     # If true, will cause all (supported) workloads to be have their requests


### PR DESCRIPTION
## What does this PR change?

Contains a fix that prevent continuous request right-sizing from infinitely failing when the recommended request is above the current limit. Now, the request update is capped at the current limit.

## Does this PR rely on any other PRs?

- Contains this patch https://github.com/kubecost/cluster-controller/pull/33


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A


## How was this PR tested?

Testing done in original CC PR.

## Have you made an update to documentation?

https://github.com/kubecost/docs/pull/541