### PR TITLE
Rename SVC to fit SVC naming rules

### DIFF
--- a/cost-analyzer/templates/kubecost-admission-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-admission-controller-template.yaml
@@ -3,9 +3,9 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: {{ template "cost-analyzer.fullname" . }}-deployment-validation
+  name: kubecost-deployment-validation
 webhooks:
-  - name: "{{ template "cost-analyzer.fullname" . }}-deployment-validation.kubecost.svc"
+  - name: "kubecost-deployment-validation.kubecost.svc"
     failurePolicy: Ignore
     namespaceSelector:
       matchExpressions:


### PR DESCRIPTION
## What does this PR change?
Addresses have rules like character limits. Let's hardcode the name of this webhook for now.


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Makes installation of the admissions controller much more consistent-- you can call the release what you like now.


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
```
helm install kubecost ./cost-analyzer -n kubecost --set kubecostAdmissionController.enabled=true
kubectl edit deployment -n kubecost                          
Warning: Deployment kubecost/kubecost-cost-analyzer will consume
Warning: Type | Unit Hrs | Cost | Diff
Warning: CPU  |    153.30|  4.85|4.85
Warning: RAM  |     78.42|  0.33|0.33
deployment.apps/kubecost-cost-analyzer edited
deployment.apps/kubecost-grafana skipped
deployment.apps/kubecost-kube-state-metrics skipped
deployment.apps/kubecost-prometheus-server skipped
```


## Have you made an update to documentation?

