### PR TITLE
Update Network Costs to v16.5

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -663,6 +663,14 @@ networkCosts:
       # classified as non-internet egress from one region to another.
       cross-region: []
 
+      # Internet contains a list of address/range that will be
+      # classified as internet traffic. This is synonymous with traffic
+      # that cannot be classified within the cluster. 
+      # NOTE: Internet classification filters are executed _after_ 
+      # NOTE: direct-classification, but before in-zone, in-region,
+      # NOTE: and cross-region. 
+      internet: []
+
       # Direct Classification specifically maps an ip address or range
       # to a region (required) and/or zone (optional). This classification
       # takes priority over in-zone, in-region, and cross-region configurations.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -611,7 +611,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v16.4
+  image: gcr.io/kubecost1/kubecost-network-costs:v16.5
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
## What does this PR change?
* Updates `network-costs` version to `v16.5`:
    * Adds an internet filter to the configuration, allow it to be the first operation checked during filtering.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Adds an internet filter to the configuration, allow it to be the first operation checked during filtering.

# Tickets Addressed
* https://github.com/kubecost/kubecost-cost-model/issues/1095

## How was this PR tested?
Live environment 

## Have you made an update to documentation?
* Inline documentation on the field in configuration stubs. 
```
# Internet contains a list of address/range that will be
# classified as internet traffic. This is synonymous with traffic
# that cannot be classified within the cluster. 
# NOTE: Internet classification filters are executed _after_ 
# NOTE: direct-classification, but before in-zone, in-region,
# NOTE: and cross-region. 
```

