### PR TITLE
Network Costs to v0.16.6

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -618,7 +618,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v16.5
+  image: gcr.io/kubecost1/kubecost-network-costs:v0.16.6
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
## What does this PR change?
* Ensure we include the semver formatted version in the helm chart for network-costs
  * No major changes to network-costs other than ensuring we version on semver compatible policy. 

