### PR TITLE
Bump kiwigrid/k8s-sidecar  to 1.23.1

### DIFF
--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -256,7 +256,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:1.21.0
+  image: kiwigrid/k8s-sidecar:1.23.1
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -20517,7 +20517,7 @@ spec:
         runAsUser: 472
       containers:
         - name: grafana-sc-dashboard
-          image: "kiwigrid/k8s-sidecar:1.21.0"
+          image: "kiwigrid/k8s-sidecar:1.23.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: LABEL


### PR DESCRIPTION
## What does this PR change?
This PR is updating kiwigrid/k8s-sidecar  to the latest release 1.23.1


## Does this PR rely on any other PRs?
No



## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No direct impact. 1.23.1 has less CVEs.


## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/2146


## How was this PR tested?
Manually by running `kubectl apply -f kubecost.yaml -n kubecost` and verifying that this change is not breaking anything.

## Have you made an update to documentation?
https://github.com/kubecost/docs/pull/621
