### PR TITLE
fix bring your own prometheus-node-exporter and kube-state-metrics

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1289,7 +1289,7 @@ serverFiles:
             regex: true
           - source_labels: [__meta_kubernetes_endpoints_name]
             action: keep
-            regex: (kubecost-kube-state-metrics|kubecost-prometheus-node-exporter|kubecost-network-costs)
+            regex: (.*kube-state-metrics|.*prometheus-node-exporter|kubecost-network-costs)
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
             action: replace
             target_label: __scheme__


### PR DESCRIPTION
## What does this PR change?

updates the scrape config job `kubernetes-service-endpoints`

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Bug fix

## Links to Issues or ZD tickets this PR addresses or fixes

- #1975 


## How was this PR tested?
tested with `helm template` and installed. Both with kubecost included prometheus-node-exporter & kube-state-metrics and then again with BYO prometheus-node-exporter & kube-state-metrics 

## Have you made an update to documentation?

┆Issue is synchronized with this [Jira Task](https://kubecost.atlassian.net/browse/GIB-267) by [Unito](https://www.unito.io)
