### PR TITLE
feat(cost-analyzer): add StatefulSet as option

### DIFF
--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -99,3 +99,57 @@ Adjusting the log format changes the format in which the logs are output making 
 |--------|----------------------------------------------------------------------------------------------------------------------------|
 | `JSON`   | `{"level":"info","time":"2006-01-02T15:04:05.999999999Z07:00","message":"Starting cost-model (git commit \"1.91.0-rc.0\")"}` |
 | `pretty` | `2006-01-02T15:04:05.999999999Z07:00 INF Starting cost-model (git commit "1.91.0-rc.0")`                                     |
+
+## Testing
+To perform local testing do next:
+- install locally [kind](https://github.com/kubernetes-sigs/kind) according to documentation.
+- install locally [ct](https://github.com/helm/chart-testing) according to documentation.
+- create local cluster using `kind` \
+use image version from https://github.com/kubernetes-sigs/kind/releases e.g. `kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8`
+```shell
+kind create cluster --image kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
+```
+- perform ct execution
+```shell
+ct install  --chart-dirs="." --charts="."
+```
+
+- perform ct StatefulSet execution
+
+```shell
+# create multiple nodes kind config
+cat > kind-config.yaml <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+EOF
+# creaet kind cluster with kind config
+kind create cluster --name kubecost-statefulset --config kind-config.yaml --image kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
+# deploy an object storage for our testing purpose (https://min.io/docs/minio/kubernetes/upstream/index.html)
+curl --silent https://raw.githubusercontent.com/minio/docs/master/source/extra/examples/minio-dev.yaml  | sed -e "s/kubealpha.local/kubecost-statefulset-worker/" -e "s%minio server /data%mkdir -p /data/kubecost; minio server /data%" | kubectl apply -f -
+# create a headless service to the minio S3 API port
+kubectl create service clusterip -n minio-dev minio --tcp=9000:9000 --clusterip="None"
+# create our testing namespace
+kubectl create namespace kubecost-statefulset
+# create the bucket config 
+cat > etlBucketConfigSecret.yaml <<EOF
+type: s3
+config:
+  bucket: kubecost
+  endpoint: minio.minio-dev:9000
+  insecure: true
+  access_key: minioadmin
+  secret_key: minioadmin
+EOF
+# create the secret with the object-store.yaml
+kubectl create secret generic -n kubecost-statefulset object-store --from-file=object-store.yaml=etlBucketConfigSecret.yaml
+# start our chart-testing
+ct install --namespace kubecost-statefulset --chart-dirs="." --charts="." --helm-extra-set-args="--set=global.prometheus.enabled=true --set=global.grafana.enabled=true --set=kubecostDeployment.leaderFollower.enabled=true --set=kubecostDeployment.statefulSet.enabled=true --set=kubecostDeployment.replicas=2 --set=kubecostModel.etlBucketConfigSecret=object-store"
+# cleanup
+kind delete cluster --name kubecost-statefulset 
+```
+
+

--- a/cost-analyzer/templates/cost-analyzer-db-pvc-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-db-pvc-template.yaml
@@ -3,6 +3,7 @@
 {{- if not .Values.persistentVolume.dbExistingClaim -}}
 {{- if .Values.persistentVolume.enabled -}}
 {{- if .Values.persistentVolume.dbPVEnabled -}}
+{{- if not (and .Values.kubecostDeployment.statefulSet.enabled .Values.kubecostDeployment.leaderFollower.enabled) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -30,6 +31,7 @@ spec:
     {{- else }}
       storage: 32.0Gi
     {{ end }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -1,7 +1,11 @@
 {{- if and (not .Values.agent) (not .Values.cloudAgent) }}
 {{- $nginxPort := int .Values.service.port | default 9090 -}}
 apiVersion: apps/v1
+{{- if and .Values.kubecostDeployment.statefulSet.enabled .Values.kubecostDeployment.leaderFollower.enabled }}
+kind: StatefulSet
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -17,6 +21,9 @@ metadata:
 spec:
 {{- if .Values.kubecostDeployment }}
   replicas: {{ .Values.kubecostDeployment.replicas | default 1 }}
+{{- end }}
+{{- if and .Values.kubecostDeployment.statefulSet.enabled .Values.kubecostDeployment.leaderFollower.enabled }}
+  serviceName: {{ template "cost-analyzer.serviceName" . }}
 {{- end }}
   selector:
     matchLabels:
@@ -264,6 +271,7 @@ spec:
         # Extra volume(s)
         {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
+{{- if not (and .Values.kubecostDeployment.statefulSet.enabled .Values.kubecostDeployment.leaderFollower.enabled) }}
         - name: persistent-configs
 {{- if .Values.persistentVolume }}
 {{- if .Values.persistentVolume.enabled }}
@@ -280,7 +288,8 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "cost-analyzer.fullname" . }}
 {{- end }}
-{{- if and (.Values.kubecostModel.etlToDisk | default true) .Values.persistentVolume.dbPVEnabled }}
+{{- end }}
+{{- if and (.Values.kubecostModel.etlToDisk | default true) .Values.persistentVolume.dbPVEnabled (not (and .Values.kubecostDeployment.statefulSet.enabled .Values.kubecostDeployment.leaderFollower.enabled)) }}
         - name: persistent-db
 {{- if .Values.persistentVolume }}
 {{- if .Values.persistentVolume.enabled }}
@@ -1165,4 +1174,39 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if and .Values.kubecostDeployment.statefulSet.enabled .Values.kubecostDeployment.leaderFollower.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: persistent-configs
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.persistentVolume.storageClass }}
+        storageClassName: {{ .Values.persistentVolume.storageClass }}
+        {{ end }}
+        resources:
+          requests:
+          {{- if .Values.persistentVolume }}
+            storage: {{ .Values.persistentVolume.size }}
+          {{- else }}
+            storage: 32.0Gi
+          {{ end }}
+    {{- if and (.Values.kubecostModel.etlToDisk | default true) .Values.persistentVolume.dbPVEnabled }}
+    - metadata:
+        name: persistent-db
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.persistentVolume.dbStorageClass }}
+        storageClassName: {{ .Values.persistentVolume.dbStorageClass }}
+        {{ end }}
+        resources:
+          requests:
+          {{- if .Values.persistentVolume }}
+            storage: {{ .Values.persistentVolume.dbSize }}
+          {{- else }}
+            storage: 32.0Gi
+          {{ end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.persistentVolume -}}
 {{- if not .Values.persistentVolume.existingClaim -}}
 {{- if .Values.persistentVolume.enabled -}}
