### PR TITLE
Add NodeExporter dnsPolicy option.

### DIFF
--- a/cost-analyzer/charts/prometheus/README.md
+++ b/cost-analyzer/charts/prometheus/README.md
@@ -206,6 +206,7 @@ Parameter | Description | Default
 `initChownData.resources` | init-chown-data pod resource requests & limits | `{}`
 `kube-state-metrics.disabled` | If false, create kube-state-metrics sub-chart, see the [kube-state-metrics chart for configuration options](https://github.com/helm/charts/tree/master/stable/kube-state-metrics) | `false`
 `nodeExporter.enabled` | If true, create node-exporter | `true`
+`nodeExporter.dnsPolicy` | node-exporter dns policy | `ClusterFirstWithHostNet`
 `nodeExporter.name` | node-exporter container name | `node-exporter`
 `nodeExporter.image.repository` | node-exporter container image repository| `prom/node-exporter`
 `nodeExporter.image.tag` | node-exporter container image tag | `v0.18.1`

--- a/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
@@ -36,6 +36,9 @@ spec:
 {{ toYaml .Values.nodeExporter.affinity | indent 8 }}
 {{- end }}
       serviceAccountName: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
+{{- if .Values.nodeExporter.dnsPolicy }}
+      dnsPolicy: "{{ .Values.nodeExporter.dnsPolicy }}"
+{{- end }}
 {{- if .Values.nodeExporter.priorityClassName }}
       priorityClassName: "{{ .Values.nodeExporter.priorityClassName }}"
 {{- end }}

--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -406,6 +406,10 @@ nodeExporter:
   ##
   hostPID: true
 
+  ## node-exporter dns policy
+  ##
+  dnsPolicy: ClusterFirstWithHostNet
+
   ## node-exporter container name
   ##
   name: node-exporter


### PR DESCRIPTION
## What does this PR change?

I have taken the actions described in the following document.

> Pods running with hostNetwork, you should explicitly set its DNS policy to "ClusterFirstWithHostNet".

https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?

on local machine

## Have you made an update to documentation?

yes
