### PR TITLE
Add config for cost-analyzer ingress labels

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
@@ -18,7 +18,10 @@ metadata:
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -419,6 +419,9 @@ kubecostModel:
 ingress:
   enabled: false
   # className: nginx
+  labels:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
## What does this PR change?

Allows the user to set `.Values.ingress.labels` to add labels to the kubecost-cost-analyzer ingress resource.

Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/2070

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- New config option. Example provided in `values.yaml`

## How was this PR tested?

```yaml
# test.yaml
ingress:
  enabled: true
  labels:
    fqdn: "kubecost.my.com"
```

```sh
$ helm template ./cost-analyzer -f test.yaml
...
# Source: cost-analyzer/templates/cost-analyzer-ingress-template.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-cost-analyzer
  namespace: kubecost
  labels:
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.101.2
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
    fqdn: kubecost.my.com
spec:
  rules:
    - host: "cost-analyzer.local"
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name: release-name-cost-analyzer
                port:
                  name: tcp-frontend
```

## Have you made an update to documentation?

- No, but I've added an example of this config to `values.yaml`