### PR TITLE
update hosted-agent

### DIFF
--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -15,8 +15,6 @@ global:
   grafana:
     enabled: false
     proxy: false
-agentCsi:
-  enabled: false
 # Agent enables specific features designed to enhance the metrics exporter deployment
 # with enhancements designed for external hosting.
 agent: true
@@ -73,10 +71,10 @@ prometheus:
           action: keep
           regex:  {{ template "cost-analyzer.networkCostsName" . }}
   server:
+    retention: 14d
     extraArgs:
       storage.tsdb.min-block-duration: 2h
       storage.tsdb.max-block-duration: 2h
-      storage.tsdb.retention: 10h
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001
@@ -88,7 +86,7 @@ prometheus:
     enableAdminApi: true
     sidecarContainers:
     - name: thanos-sidecar
-      image: thanosio/thanos:v0.29.0
+      image: thanosio/thanos:v0.30.2
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001


### PR DESCRIPTION
## What does this PR change?
Fix deprecated retention on prometheus
update thanos sidecar to 30.2 -tested in dogfood instance
remove duplicate agentCsi entry


## Does this PR rely on any other PRs?

- NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

NA


## How was this PR tested?

Test in dogfood instance

## Have you made an update to documentation?

NA
