### PR TITLE
Added PSP capability check to cost-analyzer-psp-role.template.yaml and cost-analyzer-psp-rolebinding.template.yaml

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.podSecurityPolicy }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,5 +18,6 @@ rules:
   verbs: ['use']
   resourceNames:
   - {{ template "cost-analyzer.fullname" . }}-psp
+{{- end }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-psp-rolebinding.template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-psp-rolebinding.template.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.podSecurityPolicy }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,5 +16,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "cost-analyzer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?

Disables the podSecurityPolicy role and roleBinding when using Kubernetes >= v1.25. This mirrors the previous [change](https://github.com/kubecost/cost-analyzer-helm-chart/commit/80f0eb09bcec5fe3bbcd9278b4011e3866655868) in [cost-analyzer-psp.template.yaml](https://github.com/kubecost/cost-analyzer-helm-chart/blob/develop/cost-analyzer/templates/cost-analyzer-psp.template.yaml)

## Does this PR rely on any other PRs?

No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- https://kubecost.zendesk.com/agent/tickets/3650

## How was this PR tested?

Was not tested

## Have you made an update to documentation?

No
