### PR TITLE
fix: avoid duplicate volume name in cost-analyzer

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -98,7 +98,7 @@ spec:
         */}}
         {{- $etlBackupBucketSecret := "" }}
         {{- if .Values.global.containerSecuritycontext }}
-        - name: tmp
+        - name: var-run
           emptyDir: { }
         - name: cache
           emptyDir: { }
@@ -1102,7 +1102,7 @@ spec:
             - mountPath: /var/cache/nginx
               name: cache
             - mountPath: /var/run
-              name: tmp
+              name: var-run
             {{- end }}
             {{- if .Values.kubecostFrontend.tls }}
             {{- if .Values.kubecostFrontend.tls.enabled }}


### PR DESCRIPTION


## What does this PR change?
When containerSecuritycontext is defined, cost-analyzer Deployment obtains a duplicate volume name (`tmp`) and fails to deploy.


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Unable to deploy if defining a containerSecuritycontext


## Links to Issues or ZD tickets this PR addresses or fixes
n/a

## How was this PR tested?
Manual installation

## Have you made an update to documentation?
No
