### PR TITLE
Add required values in sample savedReports

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -108,7 +108,9 @@ global:
       - title: "Example Saved Report 0"
         window: "today"
         aggregateBy: "namespace"
+        chartDisplay: "category"
         idle: "separate"
+        rate: "cumulative"
         accumulate: false # daily resolution
         filters:
           - property: "cluster"
@@ -118,7 +120,9 @@ global:
       - title: "Example Saved Report 1"
         window: "month"
         aggregateBy: "controllerKind"
+        chartDisplay: "category"
         idle: "share"
+        rate: "monthly"
         accumulate: false
         filters:
           - property: "label"
@@ -128,7 +132,9 @@ global:
       - title: "Example Saved Report 2"
         window: "2020-11-11T00:00:00Z,2020-12-09T23:59:59Z"
         aggregateBy: "service"
+        chartDisplay: "category"
         idle: "hide"
+        rate: "daily"
         accumulate: true # entire window resolution
         filters: [] # if no filters, specify empty array
 


### PR DESCRIPTION
## What does this PR change?
This PR adds the `chartDisplay` and `rate` fields to the sample `savedReports` in values.yaml.

## Does this PR rely on any other PRs?
Related docs PR https://github.com/kubecost/docs/pull/571

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can see all the parameters required when supplying an allocation report definition via helm values. 

## Links to Issues or ZD tickets this PR addresses or fixes
Addresses https://github.com/kubecost/cost-analyzer-helm-chart/issues/2003

## How was this PR tested?
N/A

## Have you made an update to documentation?
https://github.com/kubecost/docs/pull/571
