### PR TITLE
Turn off Cloud Usage pipeline by default (require opt-in)

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -715,7 +715,7 @@ spec:
             {{- else if kindIs "bool" .Values.kubecostModel.etlCloudAsset }}
               value: {{ (quote .Values.kubecostModel.etlCloudAsset) }}
             {{- else }}
-              value: "true"
+              value: "false"
             {{- end }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}


### PR DESCRIPTION
## What does this PR change?
Turns off Cloud Usage pipeline by default. Users can still opt-in.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Turns off Cloud Usage pipeline by default. Cloud Usage is on a deprecation plan, with Cloud Costs replacing it. Users can still opt-into Cloud Usage for the time being.

## How was this PR tested?
Manually

## Have you made an update to documentation?
No
