### PR TITLE
update rules to use current cadvisor labels

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "1.102.0"
+appVersion: "1.102.1"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor
   cloud costs.
 name: cost-analyzer
-version: "1.102.0"
+version: "1.102.1"
 annotations:
   "artifacthub.io/links": |
     - name: Homepage

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -609,15 +609,15 @@ prometheus:
       groups:
         - name: CPU
           rules:
-            - expr: sum(rate(container_cpu_usage_seconds_total{container_name!=""}[5m]))
+            - expr: sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))
               record: cluster:cpu_usage:rate5m
-            - expr: rate(container_cpu_usage_seconds_total{container_name!=""}[5m])
+            - expr: rate(container_cpu_usage_seconds_total{container!=""}[5m])
               record: cluster:cpu_usage_nosum:rate5m
-            - expr: avg(irate(container_cpu_usage_seconds_total{container_name!="POD", container_name!=""}[5m])) by (container_name,pod_name,namespace)
+            - expr: avg(irate(container_cpu_usage_seconds_total{container!="POD", container!=""}[5m])) by (container,pod,namespace)
               record: kubecost_container_cpu_usage_irate
-            - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""}) by (container_name,pod_name,namespace)
+            - expr: sum(container_memory_working_set_bytes{container!="POD",container!=""}) by (container,pod,namespace)
               record: kubecost_container_memory_working_set_bytes
-            - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""})
+            - expr: sum(container_memory_working_set_bytes{container!="POD",container!=""})
               record: kubecost_cluster_memory_working_set_bytes
         - name: Savings
           rules:
@@ -698,10 +698,10 @@ networkCosts:
 
       # Internet contains a list of address/range that will be
       # classified as internet traffic. This is synonymous with traffic
-      # that cannot be classified within the cluster. 
-      # NOTE: Internet classification filters are executed _after_ 
+      # that cannot be classified within the cluster.
+      # NOTE: Internet classification filters are executed _after_
       # NOTE: direct-classification, but before in-zone, in-region,
-      # NOTE: and cross-region. 
+      # NOTE: and cross-region.
       internet: []
 
       # Direct Classification specifically maps an ip address or range
@@ -880,7 +880,7 @@ federatedETL:
     # If not set, the federator will attempt to federated all clusters pushing to the federated storage.
     clusters: []
     # federator.primaryClusterID is an optional parameter that should be used when reconciliation is expected to occur on the Primary.
-    # primaryClusterID: "cluster_id" 
+    # primaryClusterID: "cluster_id"
 
 kubecostAdmissionController:
   enabled: false

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -67,7 +67,7 @@ metadata:
   namespace: kubecost
   labels:
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -443,7 +443,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -461,7 +461,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -529,7 +529,7 @@ data:
         location / {
             try_files $uri $uri/ /index.html;
         }
-        add_header ETag "1.102.0";
+        add_header ETag "1.102.1";
         listen 9090;
         listen [::]:9090;
         location /api/ {
@@ -624,7 +624,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -1176,7 +1176,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -2876,7 +2876,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -6090,7 +6090,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -7494,7 +7494,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -7920,7 +7920,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -9083,7 +9083,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -10276,7 +10276,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -11683,7 +11683,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -12651,7 +12651,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -18358,7 +18358,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -19013,7 +19013,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -19869,7 +19869,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20056,7 +20056,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20209,7 +20209,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20243,7 +20243,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20285,7 +20285,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20406,7 +20406,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20824,7 +20824,7 @@ metadata:
   labels:
 
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-1.102.0
+    helm.sh/chart: cost-analyzer-1.102.1
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20869,7 +20869,7 @@ spec:
             claimName: kubecost-cost-analyzer
       initContainers:
       containers:
-        - image: gcr.io/kubecost1/cost-model:prod-1.102.0
+        - image: gcr.io/kubecost1/cost-model:prod-1.102.1
 
           name: cost-model
           imagePullPolicy: Always
@@ -21011,7 +21011,7 @@ spec:
                 configMapKeyRef:
                   name: kubecost-cost-analyzer
                   key: kubecost-token
-        - image: gcr.io/kubecost1/frontend:prod-1.102.0
+        - image: gcr.io/kubecost1/frontend:prod-1.102.1
 
           env:
             - name: GET_HOSTS_FROM


### PR DESCRIPTION
## What does this PR change?
remove `_name` from recording rules to support modern cadvisor.

Note that this is compatible with the default install of kubecost with the bundled prometheus as well.

Our check already uses the modern label:
![image](https://user-images.githubusercontent.com/31039225/230926399-f754bade-60bc-485e-ac8e-64f6d7378647.png)


## Does this PR rely on any other PRs?

- NA
 
## How does this PR impact users? (This is the kind of thing that goes in release notes!)

update recording rules to use current cadvisor labels. Previously they would need to be modified manually

## How was this PR tested?

test-1 cluster:
default kubecost in namespace `jesse-cadvisor-update`
custom prometheus test in namespace `jesse`

## Have you made an update to documentation?

NA