### PR TITLE
Ability to configure labels and annotations for the Kubecost PVC

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-db-pvc-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-db-pvc-template.yaml
@@ -10,6 +10,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- with .Values.persistentVolume.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.persistentVolume.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
@@ -8,6 +8,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- with .Values.persistentVolume.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.persistentVolume.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -505,6 +505,8 @@ persistentVolume:
   enabled: true # Note that setting this to false means configurations will be wiped out on pod restart.
   # storageClass: "-" #
   # existingClaim: kubecost-cost-analyzer # a claim in the same namespace as kubecost
+  labels: {}
+  annotations: {}
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## What does this PR change?

Adds the `.Values.persistentVolume.labels` and `.Values.persistentVolume.annotations` configuration options.

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Users are now able to add labels & annotations to the Kubecost PVC (i.e. `pvc/kubecost-cost-analyzer`) through Helm config

## Links to Issues or ZD tickets this PR addresses or fixes

- Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/2102

## How was this PR tested?

Ran `helm template ./cost-analyzer -f values.yaml` for the following values.yaml files

```bash
persistentVolume:
  enabled: true
  labels:
    owner: thomasn
  annotations:
    revision: 14
```

And

```bash
persistentVolume:
  enabled: true
  dbPVEnabled: true
  labels:
    owner: thomasn
  annotations:
    revision: 14
```

## Have you made an update to documentation?

- No