### PR TITLE
EV-59

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -5,6 +5,9 @@ Expand the name of the chart.
 {{- define "cost-analyzer.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- define "query-service.name" -}}
+{{- default "query-service" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
 {{/*
 Create a default fully qualified app name.
@@ -22,6 +25,10 @@ If release name contains chart name it will be used as a full name.
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "query-service.fullname" -}}
+{{- printf "%s-%s" .Release.Name "query-service" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -96,6 +103,12 @@ helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+{{- define "kubecost.queryService.chartLabels" -}}
+app.kubernetes.io/name: {{ include "query-service.name" . }}
+helm.sh/chart: {{ include "cost-analyzer.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
 
 
 {{/*
@@ -115,6 +128,13 @@ Create the name of the service account
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+{{- define "query-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "query-service.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create the common labels.
@@ -126,6 +146,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app: cost-analyzer
 {{- end -}}
+{{- define "query-service.commonLabels" -}}
+{{ include "kubecost.queryService.chartLabels" . }}
+app: query-service
+{{- end -}}
 
 {{/*
 Create the selector labels.
@@ -134,6 +158,11 @@ Create the selector labels.
 app.kubernetes.io/name: {{ include "cost-analyzer.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app: cost-analyzer
+{{- end -}}
+{{- define "query-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "query-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app: query-service
 {{- end -}}
 
 {{/*

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -101,6 +101,12 @@ data:
     }
 {{- end }}
 
+  {{- if and (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) (gt (.Values.kubecostDeployment.queryServiceReplicas | toString | atoi) 0) }}
+    upstream queryservice {
+        server {{ .Release.Name }}-query-service-load-balancer.{{ .Release.Namespace }}:9003;
+    }
+  {{- end }}
+
     server {
         server_name _;
         root /var/www;
@@ -283,6 +289,32 @@ data:
         {{- if .Values.saml.rbac.enabled }}
         location /authrbac {
             proxy_pass http://model/isAdminAuthenticated;
+        }
+    {{- end }}
+
+    {{- if and (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) (gt (.Values.kubecostDeployment.queryServiceReplicas | toString | atoi) 0) }}
+        location /model/allocation {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://queryservice/allocation;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /model/assets {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://queryservice/assets;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     {{- end }}
     }

--- a/cost-analyzer/templates/query-service-cluster-role-binding-template.yaml
+++ b/cost-analyzer/templates/query-service-cluster-role-binding-template.yaml
@@ -1,0 +1,34 @@
+{{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
+{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "query-service.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "query-service.commonLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "query-service.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "query-service.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "query-service.serviceAccountName" . }}
+  labels:
+    {{ include "query-service.commonLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "query-service.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "query-service.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }} 
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/query-service-cluster-role-template.yaml
+++ b/cost-analyzer/templates/query-service-cluster-role-template.yaml
@@ -1,0 +1,109 @@
+{{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
+{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "query-service.serviceAccountName" . }}
+  labels:
+    {{ include "query-service.commonLabels" . | nindent 4 }}
+rules:
+- apiGroups: 
+    - ''
+  resources:
+    - "pods/log"
+  verbs:
+    - get
+    - list
+    - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "query-service.serviceAccountName" . }}
+  labels:
+    {{ include "query-service.commonLabels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - deployments
+      - nodes
+      - pods
+      - events
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: 
+      - storage.k8s.io
+    resources: 
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -1,0 +1,107 @@
+{{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
+{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "query-service.fullname" . }}
+  namespace: {{ .Release.Name }}
+  labels:
+    {{ include "query-service.commonLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.kubecostDeployment.queryServiceReplicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: query-service
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app: query-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: query-service
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app: query-service
+    spec:
+      restartPolicy: Always
+      serviceAccountName: {{ template "query-service.serviceAccountName" . }}
+      volumes:
+        - name: persistent-configs
+          emptyDir: {}
+        - name: persistent-db
+          emptyDir: {}
+        {{- $etlBackupBucketSecret := "" }}
+        {{- if .Values.kubecostModel.etlBucketConfigSecret }}
+            {{- $etlBackupBucketSecret = .Values.kubecostModel.etlBucketConfigSecret }}
+        {{- else if and .Values.global.thanos.enabled (ne (typeOf .Values.kubecostModel.etlBucketConfigSecret) "string") }}
+            {{- $etlBackupBucketSecret = .Values.thanos.storeSecretName }}
+        {{- end }}
+        {{- if $etlBackupBucketSecret }}
+        - name: etl-bucket-config
+          secret:
+           defaultMode: 420
+           secretName: {{ $etlBackupBucketSecret }}
+        {{- end }}
+      initContainers:
+        - name: config-db-perms-fix
+          image: busybox
+          command: ["sh", "-c", "/bin/chmod -R 777 /var/configs && /bin/chmod -R 777 /var/db"]
+          volumeMounts:
+            - name: persistent-configs
+              mountPath: /var/configs
+            - name: persistent-db
+              mountPath: /var/db
+          securityContext:
+            runAsUser: 0
+      containers:
+        - name: query-service
+          {{- if .Values.kubecostModel }}
+          {{- if .Values.kubecostModel.openSourceOnly }}
+          image: quay.io/kubecost1/kubecost-cost-model:{{ .Values.imageVersion }}
+          {{- else if .Values.kubecostModel.fullImageName }}
+          image: {{ .Values.kubecostModel.fullImageName }}
+          {{- else if .Values.imageVersion }}
+          image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
+          {{- else }}
+          image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+          {{ end }}
+          {{- else }}
+          image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+          {{ end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 200
+          imagePullPolicy: Always
+          args: ["query-service"]
+          ports:
+            - name: tcp-model
+              containerPort: 9003
+              protocol: TCP
+          volumeMounts:
+            - name: persistent-configs
+              mountPath: /var/configs
+            - name: etl-bucket-config
+              mountPath: /var/configs/etl
+            - name: persistent-db
+              mountPath: /var/db
+          env:
+            - name: CONFIG_PATH
+              value: /var/configs/
+            - name: DB_PATH
+              value: /var/db/
+            - name: ETL_FILE_STORE_ENABLED
+              value: "true"
+            {{- if $etlBackupBucketSecret }}
+            - name: ETL_BUCKET_CONFIG
+              value: "/var/configs/etl/object-store.yaml"
+            {{- end }}
+            - name: ETL_TO_DISK_ENABLED
+              value: "true"
+            - name: ETL_PATH_PREFIX
+              value: "/var/db"
+            - name: CLOUD_PROVIDER_API_KEY
+              value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API key.This GCP api key is expected to be here and is limited to accessing google's billing API.'
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/query-service-service-account-template.yaml
+++ b/cost-analyzer/templates/query-service-service-account-template.yaml
@@ -1,0 +1,17 @@
+{{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
+{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "query-service.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "query-service.commonLabels" . | nindent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/query-service-service-template.yaml
+++ b/cost-analyzer/templates/query-service-service-template.yaml
@@ -1,0 +1,19 @@
+{{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
+{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-query-service-load-balancer
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "query-service.commonLabels" . | nindent 4 }}
+spec:
+  selector:
+{{ include "query-service.selectorLabels" . | nindent 4 }}
+  type: "LoadBalancer"
+  ports:
+    - name: tcp-query-service
+      port: 9003
+      targetPort: 9003
+{{- end }}
+{{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -809,6 +809,7 @@ kubecostDeployment:
   #     maxSurge: 1
   #     maxUnavailable: 1
   #   type: RollingUpdate
+  queryServiceReplicas: 0
 
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:


### PR DESCRIPTION
## What does this PR change?
Adds support for Query Service Replicas.


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/1392


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
If Query Service Replicas are disabled, functionality is the same. Otherwise, /model/allocation and /model/assets endpoints will be forward to a StatefulSet of Query Services, round robined by a load balancer.


## Links to Issues or ZD tickets this PR addresses or fixes

- https://kubecost.atlassian.net/browse/EV-59


## How was this PR tested?
Deployed to test-1 in GKE, with QS replicas enabled and disabled. When enabled, verified that traffic is routed to load balancer, and that load balancer is properly balancing requests between replicas.

## Have you made an update to documentation?
No
