### PR TITLE
kubecost-1.101.3

### DIFF
--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -58,9 +58,9 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -254,7 +254,7 @@ data:
         source_labels:
         - __meta_kubernetes_service_annotation_prometheus_io_scrape
       - action: keep
-        regex: (kubecost-kube-state-metrics|kubecost-prometheus-node-exporter|kubecost-network-costs)
+        regex: (.*kube-state-metrics|.*prometheus-node-exporter|kubecost-network-costs)
         source_labels:
         - __meta_kubernetes_endpoints_name
       - action: replace
@@ -385,7 +385,7 @@ data:
         - source_labels: [__meta_kubernetes_pod_label_app]
           action: keep
           regex:  kubecost-network-costs
-    
+
   recording_rules.yml: |
     {}
   rules: |
@@ -434,9 +434,9 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -452,9 +452,9 @@ metadata:
   name: nginx-conf
   namespace: kubecost
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -522,7 +522,7 @@ data:
         location / {
             try_files $uri $uri/ /index.html;
         }
-        add_header ETag "1.100.0";
+        add_header ETag "1.101.3";
         listen 9090;
         listen [::]:9090;
         location /api/ {
@@ -606,7 +606,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
         }
-    
+
     }
 ---
 # Source: cost-analyzer/templates/grafana-attached-disk-metrics-template.yaml
@@ -615,9 +615,9 @@ kind: ConfigMap
 metadata:
   name: attached-disk-metrics-dashboard
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -1167,9 +1167,9 @@ kind: ConfigMap
 metadata:
   name: cluster-metrics-dashboard
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -2867,9 +2867,9 @@ kind: ConfigMap
 metadata:
   name: cluster-utilization-dashboard
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -6081,9 +6081,9 @@ kind: ConfigMap
 metadata:
   name: deployment-utilization-dashboard
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -7485,9 +7485,9 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboard-kubernetes-resource-efficiency
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -7911,9 +7911,9 @@ kind: ConfigMap
 metadata:
   name: label-cost-dashboard
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -9074,9 +9074,9 @@ kind: ConfigMap
 metadata:
   name: namespace-utilization-dashboard
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -9106,7 +9106,7 @@ data:
         	"id":9,
         	"iteration":1553150922105,
         	"links":[
-        
+
         	],
         	"panels":[
         		{
@@ -9127,7 +9127,7 @@ data:
         			"hideTimeOverride":true,
         			"id":73,
         			"links":[
-        
+
         			],
         			"pageSize":8,
         			"repeat":null,
@@ -9172,7 +9172,7 @@ data:
         					"decimals":2,
         					"pattern":"Value #B",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"decbytes"
@@ -9190,7 +9190,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value #A",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"percent"
@@ -9208,7 +9208,7 @@ data:
         					"mappingType":1,
         					"pattern":"Time",
         					"thresholds":[
-        
+
         					],
         					"type":"hidden",
         					"unit":"short"
@@ -9226,7 +9226,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value #C",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"currencyUSD"
@@ -9244,7 +9244,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value #D",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"currencyUSD"
@@ -9334,7 +9334,7 @@ data:
         			"hideTimeOverride":true,
         			"id":90,
         			"links":[
-        
+
         			],
         			"pageSize":8,
         			"repeatDirection":"v",
@@ -9358,7 +9358,7 @@ data:
         					"mappingType":1,
         					"pattern":"namespace",
         					"thresholds":[
-        
+
         					],
         					"type":"hidden",
         					"unit":"short"
@@ -9376,7 +9376,7 @@ data:
         					"mappingType":1,
         					"pattern":"persistentvolumeclaim",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"short"
@@ -9394,7 +9394,7 @@ data:
         					"mappingType":1,
         					"pattern":"storageclass",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"short"
@@ -9412,7 +9412,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"gbytes"
@@ -9430,7 +9430,7 @@ data:
         					"mappingType":1,
         					"pattern":"Time",
         					"thresholds":[
-        
+
         					],
         					"type":"hidden",
         					"unit":"short"
@@ -9457,7 +9457,7 @@ data:
         		},
         		{
         			"aliasColors":{
-        
+
         			},
         			"bars":false,
         			"dashLength":10,
@@ -9484,7 +9484,7 @@ data:
         			"lines":true,
         			"linewidth":1,
         			"links":[
-        
+
         			],
         			"nullPointMode":"null",
         			"percentage":false,
@@ -9492,7 +9492,7 @@ data:
         			"points":false,
         			"renderer":"flot",
         			"seriesOverrides":[
-        
+
         			],
         			"spaceLength":10,
         			"stack":false,
@@ -9506,7 +9506,7 @@ data:
         				}
         			],
         			"thresholds":[
-        
+
         			],
         			"timeFrom":null,
         			"timeShift":null,
@@ -9523,7 +9523,7 @@ data:
         				"name":null,
         				"show":true,
         				"values":[
-        
+
         				]
         			},
         			"yaxes":[
@@ -9551,7 +9551,7 @@ data:
         		},
         		{
         			"aliasColors":{
-        
+
         			},
         			"bars":false,
         			"dashLength":10,
@@ -9563,7 +9563,7 @@ data:
         			"error":false,
         			"fill":0,
         			"grid":{
-        
+
         			},
         			"gridPos":{
         				"h":6,
@@ -9593,7 +9593,7 @@ data:
         			"lines":true,
         			"linewidth":2,
         			"links":[
-        
+
         			],
         			"nullPointMode":"connected",
         			"percentage":false,
@@ -9601,7 +9601,7 @@ data:
         			"points":false,
         			"renderer":"flot",
         			"seriesOverrides":[
-        
+
         			],
         			"spaceLength":10,
         			"stack":false,
@@ -9621,7 +9621,7 @@ data:
         				}
         			],
         			"thresholds":[
-        
+
         			],
         			"timeFrom":"",
         			"timeShift":null,
@@ -9639,7 +9639,7 @@ data:
         				"name":null,
         				"show":true,
         				"values":[
-        
+
         				]
         			},
         			"yaxes":[
@@ -9668,7 +9668,7 @@ data:
         		},
         		{
         			"aliasColors":{
-        
+
         			},
         			"bars":false,
         			"dashLength":10,
@@ -9680,7 +9680,7 @@ data:
         			"error":false,
         			"fill":0,
         			"grid":{
-        
+
         			},
         			"gridPos":{
         				"h":6,
@@ -9707,7 +9707,7 @@ data:
         			"lines":true,
         			"linewidth":2,
         			"links":[
-        
+
         			],
         			"nullPointMode":"connected",
         			"percentage":false,
@@ -9715,7 +9715,7 @@ data:
         			"points":false,
         			"renderer":"flot",
         			"seriesOverrides":[
-        
+
         			],
         			"spaceLength":10,
         			"stack":false,
@@ -9731,7 +9731,7 @@ data:
         				}
         			],
         			"thresholds":[
-        
+
         			],
         			"timeFrom":"",
         			"timeShift":null,
@@ -9749,7 +9749,7 @@ data:
         				"name":null,
         				"show":true,
         				"values":[
-        
+
         				]
         			},
         			"yaxes":[
@@ -9778,7 +9778,7 @@ data:
         		},
         		{
         			"aliasColors":{
-        
+
         			},
         			"bars":false,
         			"dashLength":10,
@@ -9790,7 +9790,7 @@ data:
         			"error":false,
         			"fill":1,
         			"grid":{
-        
+
         			},
         			"gridPos":{
         				"h":6,
@@ -9820,7 +9820,7 @@ data:
         			"lines":true,
         			"linewidth":2,
         			"links":[
-        
+
         			],
         			"nullPointMode":"connected",
         			"percentage":false,
@@ -9828,7 +9828,7 @@ data:
         			"points":false,
         			"renderer":"flot",
         			"seriesOverrides":[
-        
+
         			],
         			"spaceLength":10,
         			"stack":false,
@@ -9858,7 +9858,7 @@ data:
         				}
         			],
         			"thresholds":[
-        
+
         			],
         			"timeFrom":"",
         			"timeShift":null,
@@ -9876,7 +9876,7 @@ data:
         				"name":null,
         				"show":true,
         				"values":[
-        
+
         				]
         			},
         			"yaxes":[
@@ -9904,7 +9904,7 @@ data:
         		},
         		{
         			"aliasColors":{
-        
+
         			},
         			"bars":false,
         			"dashLength":10,
@@ -9916,7 +9916,7 @@ data:
         			"error":false,
         			"fill":1,
         			"grid":{
-        
+
         			},
         			"gridPos":{
         				"h":6,
@@ -9946,7 +9946,7 @@ data:
         			"lines":true,
         			"linewidth":2,
         			"links":[
-        
+
         			],
         			"nullPointMode":"connected",
         			"percentage":false,
@@ -9954,7 +9954,7 @@ data:
         			"points":false,
         			"renderer":"flot",
         			"seriesOverrides":[
-        
+
         			],
         			"spaceLength":10,
         			"stack":false,
@@ -9984,7 +9984,7 @@ data:
         				}
         			],
         			"thresholds":[
-        
+
         			],
         			"timeFrom":"",
         			"timeShift":null,
