### PR TITLE
add cloud cost saved reports

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-cloud-cost-reports-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cloud-cost-reports-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.global.cloudCostReports }}
+{{- if .Values.global.cloudCostReports.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{default "cloud-cost-report-configs" .Values.cloudCostReportConfigmapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  cloud-cost-reports.json: '{{ toJson .Values.global.cloudCostReports.reports }}'
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -546,6 +546,10 @@ spec:
             - name: ASSET_REPORT_CONFIGMAP_NAME
               value: {{ .Values.assetReportConfigmapName }}
             {{- end }}
+            {{- if .Values.cloudCostReportConfigmapName }}
+              - name: CLOUD_COST_REPORT_CONFIGMAP_NAME
+                value: {{ .Values.cloudCostReportConfigmapName }}
+            {{- end }}
             {{- if .Values.savedReportConfigmapName }}
             - name: SAVED_REPORT_CONFIGMAP_NAME
               value: {{ .Values.savedReportConfigmapName }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -165,6 +165,19 @@ global:
       cloudBreakdown: "service"
       cloudJoin: "label:kubernetes_namespace"
 
+  # Set saved Cloud Cost report(s) accessible from /reports
+  # Ref: http://docs.kubecost.com/saved-reports
+  cloudCostReports:
+    enabled: false # If true, overwrites report parameters set through UI
+    reports:
+      - title: "Cloud Cost Report 0"
+        window: "today"
+        aggregateBy: "type"
+        accumulate: false # daily resolution
+        filters:
+          - property: "cluster"
+            value: "cluster-one"
+
   podAnnotations: {}
     # iam.amazonaws.com/role: role-arn
   additionalLabels: {}


### PR DESCRIPTION
## What does this PR change?
Adds configuration for enabling/disabling cloud cost reports


## Does this PR rely on any other PRs?
- yes, https://github.com/kubecost/kubecost-cost-model/pull/1398
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds configuration for enabling/disabling cloud cost reports


## Links to Issues or ZD tickets this PR addresses or fixes
- https://kubecost.atlassian.net/browse/CORE-160

## How was this PR tested?


## Have you made an update to documentation?
No, one will need to be made for http://docs.kubecost.com/saved-reports

Testing notes:
CloudCost reports are configurable through helm with the `cloudCostReports` variable.
