### PR TITLE
Added namespace configuration for network cost exporter

### DIFF
--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -8,49 +8,50 @@ While Helm is the [recommended install path](http://kubecost.com/install), these
 <a name="config-options"></a><br/>
 The following table lists the commonly used configurable parameters of the Kubecost Helm chart and their default values.
 
-Parameter | Description | Default
---------- | ----------- | -------
-`global.prometheus.enabled` | If false, use an existing Prometheus install. [More info](http://docs.kubecost.com/custom-prom). | `true`
-`prometheus.kube-state-metrics.disabled` | If false, deploy [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) for Kubernetes metrics | `false`
-`prometheus.kube-state-metrics.resources` | Set kube-state-metrics resource requests and limits. | `{}`
-`prometheus.server.persistentVolume.enabled` | If true, Prometheus server will create a Persistent Volume Claim. | `true`
-`prometheus.server.persistentVolume.size` | Prometheus server data Persistent Volume size. Default set to retain ~6000 samples per second for 15 days. | `32Gi`
-`prometheus.server.retention` | Determines when to remove old data. | `15d`
-`prometheus.server.resources` | Prometheus server resource requests and limits. | `{}`
-`prometheus.nodeExporter.resources` | Node exporter resource requests and limits. | `{}`
-`prometheus.nodeExporter.enabled` `prometheus.serviceAccounts.nodeExporter.create` | If false, do not crate NodeExporter daemonset.  | `true`
-`prometheus.alertmanager.persistentVolume.enabled` | If true, Alertmanager will create a Persistent Volume Claim. | `true`
-`prometheus.pushgateway.persistentVolume.enabled` | If true, Prometheus Pushgateway will create a Persistent Volume Claim. | `true`
-`persistentVolume.enabled` | If true, Kubecost will create a Persistent Volume Claim for product config data.  | `true`
-`persistentVolume.size` | Define PVC size for cost-analyzer  | `32.0Gi`
-`persistentVolume.dbSize` | Define PVC size for cost-analyzer's flat file database  | `32.0Gi`
-`ingress.enabled` | If true, Ingress will be created | `false`
-`ingress.annotations` | Ingress annotations | `{}`
-`ingress.paths` | Ingress paths | `["/"]`
-`ingress.hosts` | Ingress hostnames | `[cost-analyzer.local]`
-`ingress.tls` | Ingress TLS configuration (YAML) | `[]`
-`networkPolicy.enabled` | If true, create a NetworkPolicy to deny egress  | `false`
-`networkPolicy.costAnalyzer.enabled` | If true, create a newtork policy for cost-analzyer | `false`
-`networkPolicy.costAnalyzer.annotations` | Annotations to be added to the network policy | `{}`
-`networkPolicy.costAnalyzer.additionalLabels` | Additional labels to be added to the network policy | `{}`
-`networkPolicy.costAnalyzer.ingressRules` | A list of network policy ingress rules | `null`
-`networkPolicy.costAnalyzer.egressRules` | A list of network policy egress rules | `null`
-`networkCosts.enabled` | If true, collect network allocation metrics [More info](http://docs.kubecost.com/network-allocation) | `false`
+Parameter | Description                                                                                                                                                  | Default
+--------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------| -------
+`global.prometheus.enabled` | If false, use an existing Prometheus install. [More info](http://docs.kubecost.com/custom-prom).                                                             | `true`
+`prometheus.kube-state-metrics.disabled` | If false, deploy [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) for Kubernetes metrics                                               | `false`
+`prometheus.kube-state-metrics.resources` | Set kube-state-metrics resource requests and limits.                                                                                                         | `{}`
+`prometheus.server.persistentVolume.enabled` | If true, Prometheus server will create a Persistent Volume Claim.                                                                                            | `true`
+`prometheus.server.persistentVolume.size` | Prometheus server data Persistent Volume size. Default set to retain ~6000 samples per second for 15 days.                                                   | `32Gi`
+`prometheus.server.retention` | Determines when to remove old data.                                                                                                                          | `15d`
+`prometheus.server.resources` | Prometheus server resource requests and limits.                                                                                                              | `{}`
+`prometheus.nodeExporter.resources` | Node exporter resource requests and limits.                                                                                                                  | `{}`
+`prometheus.nodeExporter.enabled` `prometheus.serviceAccounts.nodeExporter.create` | If false, do not crate NodeExporter daemonset.                                                                                                               | `true`
+`prometheus.alertmanager.persistentVolume.enabled` | If true, Alertmanager will create a Persistent Volume Claim.                                                                                                 | `true`
+`prometheus.pushgateway.persistentVolume.enabled` | If true, Prometheus Pushgateway will create a Persistent Volume Claim.                                                                                       | `true`
+`persistentVolume.enabled` | If true, Kubecost will create a Persistent Volume Claim for product config data.                                                                             | `true`
+`persistentVolume.size` | Define PVC size for cost-analyzer                                                                                                                            | `32.0Gi`
+`persistentVolume.dbSize` | Define PVC size for cost-analyzer's flat file database                                                                                                       | `32.0Gi`
+`ingress.enabled` | If true, Ingress will be created                                                                                                                             | `false`
+`ingress.annotations` | Ingress annotations                                                                                                                                          | `{}`
+`ingress.paths` | Ingress paths                                                                                                                                                | `["/"]`
+`ingress.hosts` | Ingress hostnames                                                                                                                                            | `[cost-analyzer.local]`
+`ingress.tls` | Ingress TLS configuration (YAML)                                                                                                                             | `[]`
+`networkPolicy.enabled` | If true, create a NetworkPolicy to deny egress                                                                                                               | `false`
+`networkPolicy.costAnalyzer.enabled` | If true, create a newtork policy for cost-analzyer                                                                                                           | `false`
+`networkPolicy.costAnalyzer.annotations` | Annotations to be added to the network policy                                                                                                                | `{}`
+`networkPolicy.costAnalyzer.additionalLabels` | Additional labels to be added to the network policy                                                                                                          | `{}`
+`networkPolicy.costAnalyzer.ingressRules` | A list of network policy ingress rules                                                                                                                       | `null`
+`networkPolicy.costAnalyzer.egressRules` | A list of network policy egress rules                                                                                                                        | `null`
+`networkCosts.enabled` | If true, collect network allocation metrics [More info](http://docs.kubecost.com/network-allocation)                                                         | `false`
 `networkCosts.podMonitor.enabled` | If true, a [PodMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#podmonitor) for the network-cost daemonset is created | `false`
-`serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
-`serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
-`prometheusRule.enabled` | Set this to `true` to create PrometheusRule for Prometheus operator | `false`
-`prometheusRule.additionalLabels` | Additional labels that can be used so PrometheusRule will be discovered by Prometheus | `{}`
-`grafana.resources` | Grafana resource requests and limits. | `{}`
-`grafana.sidecar.datasources.defaultDatasourceEnabled` | Set this to `false` to disable creation of Prometheus datasource in Grafana | `true`
-`serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`
-`tolerations` | node taints to tolerate | `[]`
-`affinity` | pod affinity | `{}`
-`kubecostProductConfigs.productKey.mountPath` | Use instead of `kubecostProductConfigs.productKey.secretname` to declare the path at which the product key file is mounted (eg. by a secrets provisioner) | `N/A`
-`kubecostFrontend.api.fqdn` | Customize the upstream api FQDN | `computed in terms of the service name and namespace`
-`kubecostFrontend.model.fqdn` | Customize the upstream model FQDN | `computed in terms of the service name and namespace`
-`clusterController.fqdn` | Customize the upstream cluster controller FQDN | `computed in terms of the service name and namespace`
-`global.grafana.fqdn` | Customize the upstream grafana FQDN | `computed in terms of the release name and namespace`
+`networkCosts.namespace` | If set, network-cost pod and resources will be provided in a custom namespace                                                                                | `.Release.Namespace`
+`serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator                                                                                          | `false`
+`serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                                                        | `{}`
+`prometheusRule.enabled` | Set this to `true` to create PrometheusRule for Prometheus operator                                                                                          | `false`
+`prometheusRule.additionalLabels` | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                                                        | `{}`
+`grafana.resources` | Grafana resource requests and limits.                                                                                                                        | `{}`
+`grafana.sidecar.datasources.defaultDatasourceEnabled` | Set this to `false` to disable creation of Prometheus datasource in Grafana                                                                                  | `true`
+`serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own                                                           | `true`
+`tolerations` | node taints to tolerate                                                                                                                                      | `[]`
+`affinity` | pod affinity                                                                                                                                                 | `{}`
+`kubecostProductConfigs.productKey.mountPath` | Use instead of `kubecostProductConfigs.productKey.secretname` to declare the path at which the product key file is mounted (eg. by a secrets provisioner)    | `N/A`
+`kubecostFrontend.api.fqdn` | Customize the upstream api FQDN                                                                                                                              | `computed in terms of the service name and namespace`
+`kubecostFrontend.model.fqdn` | Customize the upstream model FQDN                                                                                                                            | `computed in terms of the service name and namespace`
+`clusterController.fqdn` | Customize the upstream cluster controller FQDN                                                                                                               | `computed in terms of the service name and namespace`
+`global.grafana.fqdn` | Customize the upstream grafana FQDN                                                                                                                          | `computed in terms of the release name and namespace`
 
 
 ## Testing

--- a/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: network-costs-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.networkCosts.namespace | default .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:

--- a/cost-analyzer/templates/cost-analyzer-network-costs-podmonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-podmonitor-template.yaml
@@ -6,7 +6,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "cost-analyzer.networkCostsName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.networkCosts.namespace | default .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.networkCosts.podMonitor.additionalLabels }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.networkCosts.namespace | default .Release.Namespace }}
 {{- if (or .Values.networkCosts.service.annotations .Values.networkCosts.prometheusScrape) }}
   annotations:
 {{- if .Values.networkCosts.service.annotations }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "cost-analyzer.daemonset.apiVersion" . }}
 kind: DaemonSet
 metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.networkCosts.namespace | default .Release.Namespace }}
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 {{- if .Values.networkCosts.additionalLabels }}

--- a/cost-analyzer/templates/network-costs-role.template.yaml
+++ b/cost-analyzer/templates/network-costs-role.template.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-network-costs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.networkCosts.namespace | default .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
   annotations:

--- a/cost-analyzer/templates/network-costs-rolebinding.template.yaml
+++ b/cost-analyzer/templates/network-costs-rolebinding.template.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
     name: {{ template "cost-analyzer.fullname" . }}-network-costs
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.networkCosts.namespace | default .Release.Namespace }}
     labels:
       {{ include "cost-analyzer.commonLabels" . | nindent 6 }}
 roleRef:

--- a/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cost-analyzer.networkCostsName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.networkCosts.namespace | default .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.networkCosts.additionalLabels }}


### PR DESCRIPTION
## What does this PR change?
Adds the option to configure a namespace for the network cost pod

## Does this PR rely on any other PRs?
## - Based on develop at 07.02.2023
## How does this PR impact users? (This is the kind of thing that goes in release notes!)
At the moment, only release namespace was supported. This is not helpful for more complex product setups, in specific as prometheus is not scanning every namespace for monitors by default.

## Links to Issues or ZD tickets this PR addresses or fixes
## - 
## How was this PR tested?
Only local rendering was tested. A review is required in relation to the policy changes.

## Have you made an update to documentation?
Added value to the README



┆Issue is synchronized with this [Jira Task](https://kubecost.atlassian.net/browse/GIB-244) by [Unito](https://www.unito.io)