@@ -10002,7 +10002,7 @@ data:
         				"name":null,
         				"show":true,
         				"values":[
-        
+
         				]
         			},
         			"yaxes":[
@@ -10178,7 +10178,7 @@ data:
         				"multi":false,
         				"name":"namespace",
         				"options":[
-        
+
         				],
         				"query":"query_result(sum(kube_namespace_created{namespace!=\"\"}) by (namespace))",
         				"refresh":1,
@@ -10187,7 +10187,7 @@ data:
         				"sort":0,
         				"tagValuesQuery":"",
         				"tags":[
-        
+
         				],
         				"tagsQuery":"",
         				"type":"query",
@@ -10196,7 +10196,7 @@ data:
         			{
         				"datasource":"${datasource}",
         				"filters":[
-        
+
         				],
         				"hide":0,
         				"label":"",
@@ -10267,9 +10267,9 @@ kind: ConfigMap
 metadata:
   name: node-utilization-dashboard
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -10298,7 +10298,7 @@ data:
         	"id":6,
         	"iteration":1557245882378,
         	"links":[
-        
+
         	],
         	"panels":[
         		{
@@ -10328,7 +10328,7 @@ data:
         			"id":2,
         			"interval":null,
         			"links":[
-        
+
         			],
         			"mappingType":1,
         			"mappingTypes":[
@@ -10410,7 +10410,7 @@ data:
         			"id":3,
         			"interval":null,
         			"links":[
-        
+
         			],
         			"mappingType":1,
         			"mappingTypes":[
@@ -10492,7 +10492,7 @@ data:
         			"id":4,
         			"interval":null,
         			"links":[
-        
+
         			],
         			"mappingType":1,
         			"mappingTypes":[
@@ -10565,7 +10565,7 @@ data:
         			"hideTimeOverride":true,
         			"id":21,
         			"links":[
-        
+
         			],
         			"pageSize":8,
         			"repeat":null,
@@ -10611,7 +10611,7 @@ data:
         					"mappingType":1,
         					"pattern":"Time",
         					"thresholds":[
-        
+
         					],
         					"type":"hidden",
         					"unit":"short"
@@ -10629,7 +10629,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value #C",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"short"
@@ -10647,7 +10647,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value #A",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"short"
@@ -10665,7 +10665,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value #B",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"short"
@@ -10683,7 +10683,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value #D",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"bytes"
@@ -10701,7 +10701,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value #E",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"bytes"
@@ -10719,7 +10719,7 @@ data:
         					"mappingType":1,
         					"pattern":"Value #F",
         					"thresholds":[
-        
+
         					],
         					"type":"number",
         					"unit":"bytes"
@@ -10790,7 +10790,7 @@ data:
         			"id":8,
         			"interval":null,
         			"links":[
-        
+
         			],
         			"mappingType":1,
         			"mappingTypes":[
@@ -10873,7 +10873,7 @@ data:
         			"id":18,
         			"interval":null,
         			"links":[
-        
+
         			],
         			"mappingType":1,
         			"mappingTypes":[
@@ -10955,7 +10955,7 @@ data:
         			"id":9,
         			"interval":null,
         			"links":[
-        
+
         			],
         			"mappingType":1,
         			"mappingTypes":[
@@ -11037,7 +11037,7 @@ data:
         			"id":19,
         			"interval":null,
         			"links":[
-        
+
         			],
         			"mappingType":1,
         			"mappingTypes":[
@@ -11094,7 +11094,7 @@ data:
         		},
         		{
         			"aliasColors":{
-        
+
         			},
         			"bars":false,
         			"dashLength":10,
@@ -11106,7 +11106,7 @@ data:
         			"error":false,
         			"fill":0,
         			"grid":{
-        
+
         			},
         			"gridPos":{
         				"h":6,
@@ -11136,7 +11136,7 @@ data:
         			"lines":true,
         			"linewidth":2,
         			"links":[
-        
+
         			],
         			"nullPointMode":"connected",
         			"percentage":false,
@@ -11144,7 +11144,7 @@ data:
         			"points":false,
         			"renderer":"flot",
         			"seriesOverrides":[
-        
+
         			],
         			"spaceLength":10,
         			"stack":false,
@@ -11164,7 +11164,7 @@ data:
         				}
         			],
         			"thresholds":[
-        
+
         			],
         			"timeFrom":"",
         			"timeShift":null,
@@ -11182,7 +11182,7 @@ data:
         				"name":null,
         				"show":true,
         				"values":[
-        
+
         				]
         			},
         			"yaxes":[
@@ -11211,7 +11211,7 @@ data:
         		},
         		{
         			"aliasColors":{
-        
+
         			},
         			"bars":false,
         			"dashLength":10,
@@ -11223,7 +11223,7 @@ data:
         			"error":false,
         			"fill":0,
         			"grid":{
-        
+
         			},
         			"gridPos":{
         				"h":6,
@@ -11250,7 +11250,7 @@ data:
         			"lines":true,
         			"linewidth":2,
         			"links":[
-        
+
         			],
         			"nullPointMode":"connected",
         			"percentage":false,
@@ -11258,7 +11258,7 @@ data:
         			"points":false,
         			"renderer":"flot",
         			"seriesOverrides":[
-        
+
         			],
         			"spaceLength":10,
         			"stack":false,
@@ -11277,7 +11277,7 @@ data:
         				}
         			],
         			"thresholds":[
-        
+
         			],
         			"timeFrom":"",
         			"timeShift":null,
@@ -11295,7 +11295,7 @@ data:
         				"name":null,
         				"show":true,
         				"values":[
-        
+
         				]
         			},
         			"yaxes":[
@@ -11324,7 +11324,7 @@ data:
         		},
         		{
         			"aliasColors":{
-        
+
         			},
         			"bars":false,
         			"dashLength":10,
@@ -11336,7 +11336,7 @@ data:
         			"error":false,
         			"fill":1,
         			"grid":{
-        
+
         			},
         			"gridPos":{
         				"h":6,
@@ -11366,7 +11366,7 @@ data:
         			"lines":true,
         			"linewidth":2,
         			"links":[
-        
+
         			],
         			"nullPointMode":"connected",
         			"percentage":false,
@@ -11374,7 +11374,7 @@ data:
         			"points":false,
         			"renderer":"flot",
         			"seriesOverrides":[
-        
+
         			],
         			"spaceLength":10,
         			"stack":false,
@@ -11404,7 +11404,7 @@ data:
         				}
         			],
         			"thresholds":[
-        
+
         			],
         			"timeFrom":"",
         			"timeShift":null,
@@ -11422,7 +11422,7 @@ data:
         				"name":null,
         				"show":true,
         				"values":[
-        
+
         				]
         			},
         			"yaxes":[
@@ -11450,7 +11450,7 @@ data:
         		},
         		{
         			"aliasColors":{
-        
+
         			},
         			"bars":false,
         			"dashLength":10,
@@ -11462,7 +11462,7 @@ data:
         			"error":false,
         			"fill":1,
         			"grid":{
-        
+
         			},
         			"gridPos":{
         				"h":6,
@@ -11492,7 +11492,7 @@ data:
         			"lines":true,
         			"linewidth":2,
         			"links":[
-        
+
         			],
         			"nullPointMode":"connected",
         			"percentage":false,
@@ -11500,7 +11500,7 @@ data:
         			"points":false,
         			"renderer":"flot",
         			"seriesOverrides":[
-        
+
         			],
         			"spaceLength":10,
         			"stack":false,
@@ -11530,7 +11530,7 @@ data:
         				}
         			],
         			"thresholds":[
-        
+
         			],
         			"timeFrom":"",
         			"timeShift":null,
@@ -11548,7 +11548,7 @@ data:
         				"name":null,
         				"show":true,
         				"values":[
-        
+
         				]
         			},
         			"yaxes":[
@@ -11597,7 +11597,7 @@ data:
         				"multi":false,
         				"name":"node",
         				"options":[
-        
+
         				],
         				"query":"query_result(kube_node_labels)",
         				"refresh":1,
@@ -11606,7 +11606,7 @@ data:
         				"sort":0,
         				"tagValuesQuery":"",
         				"tags":[
-        
+
         				],
         				"tagsQuery":"",
         				"type":"query",
@@ -11674,9 +11674,9 @@ kind: ConfigMap
 metadata:
   name: pod-utilization-dashboard
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -12642,9 +12642,9 @@ kind: ConfigMap
 metadata:
   name: prom-benchmark-dashboard
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -18349,9 +18349,9 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboard-networkcosts-metrics
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -19004,9 +19004,9 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboard-pod-utilization-multi-cluster
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -19860,9 +19860,9 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -19900,11 +19900,6 @@ metadata:
   name: kubecost-kube-state-metrics
 rules:
 
-- apiGroups: ["certificates.k8s.io"]
-  resources:
-  - certificatesigningrequests
-  verbs: ["list", "watch"]
-
 - apiGroups: [""]
   resources:
   - configmaps
@@ -19933,11 +19928,6 @@ rules:
 - apiGroups: ["autoscaling"]
   resources:
   - horizontalpodautoscalers
-  verbs: ["list", "watch"]
-
-- apiGroups: ["extensions", "networking.k8s.io"]
-  resources:
-  - ingresses
   verbs: ["list", "watch"]
 
 - apiGroups: ["batch"]
@@ -20057,9 +20047,9 @@ kind: ClusterRole
 metadata:
   name: kubecost-cost-analyzer
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20129,9 +20119,9 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - storage.k8s.io
-    resources: 
+    resources:
       - storageclasses
     verbs:
       - get
@@ -20210,9 +20200,9 @@ kind: ClusterRoleBinding
 metadata:
   name: kubecost-cost-analyzer
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20249,14 +20239,14 @@ metadata:
   namespace: kubecost
   name: kubecost-cost-analyzer
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
 rules:
-- apiGroups: 
+- apiGroups:
     - ''
   resources:
     - "pods/log"
@@ -20272,9 +20262,9 @@ metadata:
   name: kubecost-cost-analyzer-psp
   namespace: kubecost
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20312,9 +20302,9 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20334,9 +20324,9 @@ metadata:
     name: kubecost-cost-analyzer-psp
     namespace: kubecost
     labels:
-      
+
       app.kubernetes.io/name: cost-analyzer
-      helm.sh/chart: cost-analyzer-1.100.0
+      helm.sh/chart: cost-analyzer-1.101.3
       app.kubernetes.io/instance: kubecost
       app.kubernetes.io/managed-by: Helm
       app: cost-analyzer
@@ -20455,15 +20445,15 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
 spec:
   selector:
-    
+
     app.kubernetes.io/name: cost-analyzer
     app.kubernetes.io/instance: kubecost
     app: cost-analyzer
@@ -20555,7 +20545,7 @@ spec:
       app: grafana
       release: kubecost
   strategy:
-    type: RollingUpdate    
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -20602,7 +20592,7 @@ spec:
               subPath: provider.yaml
             - name: storage
               mountPath: "/var/lib/grafana"
-              subPath: 
+              subPath:
           ports:
             - name: service
               containerPort: 80
@@ -20683,8 +20673,6 @@ spec:
       - name: kube-state-metrics
         args:
 
-        - --collectors=certificatesigningrequests
-
 
         - --collectors=configmaps
 
@@ -20703,8 +20691,6 @@ spec:
 
         - --collectors=horizontalpodautoscalers
 
-
-        - --collectors=ingresses
 
 
         - --collectors=jobs
@@ -20757,7 +20743,7 @@ spec:
 
 
         imagePullPolicy: IfNotPresent
-        image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8"
+        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8"
         ports:
         - containerPort: 8080
         livenessProbe:
@@ -20877,9 +20863,9 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.100.0
+    helm.sh/chart: cost-analyzer-1.101.3
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20899,7 +20885,7 @@ spec:
   template:
     metadata:
       labels:
-        
+
         app.kubernetes.io/name: cost-analyzer
         app.kubernetes.io/instance: kubecost
         app: cost-analyzer
@@ -20924,8 +20910,8 @@ spec:
             claimName: kubecost-cost-analyzer
       initContainers:
       containers:
-        - image: gcr.io/kubecost1/cost-model:prod-1.100.0
-        
+        - image: gcr.io/kubecost1/cost-model:prod-1.101.3
+
           name: cost-model
           imagePullPolicy: Always
           ports:
@@ -20946,14 +20932,19 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 200
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 200
           volumeMounts:
             - name: persistent-configs
               mountPath: /var/configs
           env:
             - name: GRAFANA_ENABLED
               value: "true"
-            - name: HELM_VALUES
-              value: eyJhZmZpbml0eSI6e30sImF3c3N0b3JlIjp7ImNyZWF0ZVNlcnZpY2VBY2NvdW50IjpmYWxzZSwidXNlQXdzU3RvcmUiOmZhbHNlfSwiZXh0cmFWb2x1bWVNb3VudHMiOltdLCJleHRyYVZvbHVtZXMiOltdLCJmZWRlcmF0ZWRFVEwiOnsiZmVkZXJhdGVkQ2x1c3RlciI6ZmFsc2UsInByaW1hcnlDbHVzdGVyIjpmYWxzZSwicmVkaXJlY3RTM0JhY2t1cCI6ZmFsc2UsInVzZUV4aXN0aW5nUzNDb25maWciOmZhbHNlfSwiZ2xvYmFsIjp7ImFkZGl0aW9uYWxMYWJlbHMiOnt9LCJncmFmYW5hIjp7ImRvbWFpbk5hbWUiOiJjb3N0LWFuYWx5emVyLWdyYWZhbmEuZGVmYXVsdC5zdmMiLCJlbmFibGVkIjp0cnVlLCJwcm94eSI6dHJ1ZSwic2NoZW1lIjoiaHR0cCJ9LCJub3RpZmljYXRpb25zIjp7fSwicG9kQW5ub3RhdGlvbnMiOnt9LCJwcm9tZXRoZXVzIjp7ImVuYWJsZWQiOnRydWUsImZxZG4iOiJodHRwOi8vY29zdC1hbmFseXplci1wcm9tZXRoZXVzLXNlcnZlci5kZWZhdWx0LnN2YyJ9fSwiZ3JhZmFuYSI6eyJhZG1pblBhc3N3b3JkIjoic3Ryb25ncGFzc3dvcmQiLCJhZG1pblVzZXIiOiJhZG1pbiIsImFmZmluaXR5Ijp7fSwiZGFzaGJvYXJkUHJvdmlkZXJzIjp7fSwiZGFzaGJvYXJkcyI6e30sImRhc2hib2FyZHNDb25maWdNYXBzIjp7fSwiZGF0YXNvdXJjZXMiOnsiZGF0YXNvdXJjZXMueWFtbCI6eyJhcGlWZXJzaW9uIjoxLCJkYXRhc291cmNlcyI6W3siYWNjZXNzIjoicHJveHkiLCJpc0RlZmF1bHQiOmZhbHNlLCJuYW1lIjoicHJvbWV0aGV1cy1rdWJlY29zdCIsInR5cGUiOiJwcm9tZXRoZXVzIiwidXJsIjoiaHR0cDovL2t1YmVjb3N0LXByb21ldGhldXMtc2VydmVyLmt1YmVjb3N0LnN2Yy5jbHVzdGVyLmxvY2FsIn1dfX0sImRlcGxveW1lbnRTdHJhdGVneSI6IlJvbGxpbmdVcGRhdGUiLCJkb3dubG9hZERhc2hib2FyZHNJbWFnZSI6eyJwdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwicmVwb3NpdG9yeSI6ImN1cmxpbWFnZXMvY3VybCIsInRhZyI6ImxhdGVzdCJ9LCJlbnYiOnt9LCJlbnZGcm9tU2VjcmV0IjoiIiwiZXh0cmFTZWNyZXRNb3VudHMiOltdLCJnbG9iYWwiOnsiYWRkaXRpb25hbExhYmVscyI6e30sImdyYWZhbmEiOnsiZG9tYWluTmFtZSI6ImNvc3QtYW5hbHl6ZXItZ3JhZmFuYS5kZWZhdWx0LnN2YyIsImVuYWJsZWQiOnRydWUsInByb3h5Ijp0cnVlLCJzY2hlbWUiOiJodHRwIn0sIm5vdGlmaWNhdGlvbnMiOnt9LCJwb2RBbm5vdGF0aW9ucyI6e30sInByb21ldGhldXMiOnsiZW5hYmxlZCI6dHJ1ZSwiZnFkbiI6Imh0dHA6Ly9jb3N0LWFuYWx5emVyLXByb21ldGhldXMtc2VydmVyLmRlZmF1bHQuc3ZjIn19LCJncmFmYW5hLmluaSI6eyJhbmFseXRpY3MiOnsiY2hlY2tfZm9yX3VwZGF0ZXMiOnRydWV9LCJhdXRoLmFub255bW91cyI6eyJlbmFibGVkIjp0cnVlLCJvcmdfbmFtZSI6Ik1haW4gT3JnLiIsIm9yZ19yb2xlIjoiRWRpdG9yIn0sImdyYWZhbmFfbmV0Ijp7InVybCI6Imh0dHBzOi8vZ3JhZmFuYS5uZXQifSwibG9nIjp7Im1vZGUiOiJjb25zb2xlIn0sInBhdGhzIjp7ImRhdGEiOiIvdmFyL2xpYi9ncmFmYW5hL2RhdGEiLCJsb2dzIjoiL3Zhci9sb2cvZ3JhZmFuYSIsInBsdWdpbnMiOiIvdmFyL2xpYi9ncmFmYW5hL3BsdWdpbnMiLCJwcm92aXNpb25pbmciOiIvZXRjL2dyYWZhbmEvcHJvdmlzaW9uaW5nIn0sInNlcnZlciI6eyJyb290X3VybCI6IiUocHJvdG9jb2wpczovLyUoZG9tYWluKXM6JShodHRwX3BvcnQpcy9ncmFmYW5hIiwic2VydmVfZnJvbV9zdWJfcGF0aCI6dHJ1ZX19LCJpbWFnZSI6eyJwdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwicmVwb3NpdG9yeSI6ImdyYWZhbmEvZ3JhZmFuYSIsInRhZyI6IjkuMy4xIn0sImxkYXAiOnsiY29uZmlnIjoiIiwiZXhpc3RpbmdTZWNyZXQiOiIifSwibGl2ZW5lc3NQcm9iZSI6eyJmYWlsdXJlVGhyZXNob2xkIjoxMCwiaHR0cEdldCI6eyJwYXRoIjoiL2FwaS9oZWFsdGgiLCJwb3J0IjozMDAwfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6NjAsInRpbWVvdXRTZWNvbmRzIjozMH0sIm5vZGVTZWxlY3RvciI6e30sInBsdWdpbnMiOltdLCJyYmFjIjp7ImNyZWF0ZSI6dHJ1ZSwicHNwRW5hYmxlZCI6dHJ1ZSwicHNwVXNlQXBwQXJtb3IiOnRydWV9LCJyZWFkaW5lc3NQcm9iZSI6eyJodHRwR2V0Ijp7InBhdGgiOiIvYXBpL2hlYWx0aCIsInBvcnQiOjMwMDB9fSwicmVwbGljYXMiOjEsInJlc291cmNlcyI6e30sInNlY3VyaXR5Q29udGV4dCI6eyJmc0dyb3VwIjo0NzIsInJ1bkFzVXNlciI6NDcyfSwic2VydmljZSI6eyJhbm5vdGF0aW9ucyI6e30sImxhYmVscyI6e30sInBvcnQiOjgwLCJ0eXBlIjoiQ2x1c3RlcklQIn0sInNlcnZpY2VBY2NvdW50Ijp7ImNyZWF0ZSI6dHJ1ZX0sInNpZGVjYXIiOnsiZGFzaGJvYXJkcyI6eyJhbm5vdGF0aW9ucyI6e30sImVuYWJsZWQiOnRydWUsImVycm9yX3Rocm90dGxlX3NsZWVwIjowLCJmb2xkZXIiOiIvdG1wL2Rhc2hib2FyZHMiLCJsYWJlbCI6ImdyYWZhbmFfZGFzaGJvYXJkIn0sImltYWdlIjoia2l3aWdyaWQvazhzLXNpZGVjYXI6MS4yMS4wIiwiaW1hZ2VQdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwicmVzb3VyY2VzIjpudWxsfSwic210cCI6eyJleGlzdGluZ1NlY3JldCI6IiJ9LCJ0b2xlcmF0aW9ucyI6W119LCJpbml0Q2hvd25EYXRhIjp7InJlc291cmNlcyI6e319LCJpbml0Q2hvd25EYXRhSW1hZ2UiOiJidXN5Ym94Iiwia3ViZWNvc3REZXBsb3ltZW50Ijp7InJlcGxpY2FzIjoxfSwia3ViZWNvc3RGcm9udGVuZCI6eyJpbWFnZSI6Imdjci5pby9rdWJlY29zdDEvZnJvbnRlbmQiLCJpbWFnZVB1bGxQb2xpY3kiOiJBbHdheXMiLCJpcHY2Ijp7ImVuYWJsZWQiOnRydWV9LCJyZXNvdXJjZXMiOnsicmVxdWVzdHMiOnsiY3B1IjoiMTBtIiwibWVtb3J5IjoiNTVNaSJ9fX0sImt1YmVjb3N0TWV0cmljcyI6e30sImt1YmVjb3N0TW9kZWwiOnsiYWxsb2NhdGlvbiI6bnVsbCwiZXRsIjp0cnVlLCJldGxEYWlseVN0b3JlRHVyYXRpb25EYXlzIjo5MSwiZXRsRmlsZVN0b3JlRW5hYmxlZCI6dHJ1ZSwiZXRsSG91cmx5U3RvcmVEdXJhdGlvbkhvdXJzIjo0OSwiZXRsUmVhZE9ubHlNb2RlIjpmYWxzZSwiZXh0cmFBcmdzIjpbXSwiaW1hZ2UiOiJnY3IuaW8va3ViZWNvc3QxL2Nvc3QtbW9kZWwiLCJpbWFnZVB1bGxQb2xpY3kiOiJBbHdheXMiLCJtYXhRdWVyeUNvbmN1cnJlbmN5Ijo1LCJvdXRPZkNsdXN0ZXJQcm9tTWV0cmljc0VuYWJsZWQiOmZhbHNlLCJyZXNvdXJjZXMiOnsicmVxdWVzdHMiOnsiY3B1IjoiMjAwbSIsIm1lbW9yeSI6IjU1TWkifX0sIndhcm1DYWNoZSI6ZmFsc2UsIndhcm1TYXZpbmdzQ2FjaGUiOnRydWV9LCJrdWJlY29zdFRva2VuIjpudWxsLCJub2RlU2VsZWN0b3IiOnt9LCJwZXJzaXN0ZW50Vm9sdW1lIjp7ImRiU2l6ZSI6IjMyLjBHaSIsImVuYWJsZWQiOnRydWUsInNpemUiOiIzMkdpIn0sInBvZFNlY3VyaXR5UG9saWN5Ijp7ImVuYWJsZWQiOnRydWV9LCJwcm9tZXRoZXVzIjp7ImFsZXJ0UmVsYWJlbENvbmZpZ3MiOm51bGwsImFsZXJ0bWFuYWdlckZpbGVzIjp7ImFsZXJ0bWFuYWdlci55bWwiOnsiZ2xvYmFsIjp7fSwicmVjZWl2ZXJzIjpbeyJuYW1lIjoiZGVmYXVsdC1yZWNlaXZlciJ9XSwicm91dGUiOnsiZ3JvdXBfaW50ZXJ2YWwiOiI1bSIsImdyb3VwX3dhaXQiOiIxMHMiLCJyZWNlaXZlciI6ImRlZmF1bHQtcmVjZWl2ZXIiLCJyZXBlYXRfaW50ZXJ2YWwiOiIzaCJ9fX0sImNvbmZpZ21hcFJlbG9hZCI6eyJhbGVydG1hbmFnZXIiOnsiZW5hYmxlZCI6dHJ1ZSwiZXh0cmFBcmdzIjp7fSwiZXh0cmFDb25maWdtYXBNb3VudHMiOltdLCJleHRyYVZvbHVtZURpcnMiOltdLCJpbWFnZSI6eyJwdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwicmVwb3NpdG9yeSI6ImppbW1pZHlzb24vY29uZmlnbWFwLXJlbG9hZCIsInRhZyI6InYwLjcuMSJ9LCJuYW1lIjoiY29uZmlnbWFwLXJlbG9hZCIsInJlc291cmNlcyI6e319LCJwcm9tZXRoZXVzIjp7ImVuYWJsZWQiOnRydWUsImV4dHJhQXJncyI6e30sImV4dHJhQ29uZmlnbWFwTW91bnRzIjpbXSwiZXh0cmFWb2x1bWVEaXJzIjpbXSwiaW1hZ2UiOnsicHVsbFBvbGljeSI6IklmTm90UHJlc2VudCIsInJlcG9zaXRvcnkiOiJqaW1taWR5c29uL2NvbmZpZ21hcC1yZWxvYWQiLCJ0YWciOiJ2MC43LjEifSwibmFtZSI6ImNvbmZpZ21hcC1yZWxvYWQiLCJyZXNvdXJjZXMiOnt9fX0sImV4dHJhU2NyYXBlQ29uZmlncyI6Ii0gam9iX25hbWU6IGt1YmVjb3N0XG4gIGhvbm9yX2xhYmVsczogdHJ1ZVxuICBzY3JhcGVfaW50ZXJ2YWw6IDFtXG4gIHNjcmFwZV90aW1lb3V0OiA2MHNcbiAgbWV0cmljc19wYXRoOiAvbWV0cmljc1xuICBzY2hlbWU6IGh0dHBcbiAgZG5zX3NkX2NvbmZpZ3M6XG4gIC0gbmFtZXM6XG4gICAgLSB7eyB0ZW1wbGF0ZSBcImNvc3QtYW5hbHl6ZXIuc2VydmljZU5hbWVcIiAuIH19XG4gICAgdHlwZTogJ0EnXG4gICAgcG9ydDogOTAwM1xuLSBqb2JfbmFtZToga3ViZWNvc3QtbmV0d29ya2luZ1xuICBrdWJlcm5ldGVzX3NkX2NvbmZpZ3M6XG4gICAgLSByb2xlOiBwb2RcbiAgcmVsYWJlbF9jb25maWdzOlxuICAjIFNjcmFwZSBvbmx5IHRoZSB0aGUgdGFyZ2V0cyBtYXRjaGluZyB0aGUgZm9sbG93aW5nIG1ldGFkYXRhXG4gICAgLSBzb3VyY2VfbGFiZWxzOiBbX19tZXRhX2t1YmVybmV0ZXNfcG9kX2xhYmVsX2FwcF1cbiAgICAgIGFjdGlvbjoga2VlcFxuICAgICAgcmVnZXg6ICB7eyB0ZW1wbGF0ZSBcImNvc3QtYW5hbHl6ZXIubmV0d29ya0Nvc3RzTmFtZVwiIC4gfX1cbiIsImdsb2JhbCI6eyJhZGRpdGlvbmFsTGFiZWxzIjp7fSwiZ3JhZmFuYSI6eyJkb21haW5OYW1lIjoiY29zdC1hbmFseXplci1ncmFmYW5hLmRlZmF1bHQuc3ZjIiwiZW5hYmxlZCI6dHJ1ZSwicHJveHkiOnRydWUsInNjaGVtZSI6Imh0dHAifSwibm90aWZpY2F0aW9ucyI6e30sInBvZEFubm90YXRpb25zIjp7fSwicHJvbWV0aGV1cyI6eyJlbmFibGVkIjp0cnVlLCJmcWRuIjoiaHR0cDovL2Nvc3QtYW5hbHl6ZXItcHJvbWV0aGV1cy1zZXJ2ZXIuZGVmYXVsdC5zdmMifX0sImltYWdlUHVsbFNlY3JldHMiOm51bGwsImt1YmUtc3RhdGUtbWV0cmljcyI6eyJhZmZpbml0eSI6e30sImNvbGxlY3RvcnMiOnsiY2VydGlmaWNhdGVzaWduaW5ncmVxdWVzdHMiOnRydWUsImNvbmZpZ21hcHMiOnRydWUsImNyb25qb2JzIjp0cnVlLCJkYWVtb25zZXRzIjp0cnVlLCJkZXBsb3ltZW50cyI6dHJ1ZSwiZW5kcG9pbnRzIjp0cnVlLCJob3Jpem9udGFscG9kYXV0b3NjYWxlcnMiOnRydWUsImluZ3Jlc3NlcyI6dHJ1ZSwiam9icyI6dHJ1ZSwibGltaXRyYW5nZXMiOnRydWUsIm11dGF0aW5nd2ViaG9va2NvbmZpZ3VyYXRpb25zIjpmYWxzZSwibmFtZXNwYWNlcyI6dHJ1ZSwibmV0d29ya3BvbGljaWVzIjpmYWxzZSwibm9kZXMiOnRydWUsInBlcnNpc3RlbnR2b2x1bWVjbGFpbXMiOnRydWUsInBlcnNpc3RlbnR2b2x1bWVzIjp0cnVlLCJwb2RkaXNydXB0aW9uYnVkZ2V0cyI6dHJ1ZSwicG9kcyI6dHJ1ZSwicmVwbGljYXNldHMiOnRydWUsInJlcGxpY2F0aW9uY29udHJvbGxlcnMiOnRydWUsInJlc291cmNlcXVvdGFzIjp0cnVlLCJzZWNyZXRzIjpmYWxzZSwic2VydmljZXMiOnRydWUsInN0YXRlZnVsc2V0cyI6dHJ1ZSwic3RvcmFnZWNsYXNzZXMiOnRydWUsInZhbGlkYXRpbmd3ZWJob29rY29uZmlndXJhdGlvbnMiOmZhbHNlLCJ2ZXJ0aWNhbHBvZGF1dG9zY2FsZXJzIjpmYWxzZSwidm9sdW1lYXR0YWNobWVudHMiOmZhbHNlfSwiY3VzdG9tTGFiZWxzIjp7fSwiZGlzYWJsZWQiOmZhbHNlLCJlbmFibGVkIjp0cnVlLCJnbG9iYWwiOnsiYWRkaXRpb25hbExhYmVscyI6e30sImdyYWZhbmEiOnsiZG9tYWluTmFtZSI6ImNvc3QtYW5hbHl6ZXItZ3JhZmFuYS5kZWZhdWx0LnN2YyIsImVuYWJsZWQiOnRydWUsInByb3h5Ijp0cnVlLCJzY2hlbWUiOiJodHRwIn0sIm5vdGlmaWNhdGlvbnMiOnt9LCJwb2RBbm5vdGF0aW9ucyI6e30sInByb21ldGhldXMiOnsiZW5hYmxlZCI6dHJ1ZSwiZnFkbiI6Imh0dHA6Ly9jb3N0LWFuYWx5emVyLXByb21ldGhldXMtc2VydmVyLmRlZmF1bHQuc3ZjIn19LCJob3N0TmV0d29yayI6ZmFsc2UsImltYWdlIjp7InB1bGxQb2xpY3kiOiJJZk5vdFByZXNlbnQiLCJyZXBvc2l0b3J5IjoiazhzLmdjci5pby9rdWJlLXN0YXRlLW1ldHJpY3Mva3ViZS1zdGF0ZS1tZXRyaWNzIiwidGFnIjoidjEuOS44In0sIm5hbWVzcGFjZU92ZXJyaWRlIjoiIiwibm9kZVNlbGVjdG9yIjp7fSwicG9kQW5ub3RhdGlvbnMiOnt9LCJwcm9tZXRoZXVzIjp7fSwicHJvbWV0aGV1c1NjcmFwZSI6dHJ1ZSwicmJhYyI6eyJjcmVhdGUiOnRydWV9LCJyZXBsaWNhcyI6MSwic2VjdXJpdHlDb250ZXh0Ijp7ImVuYWJsZWQiOnRydWUsImZzR3JvdXAiOjY1NTM0LCJydW5Bc1VzZXIiOjY1NTM0fSwic2VydmljZSI6eyJhbm5vdGF0aW9ucyI6e30sImxvYWRCYWxhbmNlcklQIjoiIiwibm9kZVBvcnQiOjAsInBvcnQiOjgwODAsInR5cGUiOiJDbHVzdGVySVAifSwic2VydmljZUFjY291bnQiOnsiY3JlYXRlIjp0cnVlLCJpbWFnZVB1bGxTZWNyZXRzIjpbXX0sInRvbGVyYXRpb25zIjpbXX0sImt1YmVTdGF0ZU1ldHJpY3MiOnsiZW5hYmxlZCI6dHJ1ZX0sIm5vZGVFeHBvcnRlciI6eyJlbmFibGVkIjp0cnVlLCJleHRyYUFyZ3MiOnt9LCJleHRyYUNvbmZpZ21hcE1vdW50cyI6W10sImV4dHJhSG9zdFBhdGhNb3VudHMiOltdLCJob3N0TmV0d29yayI6dHJ1ZSwiaG9zdFBJRCI6dHJ1ZSwiaW1hZ2UiOnsicHVsbFBvbGljeSI6IklmTm90UHJlc2VudCIsInJlcG9zaXRvcnkiOiJwcm9tL25vZGUtZXhwb3J0ZXIiLCJ0YWciOiJ2MS4zLjAifSwibmFtZSI6Im5vZGUtZXhwb3J0ZXIiLCJub2RlU2VsZWN0b3IiOnt9LCJwb2QiOnsibGFiZWxzIjp7fX0sInBvZEFubm90YXRpb25zIjp7fSwicG9kU2VjdXJpdHlQb2xpY3kiOnsiYW5ub3RhdGlvbnMiOnt9fSwicHJpb3JpdHlDbGFzc05hbWUiOiIiLCJyZXNvdXJjZXMiOnt9LCJzZWN1cml0eUNvbnRleHQiOnt9LCJzZXJ2aWNlIjp7ImFubm90YXRpb25zIjp7InByb21ldGhldXMuaW8vc2NyYXBlIjoidHJ1ZSJ9LCJjbHVzdGVySVAiOiJOb25lIiwiZXh0ZXJuYWxJUHMiOltdLCJob3N0UG9ydCI6OTEwMCwibGFiZWxzIjp7fSwibG9hZEJhbGFuY2VySVAiOiIiLCJsb2FkQmFsYW5jZXJTb3VyY2VSYW5nZXMiOltdLCJzZXJ2aWNlUG9ydCI6OTEwMCwidHlwZSI6IkNsdXN0ZXJJUCJ9LCJ0b2xlcmF0aW9ucyI6W10sInVwZGF0ZVN0cmF0ZWd5Ijp7InR5cGUiOiJSb2xsaW5nVXBkYXRlIn19LCJyYmFjIjp7ImNyZWF0ZSI6dHJ1ZX0sInNlcnZlciI6eyJhZmZpbml0eSI6e30sImFsZXJ0bWFuYWdlcnMiOltdLCJiYXNlVVJMIjoiIiwiY29uZmlnTWFwT3ZlcnJpZGVOYW1lIjoiIiwiY29uZmlnUGF0aCI6Ii9ldGMvY29uZmlnL3Byb21ldGhldXMueW1sIiwiZW1wdHlEaXIiOnsic2l6ZUxpbWl0IjoiIn0sImVuYWJsZWQiOnRydWUsImVudiI6W10sImV4dHJhQXJncyI6eyJxdWVyeS5tYXgtY29uY3VycmVuY3kiOjEsInF1ZXJ5Lm1heC1zYW1wbGVzIjoxMDAwMDAwMDB9LCJleHRyYUNvbmZpZ21hcE1vdW50cyI6W10sImV4dHJhRmxhZ3MiOlsid2ViLmVuYWJsZS1saWZlY3ljbGUiXSwiZXh0cmFIb3N0UGF0aE1vdW50cyI6W10sImV4dHJhSW5pdENvbnRhaW5lcnMiOltdLCJleHRyYVNlY3JldE1vdW50cyI6W10sImV4dHJhVm9sdW1lTW91bnRzIjpbXSwiZXh0cmFWb2x1bWVzIjpbXSwiZ2xvYmFsIjp7ImV2YWx1YXRpb25faW50ZXJ2YWwiOiIxbSIsImV4dGVybmFsX2xhYmVscyI6eyJjbHVzdGVyX2lkIjoiY2x1c3Rlci1vbmUifSwic2NyYXBlX2ludGVydmFsIjoiMW0iLCJzY3JhcGVfdGltZW91dCI6IjYwcyJ9LCJpbWFnZSI6eyJwdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwicmVwb3NpdG9yeSI6InF1YXkuaW8vcHJvbWV0aGV1cy9wcm9tZXRoZXVzIiwidGFnIjoidjIuMzUuMCJ9LCJsaXZlbmVzc1Byb2JlRmFpbHVyZVRocmVzaG9sZCI6MywibGl2ZW5lc3NQcm9iZUluaXRpYWxEZWxheSI6MzAsImxpdmVuZXNzUHJvYmVTdWNjZXNzVGhyZXNob2xkIjoxLCJsaXZlbmVzc1Byb2JlVGltZW91dCI6MzAsIm5hbWUiOiJzZXJ2ZXIiLCJub2RlU2VsZWN0b3IiOnt9LCJwZXJzaXN0ZW50Vm9sdW1lIjp7ImFjY2Vzc01vZGVzIjpbIlJlYWRXcml0ZU9uY2UiXSwiYW5ub3RhdGlvbnMiOnt9LCJlbmFibGVkIjp0cnVlLCJleGlzdGluZ0NsYWltIjoiIiwibW91bnRQYXRoIjoiL2RhdGEiLCJzaXplIjoiMzJHaSIsInN1YlBhdGgiOiIifSwicG9kQW5ub3RhdGlvbnMiOnt9LCJwb2RMYWJlbHMiOnt9LCJwb2RTZWN1cml0eVBvbGljeSI6eyJhbm5vdGF0aW9ucyI6e319LCJwcmVmaXhVUkwiOiIiLCJwcmlvcml0eUNsYXNzTmFtZSI6IiIsInJlYWRpbmVzc1Byb2JlRmFpbHVyZVRocmVzaG9sZCI6MywicmVhZGluZXNzUHJvYmVJbml0aWFsRGVsYXkiOjMwLCJyZWFkaW5lc3NQcm9iZVN1Y2Nlc3NUaHJlc2hvbGQiOjEsInJlYWRpbmVzc1Byb2JlVGltZW91dCI6MzAsInJlbW90ZVJlYWQiOnt9LCJyZW1vdGVXcml0ZSI6e30sInJlcGxpY2FDb3VudCI6MSwicmVzb3VyY2VzIjp7fSwicmV0ZW50aW9uIjoiMTVkIiwic2VjdXJpdHlDb250ZXh0Ijp7ImZzR3JvdXAiOjEwMDEsInJ1bkFzR3JvdXAiOjEwMDEsInJ1bkFzTm9uUm9vdCI6dHJ1ZSwicnVuQXNVc2VyIjoxMDAxfSwic2VydmljZSI6eyJhbm5vdGF0aW9ucyI6e30sImNsdXN0ZXJJUCI6IiIsImV4dGVybmFsSVBzIjpbXSwibGFiZWxzIjp7fSwibG9hZEJhbGFuY2VySVAiOiIiLCJsb2FkQmFsYW5jZXJTb3VyY2VSYW5nZXMiOltdLCJzZXJ2aWNlUG9ydCI6ODAsInNlc3Npb25BZmZpbml0eSI6Ik5vbmUiLCJ0eXBlIjoiQ2x1c3RlcklQIn0sInNpZGVjYXJDb250YWluZXJzIjpudWxsLCJzdHJhdGVneSI6eyJ0eXBlIjoiUmVjcmVhdGUifSwidGVybWluYXRpb25HcmFjZVBlcmlvZFNlY29uZHMiOjMwMCwidG9sZXJhdGlvbnMiOltdfSwic2VydmVyRmlsZXMiOnsiYWxlcnRpbmdfcnVsZXMueW1sIjp7fSwiYWxlcnRzIjp7fSwicHJvbWV0aGV1cy55bWwiOnsicnVsZV9maWxlcyI6WyIvZXRjL2NvbmZpZy9yZWNvcmRpbmdfcnVsZXMueW1sIiwiL2V0Yy9jb25maWcvYWxlcnRpbmdfcnVsZXMueW1sIiwiL2V0Yy9jb25maWcvcnVsZXMiLCIvZXRjL2NvbmZpZy9hbGVydHMiXSwic2NyYXBlX2NvbmZpZ3MiOlt7ImpvYl9uYW1lIjoicHJvbWV0aGV1cyIsInN0YXRpY19jb25maWdzIjpbeyJ0YXJnZXRzIjpbImxvY2FsaG9zdDo5MDkwIl19XX0seyJiZWFyZXJfdG9rZW5fZmlsZSI6Ii92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC90b2tlbiIsImpvYl9uYW1lIjoia3ViZXJuZXRlcy1ub2Rlcy1jYWR2aXNvciIsImt1YmVybmV0ZXNfc2RfY29uZmlncyI6W3sicm9sZSI6Im5vZGUifV0sIm1ldHJpY19yZWxhYmVsX2NvbmZpZ3MiOlt7ImFjdGlvbiI6ImtlZXAiLCJyZWdleCI6Iihjb250YWluZXJfY3B1X3VzYWdlX3NlY29uZHNfdG90YWx8Y29udGFpbmVyX21lbW9yeV93b3JraW5nX3NldF9ieXRlc3xjb250YWluZXJfbmV0d29ya19yZWNlaXZlX2Vycm9yc190b3RhbHxjb250YWluZXJfbmV0d29ya190cmFuc21pdF9lcnJvcnNfdG90YWx8Y29udGFpbmVyX25ldHdvcmtfcmVjZWl2ZV9wYWNrZXRzX2Ryb3BwZWRfdG90YWx8Y29udGFpbmVyX25ldHdvcmtfdHJhbnNtaXRfcGFja2V0c19kcm9wcGVkX3RvdGFsfGNvbnRhaW5lcl9tZW1vcnlfdXNhZ2VfYnl0ZXN8Y29udGFpbmVyX2NwdV9jZnNfdGhyb3R0bGVkX3BlcmlvZHNfdG90YWx8Y29udGFpbmVyX2NwdV9jZnNfcGVyaW9kc190b3RhbHxjb250YWluZXJfZnNfdXNhZ2VfYnl0ZXN8Y29udGFpbmVyX2ZzX2xpbWl0X2J5dGVzfGNvbnRhaW5lcl9jcHVfY2ZzX3BlcmlvZHNfdG90YWx8Y29udGFpbmVyX2ZzX2lub2Rlc19mcmVlfGNvbnRhaW5lcl9mc19pbm9kZXNfdG90YWx8Y29udGFpbmVyX2ZzX3VzYWdlX2J5dGVzfGNvbnRhaW5lcl9mc19saW1pdF9ieXRlc3xjb250YWluZXJfY3B1X2Nmc190aHJvdHRsZWRfcGVyaW9kc190b3RhbHxjb250YWluZXJfY3B1X2Nmc19wZXJpb2RzX3RvdGFsfGNvbnRhaW5lcl9uZXR3b3JrX3JlY2VpdmVfYnl0ZXNfdG90YWx8Y29udGFpbmVyX25ldHdvcmtfdHJhbnNtaXRfYnl0ZXNfdG90YWx8Y29udGFpbmVyX2ZzX2lub2Rlc19mcmVlfGNvbnRhaW5lcl9mc19pbm9kZXNfdG90YWx8Y29udGFpbmVyX2ZzX3VzYWdlX2J5dGVzfGNvbnRhaW5lcl9mc19saW1pdF9ieXRlc3xjb250YWluZXJfc3BlY19jcHVfc2hhcmVzfGNvbnRhaW5lcl9zcGVjX21lbW9yeV9saW1pdF9ieXRlc3xjb250YWluZXJfbmV0d29ya19yZWNlaXZlX2J5dGVzX3RvdGFsfGNvbnRhaW5lcl9uZXR3b3JrX3RyYW5zbWl0X2J5dGVzX3RvdGFsfGNvbnRhaW5lcl9mc19yZWFkc19ieXRlc190b3RhbHxjb250YWluZXJfbmV0d29ya19yZWNlaXZlX2J5dGVzX3RvdGFsfGNvbnRhaW5lcl9mc193cml0ZXNfYnl0ZXNfdG90YWx8Y29udGFpbmVyX2ZzX3JlYWRzX2J5dGVzX3RvdGFsfGNhZHZpc29yX3ZlcnNpb25faW5mb3xrdWJlY29zdF9wdl9pbmZvKSIsInNvdXJjZV9sYWJlbHMiOlsiX19uYW1lX18iXX0seyJhY3Rpb24iOiJyZXBsYWNlIiwicmVnZXgiOiIoLispIiwic291cmNlX2xhYmVscyI6WyJjb250YWluZXIiXSwidGFyZ2V0X2xhYmVsIjoiY29udGFpbmVyX25hbWUifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJyZWdleCI6IiguKykiLCJzb3VyY2VfbGFiZWxzIjpbInBvZCJdLCJ0YXJnZXRfbGFiZWwiOiJwb2RfbmFtZSJ9XSwicmVsYWJlbF9jb25maWdzIjpbeyJhY3Rpb24iOiJsYWJlbG1hcCIsInJlZ2V4IjoiX19tZXRhX2t1YmVybmV0ZXNfbm9kZV9sYWJlbF8oLispIn0seyJyZXBsYWNlbWVudCI6Imt1YmVybmV0ZXMuZGVmYXVsdC5zdmM6NDQzIiwidGFyZ2V0X2xhYmVsIjoiX19hZGRyZXNzX18ifSx7InJlZ2V4IjoiKC4rKSIsInJlcGxhY2VtZW50IjoiL2FwaS92MS9ub2Rlcy8kMS9wcm94eS9tZXRyaWNzL2NhZHZpc29yIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19ub2RlX25hbWUiXSwidGFyZ2V0X2xhYmVsIjoiX19tZXRyaWNzX3BhdGhfXyJ9XSwic2NoZW1lIjoiaHR0cHMiLCJ0bHNfY29uZmlnIjp7ImNhX2ZpbGUiOiIvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvY2EuY3J0IiwiaW5zZWN1cmVfc2tpcF92ZXJpZnkiOnRydWV9fSx7ImJlYXJlcl90b2tlbl9maWxlIjoiL3Zhci9ydW4vc2VjcmV0cy9rdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3Rva2VuIiwiam9iX25hbWUiOiJrdWJlcm5ldGVzLW5vZGVzIiwia3ViZXJuZXRlc19zZF9jb25maWdzIjpbeyJyb2xlIjoibm9kZSJ9XSwibWV0cmljX3JlbGFiZWxfY29uZmlncyI6W3siYWN0aW9uIjoia2VlcCIsInJlZ2V4IjoiKGt1YmVsZXRfdm9sdW1lX3N0YXRzX3VzZWRfYnl0ZXMpIiwic291cmNlX2xhYmVscyI6WyJfX25hbWVfXyJdfV0sInJlbGFiZWxfY29uZmlncyI6W3siYWN0aW9uIjoibGFiZWxtYXAiLCJyZWdleCI6Il9fbWV0YV9rdWJlcm5ldGVzX25vZGVfbGFiZWxfKC4rKSJ9LHsicmVwbGFjZW1lbnQiOiJrdWJlcm5ldGVzLmRlZmF1bHQuc3ZjOjQ0MyIsInRhcmdldF9sYWJlbCI6Il9fYWRkcmVzc19fIn0seyJyZWdleCI6IiguKykiLCJyZXBsYWNlbWVudCI6Ii9hcGkvdjEvbm9kZXMvJDEvcHJveHkvbWV0cmljcyIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfbm9kZV9uYW1lIl0sInRhcmdldF9sYWJlbCI6Il9fbWV0cmljc19wYXRoX18ifV0sInNjaGVtZSI6Imh0dHBzIiwidGxzX2NvbmZpZyI6eyJjYV9maWxlIjoiL3Zhci9ydW4vc2VjcmV0cy9rdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L2NhLmNydCIsImluc2VjdXJlX3NraXBfdmVyaWZ5Ijp0cnVlfX0seyJqb2JfbmFtZSI6Imt1YmVybmV0ZXMtc2VydmljZS1lbmRwb2ludHMiLCJrdWJlcm5ldGVzX3NkX2NvbmZpZ3MiOlt7InJvbGUiOiJlbmRwb2ludHMifV0sIm1ldHJpY19yZWxhYmVsX2NvbmZpZ3MiOlt7ImFjdGlvbiI6ImtlZXAiLCJyZWdleCI6Iihjb250YWluZXJfY3B1X2FsbG9jYXRpb258Y29udGFpbmVyX2NwdV91c2FnZV9zZWNvbmRzX3RvdGFsfGNvbnRhaW5lcl9mc19saW1pdF9ieXRlc3xjb250YWluZXJfZnNfd3JpdGVzX2J5dGVzX3RvdGFsfGNvbnRhaW5lcl9ncHVfYWxsb2NhdGlvbnxjb250YWluZXJfbWVtb3J5X2FsbG9jYXRpb25fYnl0ZXN8Y29udGFpbmVyX21lbW9yeV91c2FnZV9ieXRlc3xjb250YWluZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVzfGNvbnRhaW5lcl9uZXR3b3JrX3JlY2VpdmVfYnl0ZXNfdG90YWx8Y29udGFpbmVyX25ldHdvcmtfdHJhbnNtaXRfYnl0ZXNfdG90YWx8RENHTV9GSV9ERVZfR1BVX1VUSUx8ZGVwbG95bWVudF9tYXRjaF9sYWJlbHN8a3ViZV9kYWVtb25zZXRfc3RhdHVzX2Rlc2lyZWRfbnVtYmVyX3NjaGVkdWxlZHxrdWJlX2RhZW1vbnNldF9zdGF0dXNfbnVtYmVyX3JlYWR5fGt1YmVfZGVwbG95bWVudF9zcGVjX3JlcGxpY2FzfGt1YmVfZGVwbG95bWVudF9zdGF0dXNfcmVwbGljYXN8a3ViZV9kZXBsb3ltZW50X3N0YXR1c19yZXBsaWNhc19hdmFpbGFibGV8a3ViZV9qb2Jfc3RhdHVzX2ZhaWxlZHxrdWJlX25hbWVzcGFjZV9hbm5vdGF0aW9uc3xrdWJlX25hbWVzcGFjZV9sYWJlbHN8a3ViZV9ub2RlX2luZm98a3ViZV9ub2RlX2xhYmVsc3xrdWJlX25vZGVfc3RhdHVzX2FsbG9jYXRhYmxlfGt1YmVfbm9kZV9zdGF0dXNfYWxsb2NhdGFibGVfY3B1X2NvcmVzfGt1YmVfbm9kZV9zdGF0dXNfYWxsb2NhdGFibGVfbWVtb3J5X2J5dGVzfGt1YmVfbm9kZV9zdGF0dXNfY2FwYWNpdHl8a3ViZV9ub2RlX3N0YXR1c19jYXBhY2l0eV9jcHVfY29yZXN8a3ViZV9ub2RlX3N0YXR1c19jYXBhY2l0eV9tZW1vcnlfYnl0ZXN8a3ViZV9ub2RlX3N0YXR1c19jb25kaXRpb258a3ViZV9wZXJzaXN0ZW50dm9sdW1lX2NhcGFjaXR5X2J5dGVzfGt1YmVfcGVyc2lzdGVudHZvbHVtZV9zdGF0dXNfcGhhc2V8a3ViZV9wZXJzaXN0ZW50dm9sdW1lY2xhaW1faW5mb3xrdWJlX3BlcnNpc3RlbnR2b2x1bWVjbGFpbV9yZXNvdXJjZV9yZXF1ZXN0c19zdG9yYWdlX2J5dGVzfGt1YmVfcG9kX2NvbnRhaW5lcl9pbmZvfGt1YmVfcG9kX2NvbnRhaW5lcl9yZXNvdXJjZV9saW1pdHN8a3ViZV9wb2RfY29udGFpbmVyX3Jlc291cmNlX2xpbWl0c19jcHVfY29yZXN8a3ViZV9wb2RfY29udGFpbmVyX3Jlc291cmNlX2xpbWl0c19tZW1vcnlfYnl0ZXN8a3ViZV9wb2RfY29udGFpbmVyX3Jlc291cmNlX3JlcXVlc3RzfGt1YmVfcG9kX2NvbnRhaW5lcl9yZXNvdXJjZV9yZXF1ZXN0c19jcHVfY29yZXN8a3ViZV9wb2RfY29udGFpbmVyX3Jlc291cmNlX3JlcXVlc3RzX21lbW9yeV9ieXRlc3xrdWJlX3BvZF9jb250YWluZXJfc3RhdHVzX3Jlc3RhcnRzX3RvdGFsfGt1YmVfcG9kX2NvbnRhaW5lcl9zdGF0dXNfcnVubmluZ3xrdWJlX3BvZF9jb250YWluZXJfc3RhdHVzX3Rlcm1pbmF0ZWRfcmVhc29ufGt1YmVfcG9kX2xhYmVsc3xrdWJlX3BvZF9vd25lcnxrdWJlX3BvZF9zdGF0dXNfcGhhc2V8a3ViZV9yZXBsaWNhc2V0X293bmVyfGt1YmVfc3RhdGVmdWxzZXRfcmVwbGljYXN8a3ViZV9zdGF0ZWZ1bHNldF9zdGF0dXNfcmVwbGljYXN8a3ViZWNvc3RfY2x1c3Rlcl9pbmZvfGt1YmVjb3N0X2NsdXN0ZXJfbWFuYWdlbWVudF9jb3N0fGt1YmVjb3N0X2NsdXN0ZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVzfGt1YmVjb3N0X2xvYWRfYmFsYW5jZXJfY29zdHxrdWJlY29zdF9uZXR3b3JrX2ludGVybmV0X2VncmVzc19jb3N0fGt1YmVjb3N0X25ldHdvcmtfcmVnaW9uX2VncmVzc19jb3N0fGt1YmVjb3N0X25ldHdvcmtfem9uZV9lZ3Jlc3NfY29zdHxrdWJlY29zdF9ub2RlX2lzX3Nwb3R8a3ViZWNvc3RfcG9kX25ldHdvcmtfZWdyZXNzX2J5dGVzX3RvdGFsfG5vZGVfY3B1X2hvdXJseV9jb3N0fG5vZGVfY3B1X3NlY29uZHNfdG90YWx8bm9kZV9kaXNrX3JlYWRzX2NvbXBsZXRlZHxub2RlX2Rpc2tfcmVhZHNfY29tcGxldGVkX3RvdGFsfG5vZGVfZGlza193cml0ZXNfY29tcGxldGVkfG5vZGVfZGlza193cml0ZXNfY29tcGxldGVkX3RvdGFsfG5vZGVfZmlsZXN5c3RlbV9kZXZpY2VfZXJyb3J8bm9kZV9ncHVfY291bnR8bm9kZV9ncHVfaG91cmx5X2Nvc3R8bm9kZV9tZW1vcnlfQnVmZmVyc19ieXRlc3xub2RlX21lbW9yeV9DYWNoZWRfYnl0ZXN8bm9kZV9tZW1vcnlfTWVtQXZhaWxhYmxlX2J5dGVzfG5vZGVfbWVtb3J5X01lbUZyZWVfYnl0ZXN8bm9kZV9tZW1vcnlfTWVtVG90YWxfYnl0ZXN8bm9kZV9uZXR3b3JrX3RyYW5zbWl0X2J5dGVzX3RvdGFsfG5vZGVfcmFtX2hvdXJseV9jb3N0fG5vZGVfdG90YWxfaG91cmx5X2Nvc3R8cG9kX3B2Y19hbGxvY2F0aW9ufHB2X2hvdXJseV9jb3N0fHNlcnZpY2Vfc2VsZWN0b3JfbGFiZWxzfHN0YXRlZnVsU2V0X21hdGNoX2xhYmVsc3xrdWJlY29zdF9wdl9pbmZvfHVwKSIsInNvdXJjZV9sYWJlbHMiOlsiX19uYW1lX18iXX1dLCJyZWxhYmVsX2NvbmZpZ3MiOlt7ImFjdGlvbiI6ImtlZXAiLCJyZWdleCI6dHJ1ZSwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX2Fubm90YXRpb25fcHJvbWV0aGV1c19pb19zY3JhcGUiXX0seyJhY3Rpb24iOiJrZWVwIiwicmVnZXgiOiIoa3ViZWNvc3Qta3ViZS1zdGF0ZS1tZXRyaWNzfGt1YmVjb3N0LXByb21ldGhldXMtbm9kZS1leHBvcnRlcnxrdWJlY29zdC1uZXR3b3JrLWNvc3RzKSIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfZW5kcG9pbnRzX25hbWUiXX0seyJhY3Rpb24iOiJyZXBsYWNlIiwicmVnZXgiOiIoaHR0cHM/KSIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9hbm5vdGF0aW9uX3Byb21ldGhldXNfaW9fc2NoZW1lIl0sInRhcmdldF9sYWJlbCI6Il9fc2NoZW1lX18ifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJyZWdleCI6IiguKykiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfYW5ub3RhdGlvbl9wcm9tZXRoZXVzX2lvX3BhdGgiXSwidGFyZ2V0X2xhYmVsIjoiX19tZXRyaWNzX3BhdGhfXyJ9LHsiYWN0aW9uIjoicmVwbGFjZSIsInJlZ2V4IjoiKFteOl0rKSg/OjpcXGQrKT87KFxcZCspIiwicmVwbGFjZW1lbnQiOiIkMTokMiIsInNvdXJjZV9sYWJlbHMiOlsiX19hZGRyZXNzX18iLCJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX2Fubm90YXRpb25fcHJvbWV0aGV1c19pb19wb3J0Il0sInRhcmdldF9sYWJlbCI6Il9fYWRkcmVzc19fIn0seyJhY3Rpb24iOiJsYWJlbG1hcCIsInJlZ2V4IjoiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9sYWJlbF8oLispIn0seyJhY3Rpb24iOiJyZXBsYWNlIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19uYW1lc3BhY2UiXSwidGFyZ2V0X2xhYmVsIjoia3ViZXJuZXRlc19uYW1lc3BhY2UifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfbmFtZSJdLCJ0YXJnZXRfbGFiZWwiOiJrdWJlcm5ldGVzX25hbWUifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3BvZF9ub2RlX25hbWUiXSwidGFyZ2V0X2xhYmVsIjoia3ViZXJuZXRlc19ub2RlIn1dfSx7ImpvYl9uYW1lIjoia3ViZXJuZXRlcy1zZXJ2aWNlLWVuZHBvaW50cy1zbG93Iiwia3ViZXJuZXRlc19zZF9jb25maWdzIjpbeyJyb2xlIjoiZW5kcG9pbnRzIn1dLCJyZWxhYmVsX2NvbmZpZ3MiOlt7ImFjdGlvbiI6ImtlZXAiLCJyZWdleCI6dHJ1ZSwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX2Fubm90YXRpb25fcHJvbWV0aGV1c19pb19zY3JhcGVfc2xvdyJdfSx7ImFjdGlvbiI6InJlcGxhY2UiLCJyZWdleCI6IihodHRwcz8pIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX2Fubm90YXRpb25fcHJvbWV0aGV1c19pb19zY2hlbWUiXSwidGFyZ2V0X2xhYmVsIjoiX19zY2hlbWVfXyJ9LHsiYWN0aW9uIjoicmVwbGFjZSIsInJlZ2V4IjoiKC4rKSIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9hbm5vdGF0aW9uX3Byb21ldGhldXNfaW9fcGF0aCJdLCJ0YXJnZXRfbGFiZWwiOiJfX21ldHJpY3NfcGF0aF9fIn0seyJhY3Rpb24iOiJyZXBsYWNlIiwicmVnZXgiOiIoW146XSspKD86OlxcZCspPzsoXFxkKykiLCJyZXBsYWNlbWVudCI6IiQxOiQyIiwic291cmNlX2xhYmVscyI6WyJfX2FkZHJlc3NfXyIsIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfYW5ub3RhdGlvbl9wcm9tZXRoZXVzX2lvX3BvcnQiXSwidGFyZ2V0X2xhYmVsIjoiX19hZGRyZXNzX18ifSx7ImFjdGlvbiI6ImxhYmVsbWFwIiwicmVnZXgiOiJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX2xhYmVsXyguKykifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX25hbWVzcGFjZSJdLCJ0YXJnZXRfbGFiZWwiOiJrdWJlcm5ldGVzX25hbWVzcGFjZSJ9LHsiYWN0aW9uIjoicmVwbGFjZSIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9uYW1lIl0sInRhcmdldF9sYWJlbCI6Imt1YmVybmV0ZXNfbmFtZSJ9LHsiYWN0aW9uIjoicmVwbGFjZSIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfcG9kX25vZGVfbmFtZSJdLCJ0YXJnZXRfbGFiZWwiOiJrdWJlcm5ldGVzX25vZGUifV0sInNjcmFwZV9pbnRlcnZhbCI6IjVtIiwic2NyYXBlX3RpbWVvdXQiOiIzMHMifSx7Imhvbm9yX2xhYmVscyI6dHJ1ZSwiam9iX25hbWUiOiJwcm9tZXRoZXVzLXB1c2hnYXRld2F5Iiwia3ViZXJuZXRlc19zZF9jb25maWdzIjpbeyJyb2xlIjoic2VydmljZSJ9XSwicmVsYWJlbF9jb25maWdzIjpbeyJhY3Rpb24iOiJrZWVwIiwicmVnZXgiOiJwdXNoZ2F0ZXdheSIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9hbm5vdGF0aW9uX3Byb21ldGhldXNfaW9fcHJvYmUiXX1dfSx7ImpvYl9uYW1lIjoia3ViZXJuZXRlcy1zZXJ2aWNlcyIsImt1YmVybmV0ZXNfc2RfY29uZmlncyI6W3sicm9sZSI6InNlcnZpY2UifV0sIm1ldHJpY3NfcGF0aCI6Ii9wcm9iZSIsInBhcmFtcyI6eyJtb2R1bGUiOlsiaHR0cF8yeHgiXX0sInJlbGFiZWxfY29uZmlncyI6W3siYWN0aW9uIjoia2VlcCIsInJlZ2V4Ijp0cnVlLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfYW5ub3RhdGlvbl9wcm9tZXRoZXVzX2lvX3Byb2JlIl19LHsic291cmNlX2xhYmVscyI6WyJfX2FkZHJlc3NfXyJdLCJ0YXJnZXRfbGFiZWwiOiJfX3BhcmFtX3RhcmdldCJ9LHsicmVwbGFjZW1lbnQiOiJibGFja2JveCIsInRhcmdldF9sYWJlbCI6Il9fYWRkcmVzc19fIn0seyJzb3VyY2VfbGFiZWxzIjpbIl9fcGFyYW1fdGFyZ2V0Il0sInRhcmdldF9sYWJlbCI6Imluc3RhbmNlIn0seyJhY3Rpb24iOiJsYWJlbG1hcCIsInJlZ2V4IjoiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9sYWJlbF8oLispIn0seyJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX25hbWVzcGFjZSJdLCJ0YXJnZXRfbGFiZWwiOiJrdWJlcm5ldGVzX25hbWVzcGFjZSJ9LHsic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX25hbWUiXSwidGFyZ2V0X2xhYmVsIjoia3ViZXJuZXRlc19uYW1lIn1dfV19LCJyZWNvcmRpbmdfcnVsZXMueW1sIjp7fSwicnVsZXMiOnsiZ3JvdXBzIjpbeyJuYW1lIjoiQ1BVIiwicnVsZXMiOlt7ImV4cHIiOiJzdW0ocmF0ZShjb250YWluZXJfY3B1X3VzYWdlX3NlY29uZHNfdG90YWx7Y29udGFpbmVyX25hbWUhPVwiXCJ9WzVtXSkpIiwicmVjb3JkIjoiY2x1c3RlcjpjcHVfdXNhZ2U6cmF0ZTVtIn0seyJleHByIjoicmF0ZShjb250YWluZXJfY3B1X3VzYWdlX3NlY29uZHNfdG90YWx7Y29udGFpbmVyX25hbWUhPVwiXCJ9WzVtXSkiLCJyZWNvcmQiOiJjbHVzdGVyOmNwdV91c2FnZV9ub3N1bTpyYXRlNW0ifSx7ImV4cHIiOiJhdmcoaXJhdGUoY29udGFpbmVyX2NwdV91c2FnZV9zZWNvbmRzX3RvdGFse2NvbnRhaW5lcl9uYW1lIT1cIlBPRFwiLCBjb250YWluZXJfbmFtZSE9XCJcIn1bNW1dKSkgYnkgKGNvbnRhaW5lcl9uYW1lLHBvZF9uYW1lLG5hbWVzcGFjZSkiLCJyZWNvcmQiOiJrdWJlY29zdF9jb250YWluZXJfY3B1X3VzYWdlX2lyYXRlIn0seyJleHByIjoic3VtKGNvbnRhaW5lcl9tZW1vcnlfd29ya2luZ19zZXRfYnl0ZXN7Y29udGFpbmVyX25hbWUhPVwiUE9EXCIsY29udGFpbmVyX25hbWUhPVwiXCJ9KSBieSAoY29udGFpbmVyX25hbWUscG9kX25hbWUsbmFtZXNwYWNlKSIsInJlY29yZCI6Imt1YmVjb3N0X2NvbnRhaW5lcl9tZW1vcnlfd29ya2luZ19zZXRfYnl0ZXMifSx7ImV4cHIiOiJzdW0oY29udGFpbmVyX21lbW9yeV93b3JraW5nX3NldF9ieXRlc3tjb250YWluZXJfbmFtZSE9XCJQT0RcIixjb250YWluZXJfbmFtZSE9XCJcIn0pIiwicmVjb3JkIjoia3ViZWNvc3RfY2x1c3Rlcl9tZW1vcnlfd29ya2luZ19zZXRfYnl0ZXMifV19LHsibmFtZSI6IlNhdmluZ3MiLCJydWxlcyI6W3siZXhwciI6InN1bShhdmcoa3ViZV9wb2Rfb3duZXJ7b3duZXJfa2luZCE9XCJEYWVtb25TZXRcIn0pIGJ5IChwb2QpICogc3VtKGNvbnRhaW5lcl9jcHVfYWxsb2NhdGlvbikgYnkgKHBvZCkpIiwibGFiZWxzIjp7ImRhZW1vbnNldCI6ImZhbHNlIn0sInJlY29yZCI6Imt1YmVjb3N0X3NhdmluZ3NfY3B1X2FsbG9jYXRpb24ifSx7ImV4cHIiOiJzdW0oYXZnKGt1YmVfcG9kX293bmVye293bmVyX2tpbmQ9XCJEYWVtb25TZXRcIn0pIGJ5IChwb2QpICogc3VtKGNvbnRhaW5lcl9jcHVfYWxsb2NhdGlvbikgYnkgKHBvZCkpIC8gc3VtKGt1YmVfbm9kZV9pbmZvKSIsImxhYmVscyI6eyJkYWVtb25zZXQiOiJ0cnVlIn0sInJlY29yZCI6Imt1YmVjb3N0X3NhdmluZ3NfY3B1X2FsbG9jYXRpb24ifSx7ImV4cHIiOiJzdW0oYXZnKGt1YmVfcG9kX293bmVye293bmVyX2tpbmQhPVwiRGFlbW9uU2V0XCJ9KSBieSAocG9kKSAqIHN1bShjb250YWluZXJfbWVtb3J5X2FsbG9jYXRpb25fYnl0ZXMpIGJ5IChwb2QpKSIsImxhYmVscyI6eyJkYWVtb25zZXQiOiJmYWxzZSJ9LCJyZWNvcmQiOiJrdWJlY29zdF9zYXZpbmdzX21lbW9yeV9hbGxvY2F0aW9uX2J5dGVzIn0seyJleHByIjoic3VtKGF2ZyhrdWJlX3BvZF9vd25lcntvd25lcl9raW5kPVwiRGFlbW9uU2V0XCJ9KSBieSAocG9kKSAqIHN1bShjb250YWluZXJfbWVtb3J5X2FsbG9jYXRpb25fYnl0ZXMpIGJ5IChwb2QpKSAvIHN1bShrdWJlX25vZGVfaW5mbykiLCJsYWJlbHMiOnsiZGFlbW9uc2V0IjoidHJ1ZSJ9LCJyZWNvcmQiOiJrdWJlY29zdF9zYXZpbmdzX21lbW9yeV9hbGxvY2F0aW9uX2J5dGVzIn1dfV19fSwic2VydmljZUFjY291bnRzIjp7ImFsZXJ0bWFuYWdlciI6eyJjcmVhdGUiOnRydWV9LCJub2RlRXhwb3J0ZXIiOnsiY3JlYXRlIjp0cnVlfSwicHVzaGdhdGV3YXkiOnsiY3JlYXRlIjp0cnVlfSwic2VydmVyIjp7ImFubm90YXRpb25zIjp7fSwiY3JlYXRlIjp0cnVlfX19LCJyZW1vdGVXcml0ZSI6e30sInJlcG9ydGluZyI6eyJlcnJvclJlcG9ydGluZyI6dHJ1ZSwibG9nQ29sbGVjdGlvbiI6dHJ1ZSwicHJvZHVjdEFuYWx5dGljcyI6dHJ1ZSwidmFsdWVzUmVwb3J0aW5nIjp0cnVlfSwic2VydmljZSI6eyJhbm5vdGF0aW9ucyI6e30sImxhYmVscyI6e30sInBvcnQiOjkwOTAsInRhcmdldFBvcnQiOjkwOTAsInR5cGUiOiJDbHVzdGVySVAifSwic2VydmljZUFjY291bnQiOnsiYW5ub3RhdGlvbnMiOnt9LCJjcmVhdGUiOnRydWV9LCJzaWdWNFByb3h5Ijp7ImV4dHJhRW52IjpudWxsLCJob3N0IjoiYXBzLXdvcmtzcGFjZXMudXMtd2VzdC0yLmFtYXpvbmF3cy5jb20iLCJpbWFnZSI6InB1YmxpYy5lY3IuYXdzL2F3cy1vYnNlcnZhYmlsaXR5L2F3cy1zaWd2NC1wcm94eTpsYXRlc3QiLCJpbWFnZVB1bGxQb2xpY3kiOiJBbHdheXMiLCJuYW1lIjoiYXBzIiwicG9ydCI6ODAwNSwicmVnaW9uIjoidXMtd2VzdC0yIn0sInN1cHBvcnRORlMiOmZhbHNlLCJ0b2xlcmF0aW9ucyI6W119
             - name: READ_ONLY
               value: "false"
             - name: PROMETHEUS_SERVER_ENDPOINT
@@ -21038,11 +21029,13 @@ spec:
             - name: MAX_QUERY_CONCURRENCY
               value: "5"
             - name: UTC_OFFSET
-              value: 
+              value: "0"
             - name: CLUSTER_ID
               value: cluster-one
             - name: SQL_ADDRESS
               value: pgprometheus
+            - name: COST_EVENTS_AUDIT_ENABLED
+              value: "false"
             - name: RELEASE_NAME
               value: kubecost
             - name: KUBECOST_NAMESPACE
@@ -21057,8 +21050,8 @@ spec:
                 configMapKeyRef:
                   name: kubecost-cost-analyzer
                   key: kubecost-token
-        - image: gcr.io/kubecost1/frontend:prod-1.100.0
-        
+        - image: gcr.io/kubecost1/frontend:prod-1.101.3
+
           env:
             - name: GET_HOSTS_FROM
               value: dns
@@ -21074,6 +21067,13 @@ spec:
               memory: 55Mi
           imagePullPolicy: Always
           readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 200
+          livenessProbe:
             httpGet:
               path: /healthz
               port: 9003


### PR DESCRIPTION
updated to 1.101.3

generate with:
```
helm template kubecost \
  --repo https://kubecost.github.io/cost-analyzer cost-analyzer \
  --namespace kubecost --version 1.101.3
```

Then remove helm values as they could be misleading after manual changes to the manifest.