### PR TITLE
Always set GOOGLE_APPLICATION_CREDENTIALS in CC

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -212,12 +212,8 @@ spec:
           value: {{ .Release.Namespace }}
         - name: TURNDOWN_DEPLOYMENT
           value: {{ template "kubecost.clusterControllerName" . }}
-        {{- if .Values.kubecostProductConfigs }}
-        {{- if .Values.kubecostProductConfigs.gcpSecretName }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/keys/service-key.json
-        {{- end }}
-        {{- end }}
         - name: CC_LOG_LEVEL
           value: {{ .Values.clusterController.logLevel | default "info" }}
         - name: CC_KUBESCALER_COST_MODEL_PATH


### PR DESCRIPTION
## What does this PR change?
These if statements were not consistent with our public install instructions for Cluster Controller (they do not specify that gcpSecretName should be set) and also are not consistent with this template for the deployment because even if gcpSecretName is set, it is not mounted anywhere. 

By making this change, following our full Cluster Controller install instructions on GKE will work correctly.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixed a bug in the Helm chart when using Cluster Controller in GKE with full capabilities (turndown, etc.). The GCP service account credentials were not being correctly passed to the application, resulting in a failure to initialize.


## Links to Issues or ZD tickets this PR addresses or fixes

- Fixes https://kubecost.atlassian.net/browse/CORE-209


## How was this PR tested?
Followed the public Kubecost documentation for installing Cluster Controller with turndown enabled on a fresh GKE cluster. Observed correct startup logs, instead of the failure "validating provider" logs observed previously.

## Have you made an update to documentation?
N/A, this PR makes functionality consistent with our documentation.