### PR TITLE
Add ScrapeConfig for Kubecost Cloud Agent

### DIFF
--- a/cost-analyzer/values-cloud-agent.yaml
+++ b/cost-analyzer/values-cloud-agent.yaml
@@ -34,3 +34,15 @@ prometheus:
   kube-state-metrics:
     enabled: false
     disabled: true
+  extraScrapeConfigs: |
+    - job_name: kubecost-cloud-agent
+      honor_labels: true
+      scrape_interval: 1m
+      scrape_timeout: 60s
+      metrics_path: /metrics
+      scheme: http
+      dns_sd_configs:
+      - names:
+        - {{ .Release.Name }}-cloud-agent
+        type: 'A'
+        port: 9005


### PR DESCRIPTION
## What does this PR change?

An explicit scrape job for bundled Prometheus to scrape metrics from the kubecost-cloud-agent. It is parameterized to work regardless of what releasename or namespace the user chooses.

<img width="1464" alt="Screenshot 2023-04-12 at 8 34 50 PM" src="https://user-images.githubusercontent.com/11251627/231642345-25bf8d01-682e-4c42-9718-b5d7ef3b4187.png">

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- 

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1742

## How was this PR tested?

- Ran `helm template` with the default install command provided at https://app.kubecost.com to validate the Prometheus scrapeconfig created.
- Ran `helm install` using this scrapeconfig, and I'm seeing values populated in the Kubecost Cloud dashboard.

## Have you made an update to documentation?

- No

