### PR TITLE
Add primaryClusterID to federator configuration

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -853,6 +853,8 @@ federatedETL:
     # federator.clusters is an optional whitelist of clusters by cluster id.
     # If not set, the federator will attempt to federated all clusters pushing to the federated storage.
     clusters: []
+    # federator.primaryClusterID is an optional parameter that should be used when reconciliation is expected to occur on the Primary.
+    # primaryClusterID: "cluster_id" 
 
 kubecostAdmissionController:
   enabled: false


### PR DESCRIPTION
## What does this PR change?
Adds `federator.primaryClusterID` to federated ETL configs, so that the federator can avoid overwriting extant merged data on the primary.


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/1287
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
See linked KCCM PR


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
See linked KCCM PR

## Have you made an update to documentation?

