### PR TITLE
Add config for encrypted Okta SAML claims

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -213,6 +213,16 @@ spec:
           secret:
             secretName: {{ .Values.saml.secretName }}
         {{- end }}
+        {{- if .Values.saml.encryptionCertSecret }}
+        - name: saml-encryption-cert
+          secret:
+            secretName: {{ .Values.saml.encryptionCertSecret }}
+        {{- end }}
+        {{- if .Values.saml.decryptionKeySecret }}
+        - name: saml-decryption-key
+          secret:
+            secretName: {{ .Values.saml.decryptionKeySecret }}
+        {{- end }}
         {{- if .Values.saml.metadataSecretName }}
         - name: metadata-secret-volume
           secret:
@@ -473,6 +483,14 @@ spec:
             {{- if .Values.saml.secretName }}
             - name: secret-volume
               mountPath: /var/configs/secret-volume
+            {{- end }}
+            {{- if .Values.saml.encryptionCertSecret }}
+            - name: saml-encryption-cert
+              mountPath: /var/configs/saml-encryption-cert
+            {{- end }}
+            {{- if .Values.saml.decryptionKeySecret }}
+            - name: saml-decryption-key
+              mountPath: /var/configs/saml-decryption-key
             {{- end }}
             {{- if .Values.saml.metadataSecretName }}
             - name: metadata-secret-volume
@@ -899,6 +917,10 @@ spec:
             - name: SAML_RBAC_ENABLED
               value: "true"
             {{- end }}
+            {{- if and .Values.saml.encryptionCertSecret .Values.saml.decryptionKeySecret }}
+            - name: SAML_RESPONSE_ENCRYPTED
+              value: "true"
+            {{- end}}
             {{- end }}
             {{- end }}
             {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.clusterIDConfigmap) }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -197,6 +197,8 @@ saml:
   # audienceURI: "http://localhost:9090" # by convention, the same as the appRootURL, but any string uniquely identifying kubecost to your samp IDP. Optional if you follow the convention
   # nameIDFormat: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" If your SAML provider requires a specific nameid format
   # isGLUUProvider: false # An additional URL parameter must be appended for GLUU providers
+  # encryptionCertSecret: "kubecost-saml-cert" # k8s secret where the x509 certificate used to encrypt an Okta saml response is stored
+  # decryptionKeySecret: "kubecost-sank-decryption-key" # k8s secret where the private key associated with the encryptionCertSecret is stored
   rbac:
     enabled: false
     groups:


### PR DESCRIPTION
## What does this PR change?
Adds Helm logic for providing info for decrypting SAML claims encrypted with Okta.

## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/1372
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
See linked KCM PR


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
See linked KCM PR

## Have you made an update to documentation?
See linked KCM PR
