### PR TITLE
Set up helm param for Cost Audit Event pipeline

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -929,6 +929,10 @@ spec:
             - name: GOOGLE_ANALYTICS_TAG
               value: {{ .Values.reporting.googleAnalyticsTag }}
             {{- end }}
+            {{- if .Values.costEventsAudit }}
+            - name: COST_EVENTS_AUDIT_ENABLED
+              value: {{ (quote .Values.costEventsAudit.enabled) | default (quote false) }}
+            {{- end }}
             {{- /*
               Leader/Follower has baseline requirements before enabling:
                 * ETL FileStore Enabled

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -857,6 +857,13 @@ federatedETL:
 kubecostAdmissionController:
   enabled: false
 
+# Enables or disables the Cost Event Audit pipeline, which tracks recent changes at cluster level
+# and provides an estimated cost impact via the Kubecost Predict API.
+#
+# It is disabled by default to avoid problems in high-scale environments.
+costEventsAudit:
+  enabled: false
+
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request
 
 # These configs can also be set from the Settings page in the Kubecost product UI


### PR DESCRIPTION
## What does this PR change?
This PR introduces a `.Values.costEventsAudit.enabled` helm value linked to an `COST_EVENTS_AUDIT_ENABLED` environment variable. This enables/disables the cost event audit pipeline. 

## Does this PR rely on any other PRs?
KCM PR: https://github.com/kubecost/kubecost-cost-model/pull/1273

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can control whether the cost event audit pipeline is enabled/disabled via this control. Particularly useful for large scale customers where the impact of the Kubernetes API watchers can be unexpected.

## Links to Issues or ZD tickets this PR addresses or fixes
N/A

## How was this PR tested?
Local helm template and upgrade in local cluster, verifying that if value is set in values.yaml, the same boolean is reflected in the container envvar.

## Have you made an update to documentation?
Public docs should include this note. PR TBD.
