### PR TITLE
Split grafana sidecar image name and image version config

### DIFF
--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -73,8 +73,8 @@ spec:
       containers:
 {{- if .Values.sidecar.dashboards.enabled }}
         - name: {{ template "grafana.name" . }}-sc-dashboard
-          image: "{{ .Values.sidecar.image }}"
-          imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+          image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.sidecar.image.pullPolicy }}
           env:
             - name: LABEL
               value: "{{ .Values.sidecar.dashboards.label }}"
@@ -90,8 +90,8 @@ spec:
 {{- end}}
 {{- if .Values.sidecar.datasources.enabled }}
         - name: {{ template "grafana.name" . }}-sc-datasources
-          image: "{{ .Values.sidecar.image }}"
-          imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+          image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.sidecar.image.pullPolicy }}
           env:
             - name: LABEL
               value: "{{ .Values.sidecar.datasources.label }}"

--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -256,8 +256,10 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:1.23.1
-  imagePullPolicy: IfNotPresent
+  image:
+    repository: kiwigrid/k8s-sidecar
+    tag: 1.23.1
+    pullPolicy: IfNotPresent
   resources:
 #   limits:
 #     cpu: 100m


### PR DESCRIPTION
## What does this PR change?
This PR would allow users to override the Grafana sidecar image name without taking on the responsibility of updating image versions.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No direct impact on users. 


## Links to Issues or ZD tickets this PR addresses or fixes
Fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/2191


## How was this PR tested?
Manually. Checked that Grafana sidecar still has the correct repo and tag:

```
❯ kubectl get deploy kubecost-grafana -n kubecost -o yaml | grep sidecar
        image: kiwigrid/k8s-sidecar:1.23.1
```

## Have you made an update to documentation?
N/A
