### PR TITLE
Add mimir-proxy to support Grafana Mimir as timeseries database

### DIFF
--- a/cost-analyzer/templates/mimir-proxy-configmap-template.yaml
+++ b/cost-analyzer/templates/mimir-proxy-configmap-template.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.mimirProxy }}
+{{- if .Values.global.mimirProxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  default.conf: |
+    server {
+        listen {{ .Values.global.mimirProxy.port }};
+        location / {
+          proxy_pass  {{ .Values.global.mimirProxy.mimirEndpoint }};
+          proxy_set_header  X-Scope-OrgID "{{ .Values.global.mimirProxy.orgIdentifier }}";
+        }
+    }
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/mimir-proxy-configmap-template.yaml
+++ b/cost-analyzer/templates/mimir-proxy-configmap-template.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy-configmap
+  name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy
   namespace: {{ .Release.Namespace }}
 data:
   default.conf: |

--- a/cost-analyzer/templates/mimir-proxy-deployment-template.yaml
+++ b/cost-analyzer/templates/mimir-proxy-deployment-template.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy-deployment
+  name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy
   namespace: {{ .Release.Namespace }}
   labels:
     app: mimir-proxy
@@ -32,7 +32,7 @@ spec:
       volumes:
       - name: default-conf
         configMap:
-          name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy-configmap
+          name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy
           items:
             - key: default.conf
               path: default.conf

--- a/cost-analyzer/templates/mimir-proxy-deployment-template.yaml
+++ b/cost-analyzer/templates/mimir-proxy-deployment-template.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.global.mimirProxy }}
+{{- if .Values.global.mimirProxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: mimir-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mimir-proxy
+  template:
+    metadata:
+      labels:
+        app: mimir-proxy
+    spec:
+      containers:
+      - name: {{ .Values.global.mimirProxy.name }}
+        image: {{ .Values.global.mimirProxy.image }}
+        ports:
+          - containerPort: {{ .Values.global.mimirProxy.port }}
+            protocol: TCP
+        resources: {}
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - mountPath: /etc/nginx/conf.d
+          name: default-conf
+          readOnly: true
+      volumes:
+      - name: default-conf
+        configMap:
+          name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy-configmap
+          items:
+            - key: default.conf
+              path: default.conf
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/mimir-proxy-service-template.yaml
+++ b/cost-analyzer/templates/mimir-proxy-service-template.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.mimirProxy }}
+{{- if .Values.global.mimirProxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: mimir-proxy
+      protocol: TCP
+      port: {{ .Values.global.mimirProxy.port }}
+      targetPort: {{ .Values.global.mimirProxy.port }}
+  selector:
+    app: mimir-proxy
+  type: ClusterIP
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/mimir-proxy-service-template.yaml
+++ b/cost-analyzer/templates/mimir-proxy-service-template.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy-service
+  name: {{ template "cost-analyzer.fullname" . }}-mimir-proxy
   namespace: {{ .Release.Namespace }}
 spec:
   ports:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -55,6 +55,19 @@ global:
       # role_arn: ROLE_ARN # AWS role arn
       # profile: PROFILE # AWS profile
 
+  # Mimir Proxy to help Kubecost to query metrics from multi-tenant Grafana Mimir.
+  # Set `mimirProxy.enabled=true`` to enable Mimir Proxy. 
+  # You also need to set `global.prometheus.fqdn=https://localhost:8085/prometheus`
+  # Learn more at https://grafana.com/docs/mimir/latest/operators-guide/secure/authentication-and-authorization/#without-an-authenticating-reverse-proxy
+  mimirProxy:
+    enabled: false
+    name: mimir-proxy
+    image: nginxinc/nginx-unprivileged
+    port: 8085
+    mimirEndpoint: https://MIMIR_ENDPOINT
+    orgIdentifier: YOUR_ID #Your Grafana Mimir tenant ID
+
+
   notifications:
     # Kubecost alerting configuration
     # Ref: http://docs.kubecost.com/alerts

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -56,16 +56,16 @@ global:
       # profile: PROFILE # AWS profile
 
   # Mimir Proxy to help Kubecost to query metrics from multi-tenant Grafana Mimir.
-  # Set `mimirProxy.enabled=true`` to enable Mimir Proxy. 
-  # You also need to set `global.prometheus.fqdn=https://localhost:8085/prometheus`
+  # Set `global.mimirProxy.enabled=true` to enable Mimir Proxy. 
+  # You also need to set `global.prometheus.fqdn=https://localhost:8085/`
   # Learn more at https://grafana.com/docs/mimir/latest/operators-guide/secure/authentication-and-authorization/#without-an-authenticating-reverse-proxy
   mimirProxy:
     enabled: false
     name: mimir-proxy
     image: nginxinc/nginx-unprivileged
     port: 8085
-    mimirEndpoint: https://MIMIR_ENDPOINT
-    orgIdentifier: YOUR_ID #Your Grafana Mimir tenant ID
+    mimirEndpoint: $mimir_endpoint #Your Mimir query endpoint
+    orgIdentifier: $your_tenant_ID #Your Grafana Mimir tenant ID
 
 
   notifications:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -56,15 +56,16 @@ global:
       # profile: PROFILE # AWS profile
 
   # Mimir Proxy to help Kubecost to query metrics from multi-tenant Grafana Mimir.
-  # Set `global.mimirProxy.enabled=true` to enable Mimir Proxy. 
-  # You also need to set `global.prometheus.fqdn=https://localhost:8085/`
+  # Set `global.mimirProxy.enabled=true` and `global.prometheus.enabled=false` to enable Mimir Proxy. 
+  # You also need to set `global.prometheus.fqdn=http://kubecost-cost-analyzer-mimir-proxy.kubecost.svc:8085/prometheus` 
+  # or `global.prometheus.fqdn=http://{{ template "cost-analyzer.fullname" . }}-mimir-proxy.{{ .Release.Namespace }}.svc:8085/prometheus'
   # Learn more at https://grafana.com/docs/mimir/latest/operators-guide/secure/authentication-and-authorization/#without-an-authenticating-reverse-proxy
   mimirProxy:
     enabled: false
     name: mimir-proxy
     image: nginxinc/nginx-unprivileged
     port: 8085
-    mimirEndpoint: $mimir_endpoint #Your Mimir query endpoint
+    mimirEndpoint: $mimir_endpoint #Your Mimir query endpoint. If your Mimir query endpoint is http://example.com/prometheus, replace $mimir_endpoint with http://example.com/
     orgIdentifier: $your_tenant_ID #Your Grafana Mimir tenant ID
 
 


### PR DESCRIPTION
## What does this PR change?

This PR add new support for Grafana Mimir as a database by adding a proxy allowing Kubecost to query metrics from a specific Grafana Mimir tenant.

Credit to @jessegoodier to provide the solution. I help to translate it to Helm templates

## Does this PR rely on any other PRs?

N/A


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

This PR add new support for Grafana Mimir as a database by adding a proxy allowing Kubecost to query metrics from a specific Grafana Mimir tenant.

## Links to Issues or ZD tickets this PR addresses or fixes

N/A


## How was this PR tested?

Helm template command:

```
helm template kubecost cost-analyzer/ -n kubecost-mimir --create-namespace --set global.mimirProxy.enabled=true --set global.prometheus.fqdn=https://localhost:8085/ > /tmp/mimir-test
```

@jessegoodier can you help with verifying the deployment and review please?

## Have you made an update to documentation?

No, the documentation will come after this PR is completed
