### PR TITLE
Update Cluster Controller to v0.6.2

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -721,7 +721,7 @@ kubecostDeployment:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.6.1
+  image: gcr.io/kubecost1/cluster-controller:v0.6.2
   imagePullPolicy: Always
   kubescaler:
     # If true, will cause all (supported) workloads to be have their requests


### PR DESCRIPTION
## What does this PR change?
Changes in one PR: https://github.com/kubecost/cluster-controller/pull/35


## Does this PR rely on any other PRs?

- https://github.com/kubecost/cluster-controller/pull/35


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
See other PR release note

## How was this PR tested?
See other PR.

┆Issue is synchronized with this [Jira Task](https://kubecost.atlassian.net/browse/GIB-272) by [Unito](https://www.unito.io)
