### PR TITLE
Update Helm chart to support GCP MP Enterprise integration

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -363,12 +363,12 @@ spec:
           - name: AGENT_ENCODED_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.reportingSecret }}
+                name: {{ default "kubecost-reporting-secret" .Values.reportingSecret }}
                 key: reporting-key
           - name: AGENT_CONSUMER_ID
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.reportingSecret }}
+                name: {{ default "kubecost-reporting-secret" .Values.reportingSecret }}
                 key: consumer-id
           volumeMounts:
           - name: ubbagent-config

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -73,6 +73,11 @@ spec:
       restartPolicy: Always
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       volumes:
+      {{- if .Values.global.gcpstore.enabled }}
+        - name: ubbagent-config
+          configMap:
+            name: ubbagent-config
+      {{- end }}
       {{- if .Values.hosted }}
         - name: config-store
           secret:
@@ -346,6 +351,28 @@ spec:
           env:
           {{- toYaml .Values.sigV4Proxy.extraEnv | nindent 10 }}
           {{- end }}
+        {{- end }}
+        {{- if .Values.global.gcpstore.enabled }}
+        - name: ubbagent
+          image: gcr.io/kubecost1/gcp-mp/ent/cost-model/ubbagent:1.0
+          env:
+          - name: AGENT_CONFIG_FILE
+            value: "/etc/ubbagent/config.yaml"
+          - name: AGENT_LOCAL_PORT
+            value: "6080"
+          - name: AGENT_ENCODED_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.reportingSecret }}
+                key: reporting-key
+          - name: AGENT_CONSUMER_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.reportingSecret }}
+                key: consumer-id
+          volumeMounts:
+          - name: ubbagent-config
+            mountPath: /etc/ubbagent
         {{- end }}
         {{- if .Values.kubecostModel }}
         {{- if .Values.kubecostModel.openSourceOnly }}

--- a/cost-analyzer/templates/gcpstore-config-map-template.yaml
+++ b/cost-analyzer/templates/gcpstore-config-map-template.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.global.gcpstore.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ubbagent-config
+data:
+  config.yaml: |
+    # The identity section contains authentication information used
+    # by the agent.
+    identities:
+    - name: gcp
+      gcp:
+        # This parameter accepts a base64-encoded JSON service
+        # account key. The value comes from the reporting secret.
+        encodedServiceAccountKey: $AGENT_ENCODED_KEY
+
+    # The metrics section defines the metric that will be reported.
+    # Metric names should match verbatim the identifiers created
+    # during pricing setup.
+    metrics:
+
+    - name: commercial_ent_node_hr
+      type: int
+      endpoints:
+      - name: servicecontrol
+
+      # The passthrough marker indicates that no aggregation should
+      # occur for this metric. Reports received are immediately sent
+      # to the reporting endpoint. We use passthrough for the
+      # instance_time metric since reports are generated
+      # automatically by a heartbeat source defined in a later
+      # section.
+      passthrough: {}
+
+    # The endpoints section defines where metering data is ultimately
+    # sent. Currently supported endpoints include:
+    # * disk - some directory on the local filesystem
+    # * servicecontrol - Google Service Control
+    endpoints:
+    - name: servicecontrol
+      servicecontrol:
+        identity: gcp
+        # The service name is unique to your application and will be
+        # provided during onboarding.
+        serviceName: kubecost-ent.endpoints.kubecost-public.cloud.goog
+        consumerId: $AGENT_CONSUMER_ID  # From the reporting secret.
+      
+
+    # The sources section lists metric data sources run by the agent
+    # itself. The currently-supported source is 'heartbeat', which
+    # sends a defined value to a metric at a defined interval. In
+    # this example, the heartbeat sends a 60-second value through the
+    # "instance_time" metric every minute.
+    sources:
+    - name: commercial_ent_node_hr_heartbeat
+      heartbeat:
+        metric: commercial_ent_node_hr
+        intervalSeconds: 3600
+        value:
+          int64Value: 1
+{{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -22,6 +22,10 @@ global:
     proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
 #    fqdn: cost-analyzer-grafana.default.svc
 
+  # Enable only when you are using GCP Marketplace ENT listing. Learn more at https://console.cloud.google.com/marketplace/product/kubecost-public/kubecost-ent    
+  gcpstore:
+    enabled: false
+
   # Amazon Managed Service for Prometheus
   amp:
     enabled: false # If true, kubecost will be configured to remote_write and query from Amazon Managed Service for Prometheus.
@@ -893,6 +897,11 @@ kubecostAdmissionController:
 # It is disabled by default to avoid problems in high-scale environments.
 costEventsAudit:
   enabled: false
+
+# Reporting Secret for GCP Marketplace integration.
+# The value will be replaced automatically when Kubecost is deployed following GCP MP instructions.
+# Do not change the value manually.
+reportingSecret: "kubecost-reporting-secret"
 
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -898,10 +898,6 @@ kubecostAdmissionController:
 costEventsAudit:
   enabled: false
 
-# Reporting Secret for GCP Marketplace integration.
-# The value will be replaced automatically when Kubecost is deployed following GCP MP instructions.
-# Do not change the value manually.
-reportingSecret: "kubecost-reporting-secret"
 
 # readonly: false # disable updates to kubecost from the frontend UI and via POST request
 


### PR DESCRIPTION
## What does this PR change?

Add necessary changes to support Kubecost Enterprise product listed on the Google Cloud Marketplace. So, it can help to accelerate the update process for this integration.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

This is required code changes for our product listed on GCP Marketplace to transact with customers using GCP MP Private Offers

## Links to Issues or ZD tickets this PR addresses or fixes

[2067](https://github.com/kubecost/cost-analyzer-helm-chart/issues/2067)


## How was this PR tested?

The integration was tested ad approved on the GCP MP at https://console.cloud.google.com/marketplace/product/kubecost-public/kubecost-ent 

## Have you made an update to documentation?

Yes, at the specific repo for GCP Marketplace https://github.com/kubecost/gcp-marketplace 
