### PR TITLE
Change registry url to registry.k8s.io

### DIFF
--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/values.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 # Default values for kube-state-metrics.
 prometheusScrape: true
 image:
-  repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
+  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
   tag: v1.9.8
   pullPolicy: IfNotPresent
 

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -20757,7 +20757,7 @@ spec:
 
 
         imagePullPolicy: IfNotPresent
-        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8"
+        image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8"
         ports:
         - containerPort: 8080
         livenessProbe:


### PR DESCRIPTION
## What does this PR change?

as k8s.gcr.io will be frozen and will need to replace it with `registry.k8s.io`

Ref: https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/

## Does this PR rely on any other PRs?

No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

there is no direct impact on the users.


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?

