### PR TITLE
Cherry-pick PR #1931 into v1.100 branch "If Thanos is enabled, then enable ETL backups by default"

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -87,11 +87,21 @@ spec:
             items:
               - key: nginx.conf
                 path: default.conf
+        {{- /*
+          If Thanos is enabled, then enable ETL backups by default.
+          To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret=""
+        */}}
+        {{- $etlBackupBucketSecret := "" }}
         {{- if .Values.kubecostModel.etlBucketConfigSecret }}
+            {{- $etlBackupBucketSecret = .Values.kubecostModel.etlBucketConfigSecret }}
+        {{- else if and .Values.global.thanos.enabled (ne .Values.kubecostModel.etlBucketConfigSecret "") }}
+            {{- $etlBackupBucketSecret = .Values.thanos.storeSecretName }}
+        {{- end }}
+        {{- if $etlBackupBucketSecret }}
         - name: etl-bucket-config
           secret:
            defaultMode: 420
-           secretName: {{ .Values.kubecostModel.etlBucketConfigSecret }}
+           secretName: {{ $etlBackupBucketSecret }}
         {{- end }}
         {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
         - name: federated-storage-config
@@ -362,7 +372,7 @@ spec:
             # Extra volume mount(s)
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.kubecostModel.etlBucketConfigSecret }}
+            {{- if $etlBackupBucketSecret }}
             - name: etl-bucket-config
               mountPath: /var/configs/etl
               readOnly: true
@@ -645,7 +655,7 @@ spec:
             - name: ETL_READ_ONLY
               value: "true"
             {{- end }}
-            {{- if .Values.kubecostModel.etlBucketConfigSecret }}
+            {{- if $etlBackupBucketSecret }}
             - name: ETL_TO_DISK_ENABLED
               value: "false"
             - name: ETL_BUCKET_CONFIG


### PR DESCRIPTION
Cherry pick the changes made in https://github.com/kubecost/cost-analyzer-helm-chart/pull/1931 into the v1.100 branch
