### PR TITLE
Add support for Google Cloud Managed Prometheus

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
@@ -15,7 +15,9 @@ data:
   {{ else }}
     prometheus-alertmanager-endpoint: {{ .Values.global.notifications.alertmanager.fqdn }}
   {{- end -}}
-  {{if .Values.global.amp.enabled }}
+  {{ if .Values.global.gmp.enabled }}
+    prometheus-server-endpoint: {{ .Values.global.gmp.prometheusServerEndpoint }}
+  {{- else if .Values.global.amp.enabled }}
     prometheus-server-endpoint: {{ .Values.global.amp.prometheusServerEndpoint }}
   {{- else if .Values.global.prometheus.enabled }}
   {{- if .Values.global.zone }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -318,6 +318,29 @@ spec:
             runAsUser: 0
 {{ end }}
       containers:
+        {{- if .Values.global.gmp.enabled }}
+        - name: {{ .Values.global.gmp.gmpProxy.name }}
+          image: {{ .Values.global.gmp.gmpProxy.image }}
+          {{- if .Values.global.gmp.gmpProxy.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.global.gmp.gmpProxy.imagePullPolicy }}
+          {{- else }}
+          imagePullPolicy: Always
+          {{- end }}
+          args:
+          - "--web.listen-address=:{{ .Values.global.gmp.gmpProxy.port }}"
+          - "--query.project-id={{ .Values.global.gmp.gmpProxy.projectId }}"
+          ports:
+          - name: web
+            containerPort: {{ .Values.global.gmp.gmpProxy.port | int }}
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: web
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: web
+        {{- end }}
         {{- if .Values.global.amp.enabled }}
         - name: sigv4proxy
           image: {{ .Values.sigV4Proxy.image }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -24,7 +24,8 @@ global:
 
   # Google Cloud Managed Service for Prometheus
   gmp:
-  # Remember to set up these parameters when install the Kubecost Helm chart with `global.gmp.enabled=true` if you want to use GMP self-deployed collection (Recommended) to ultilize Kubecost scrape configs. 
+  # Remember to set up these parameters when install the Kubecost Helm chart with `global.gmp.enabled=true` if you want to use GMP self-deployed collection (Recommended) to ultilize Kubecost scrape configs.
+  # If enabling GMP, it is highly recommended to utilize Google's distribution of Prometheus.
   # Learn more at https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-unmanaged
   # --set prometheus.server.image.repository="gke.gcr.io/prometheus-engine/prometheus" \
   # --set prometheus.server.image.tag="v2.35.0-gmp.2-gke.0"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -22,6 +22,22 @@ global:
     proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
 #    fqdn: cost-analyzer-grafana.default.svc
 
+  # Google Cloud Managed Service for Prometheus
+  gmp:
+  # Remember to set up these parameters when install the Kubecost Helm chart with `global.gmp.enabled=true` if you want to use GMP self-deployed collection (Recommended) to ultilize Kubecost scrape configs. 
+  # Learn more at https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-unmanaged
+  # --set prometheus.server.image.repository="gke.gcr.io/prometheus-engine/prometheus" \
+  # --set prometheus.server.image.tag="v2.35.0-gmp.2-gke.0"
+    enabled: false # If true, kubecost will be configured to use GMP Prometheus image and query from Google Cloud Managed Service for Prometheus.
+    prometheusServerEndpoint: http://localhost:8085/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the SigV4Proxy side car to the AMP workspace.
+    gmpProxy:
+      enabled: false
+      image: gke.gcr.io/prometheus-engine/frontend:v0.4.1-gke.0 # GMP Prometheus proxy image that serve as an endpoint to query metrics from GMP
+      imagePullPolicy: Always
+      name: gmp-proxy
+      port: 8085
+      projectId: YOUR_PROJECT_ID # example GCP project ID
+
   # Amazon Managed Service for Prometheus
   amp:
     enabled: false # If true, kubecost will be configured to remote_write and query from Amazon Managed Service for Prometheus.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -30,7 +30,7 @@ global:
   # --set prometheus.server.image.repository="gke.gcr.io/prometheus-engine/prometheus" \
   # --set prometheus.server.image.tag="v2.35.0-gmp.2-gke.0"
     enabled: false # If true, kubecost will be configured to use GMP Prometheus image and query from Google Cloud Managed Service for Prometheus.
-    prometheusServerEndpoint: http://localhost:8085/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the SigV4Proxy side car to the AMP workspace.
+    prometheusServerEndpoint: http://localhost:8085/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the GMP Prom proxy side car to the GMP database.
     gmpProxy:
       enabled: false
       image: gke.gcr.io/prometheus-engine/frontend:v0.4.1-gke.0 # GMP Prometheus proxy image that serve as an endpoint to query metrics from GMP


### PR DESCRIPTION
## What does this PR change?

This PR adds support for Google Cloud Managed Service for Prometheus (GMP).

- The bundled Prometheus server can be configured with GMP Prometheus image to send metrics to GMP database.
- The cost-model will run queries against the GMP database through GMP Prometheus proxy container.

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- If `global.gmp` is enabled, the chart will configure the bundled Prometheus with GMP Prometheus image to send metrics to GMP database and the cost-model will run queries against the GMP database through GMP Prometheus proxy container.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/2067

## How was this PR tested?

- This PR was tested with multiple helm template commands and a deployment test on dev-1 cluster. There are a few known caveats which should be covered in different issues/PRs:
  * The Prometheus Targets health check in diagnostics page shows random error message because of missing API endpoints on GMP side. (v1.102.0)
  * Disconnected cluster shows as active (v1.102.0)

### GMP enabled
```bash
helm template kubecost-gmp cost-analyzer/ \
--namespace linhlam-kc --create-namespace \
--set prometheus.server.image.repository="gke.gcr.io/prometheus-engine/prometheus" \
--set prometheus.server.image.tag="v2.35.0-gmp.2-gke.0" \
--set global.gmp.enabled="false" \
--set global.gmp.gmpProxy.projectId="<$GCP_PROJECT_ID>" \
--set prometheus.server.global.external_labels.cluster_id="cluster_linh_kc" \
--set kubecostProductConfigs.clusterName="cluster_linh_kc" > /tmp/gmp-templates
```
### AMP enabled (Verify the changes are not affecting current setup)
```bash
helm template kubecost-gmp cost-analyzer/ \
--namespace linhlam-kc --create-namespace \
-f https://tinyurl.com/kubecost-amazon-eks \
-f https://tinyurl.com/kubecost-amp \
--set global.amp.prometheusServerEndpoint=${QUERYURL} \
--set global.amp.remoteWriteService=${REMOTEWRITEURL} > /tmp/gmp-templates
```
### Default installation (Verify the changes are not affecting current setup)
```bash
helm template kubecost-gmp cost-analyzer/ \
--namespace linhlam-kc --create-namespace > /tmp/gmp-templates
```
### Deployment test
```bash
helm upgrade -i kubecost-gmp cost-analyzer/ \
--namespace linhlam-kc --create-namespace \
--set prometheus.server.image.repository="gke.gcr.io/prometheus-engine/prometheus" \
--set prometheus.server.image.tag="v2.35.0-gmp.2-gke.0" \
--set global.gmp.enabled="true" \
--set global.gmp.gmpProxy.projectId="<$GCP_PROJECT_ID>" \
--set prometheus.server.global.external_labels.cluster_id="cluster_linh_kc" \
--set kubecostProductConfigs.clusterName="cluster_linh_kc"
```
- Verified Kubecost metrics are sent to GMP from GCP monitoring console with this Promql: `avg(node_cpu_hourly_cost) by (cluster_id)`
- Verified Kubecost is using GMP Proxy as Prometheus server endpoint and Kubecost is able to query metrics successfully from that endpoint.

## Have you made an update to documentation?

- I will update Kubecost public doc once this PR is approved
cc: @AjayTripathy  @dwbrown2  @thomasvn  for your visibility 