### PR TITLE
minor fixes for hosted agent

### DIFF
--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -73,7 +73,7 @@ prometheus:
     enableAdminApi: true
     sidecarContainers:
     - name: thanos-sidecar
-      image: thanosio/thanos:v0.22.0
+      image: thanosio/thanos:v0.29.0
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -1,5 +1,14 @@
 # Kubecost running as an Agent is designed for external hosting. The current setup deploys a
 # kubecost-agent pod, low data retention prometheus server + thanos sidecar, and node-exporter.
+networkCosts:
+  enabled: false
+  # config:
+  #   services:
+  #     amazon-web-services: true
+  #     google-cloud-services: true
+  #     azure-cloud-services: true
+
+
 global:
   thanos:
     enabled: false
@@ -12,6 +21,7 @@ agentCsi:
 # with enhancements designed for external hosting.
 agent: true
 # agentKeySecretName: kubecost-agent-object-store
+
 
 # No Grafana configuration is required.
 grafana:
@@ -37,18 +47,17 @@ prometheus:
     enabled: false
     disabled: true
   extraScrapeConfigs: |
-    - job_name: kubecost
+    - job_name: kubecost-agent
       honor_labels: true
       scrape_interval: 1m
       scrape_timeout: 60s
       metrics_path: /metrics
-      kubernetes_sd_configs:
-        - role: pod
-      relabel_configs:
-      # Scrape only the the targets matching the following metadata
-        - source_labels: [__meta_kubernetes_pod_label_app]
-          action: keep
-          regex:  kubecost-agent-agent
+      scheme: http
+      dns_sd_configs:
+      - names:
+        - kubecost-agent-agent
+        type: 'A'
+        port: 9005
     - job_name: kubecost-networking
       kubernetes_sd_configs:
         - role: pod

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -27,13 +27,33 @@ kubecostMetrics:
     exportClusterInfo: true
     exportClusterCache: true
 
-# Prometheus defaults to low rentention (10h), disables KSM, and attaches a thanos-sidecar
+# Prometheus defaults to low retention (10h), disables KSM, and attaches a thanos-sidecar
 # for exporting metrics.
 prometheus:
   kube-state-metrics:
     enabled: false
     disabled: true
-
+  extraScrapeConfigs: |
+    - job_name: kubecost
+      honor_labels: true
+      scrape_interval: 1m
+      scrape_timeout: 60s
+      metrics_path: /metrics
+      kubernetes_sd_configs:
+        - role: pod
+      relabel_configs:
+      # Scrape only the the targets matching the following metadata
+        - source_labels: [__meta_kubernetes_pod_label_app]
+          action: keep
+          regex:  kubecost-agent-agent
+    - job_name: kubecost-networking
+      kubernetes_sd_configs:
+        - role: pod
+      relabel_configs:
+      # Scrape only the the targets matching the following metadata
+        - source_labels: [__meta_kubernetes_pod_label_app]
+          action: keep
+          regex:  {{ template "cost-analyzer.networkCostsName" . }}
   server:
     extraArgs:
       storage.tsdb.min-block-duration: 2h

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -6,7 +6,8 @@ global:
   grafana:
     enabled: false
     proxy: false
-
+agentCsi:
+  enabled: false
 # Agent enables specific features designed to enhance the metrics exporter deployment
 # with enhancements designed for external hosting.
 agent: true

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -31,6 +31,8 @@ kubecostMetrics:
 # Prometheus defaults to low retention (10h), disables KSM, and attaches a thanos-sidecar
 # for exporting metrics.
 prometheus:
+  nodeExporter:
+    enabled: false
   kube-state-metrics:
     enabled: false
     disabled: true


### PR DESCRIPTION
## What does this PR change?

This only impacts users that are applying this file during helm installs of the hosted-agent. It is not in any other install path.

## Fixes 

`Failed to get upgrade info: template: cost-analyzer/templates/kubecost-metrics-deployment-template.yaml:47:24: executing "cost-analyzer/templates/kubecost-metrics-deployment-template.yaml" at <.Values.agentCsi.enabled>: nil pointer evaluating interface {}.enabled
`

and 

Prometheus targets broken after https://github.com/kubecost/cost-analyzer-helm-chart/pull/1805
1805 is a good cange. this workaround for hosted agents is simple enough. 

## Does this PR rely on any other PRs?

NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Only hosted kubecost

## Links to Issues or ZD tickets this PR addresses or fixes

## How was this PR tested?

Multiple customers using directly from this branch

## Have you made an update to documentation?

NA