### PR TITLE
Disable bundled KSM's collectors

### DIFF
--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/values.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/values.yaml
@@ -89,14 +89,14 @@ podAnnotations: {}
 # Available collectors for kube-state-metrics. By default all available
 # collectors are enabled.
 collectors:
-  certificatesigningrequests: true
+  certificatesigningrequests: false
   configmaps: true
   cronjobs: true
   daemonsets: true
   deployments: true
   endpoints: true
   horizontalpodautoscalers: true
-  ingresses: true
+  ingresses: false
   jobs: true
   limitranges: true
   mutatingwebhookconfigurations: false


### PR DESCRIPTION
## What does this PR change?

Beginning in Kubernetes v1.22, the following APIs were deprecated: `/apis/certificates.k8s.io/v1beta1/certificatesigningrequests`, `/apis/extensions/v1beta1/ingresses`. However, Kubecost’s bundled kube-state-metrics (KSM) v1.9.8 was still making frequent requests to those endpoints. This incurs costs to the Kubernetes API server and logging systems.

This PR default disables the `collector.ingresses` and `collector.certificatesigningrequests`.

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- There should be no impact because Kubecost does not use KSM’s metrics related to ingresses and certificate signing requests.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1493

## How was this PR tested?

- Deployed default Kubecost configuration `helm upgrade -i kubecost ./cost-analyzer-helm-chart/cost-analyzer` and verified in KSM’s logs that collectors were disabled.

## Have you made an update to documentation?

- Not needed