+{{- if not (and .Values.kubecostDeployment.statefulSet.enabled .Values.kubecostDeployment.leaderFollower.enabled) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -28,6 +29,7 @@ spec:
     {{- else }}
       storage: 32.0Gi
     {{ end }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -899,6 +899,9 @@ networkCosts:
 ## Used for HA mode in Business & Enterprise tier
 ##
 kubecostDeployment:
+  # Instead of a kubecost-analyzer Deployment, you can set it to be a StatefulSet as for volumeClaimTemplates usage and real stateful behaviour
+  statefulSet:
+    enabled: false
   replicas: 1
   leaderFollower:
     enabled: false


### PR DESCRIPTION
## What does this PR change?
It enables the option to create a `StatefulSet` with `claimVolumeTemplates` and any `StorageClass`. 

With the current `Deployment` implementation you only have two options, if you want to set up cost-analyzer in HA mode (replicas > 1).

1. You can use `emptyDir`, as this would create a volume mount without a PV on each Kubernetes Node where a Pod is started.
2. You can use a `StorageClass` which enables you to get a PV with [RWM (ReadWriteMany)].

With this feature you are now able to use any `StorageClass` as the `claimVolumeTemplates` creates automatically a PVC for each Pod scaled by the `StatefulSet`.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
With `.statefulSet.enabled = true` you are able to get a cost-analyzer `StatefulSet` rolled out, instead of a `Deployment` and get automatically a `PersistenVolumeClaim` per scaled `Pod`. As this is a StatefulSet feature.

## Links to Issues or ZD tickets this PR addresses or fixes
None created

## How was this PR tested?
Kind cluster and a started StatefulSet as written in the `README.md` with ct (chart-testing) cli command.

## Have you made an update to documentation?
Not yet

[RWM (ReadWriteMany)]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
