### PR TITLE
feat: add container securitycontext to prometheus-server deployment

### DIFF
--- a/cost-analyzer/charts/prometheus/README.md
+++ b/cost-analyzer/charts/prometheus/README.md
@@ -181,6 +181,7 @@ Parameter | Description | Default
 `alertmanager.strategy` | Deployment strategy | `{ "type": "RollingUpdate" }`
 `alertmanagerFiles.alertmanager.yml` | Prometheus alertmanager configuration | example configuration
 `configmapReload.prometheus.enabled` | If false, the configmap-reload container for Prometheus will not be deployed | `true`
+`configmapReload.prometheus.containerSecurityContext` | securityContext for container | `{}`
 `configmapReload.prometheus.name` | configmap-reload container name | `configmap-reload`
 `configmapReload.prometheus.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
 `configmapReload.prometheus.image.tag` | configmap-reload container image tag | `v0.5.0`
@@ -320,6 +321,7 @@ Parameter | Description | Default
 `server.persistentVolume.storageClass` | Prometheus server data Persistent Volume Storage Class |  `unset`
 `server.persistentVolume.volumeBindingMode` | Prometheus server data Persistent Volume Binding Mode | `unset`
 `server.persistentVolume.subPath` | Subdirectory of Prometheus server data Persistent Volume to mount | `""`
+`server.containerSecurityContext` | securityContext for container | `{}`
 `server.emptyDir.sizeLimit` | emptyDir sizeLimit if a Persistent Volume is not used | `""`
 `server.podAnnotations` | annotations to be added to Prometheus server pods | `{}`
 `server.podLabels` | labels to be added to Prometheus server pods | `{}`

--- a/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
@@ -60,6 +60,10 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.configmapReload.prometheus.resources | indent 12 }}
+          {{- with .Values.configmapReload.prometheus.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if .Values.selfsignedCertConfigMapName }}
             - name: {{ .Values.selfsignedCertConfigMapName }}
@@ -123,6 +127,10 @@ spec:
             successThreshold: {{ .Values.server.livenessProbeSuccessThreshold }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}
+          {{- with .Values.server.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -333,7 +333,6 @@ configmapReload:
     ##
     extraVolumeDirs: []
 
-
     ## Additional configmap-reload mounts
     ##
     extraConfigmapMounts: []
@@ -343,11 +342,14 @@ configmapReload:
       #   configMap: prometheus-alerts
       #   readOnly: true
 
-
     ## configmap-reload resource requests and limits
     ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
     ##
     resources: {}
+
+    ## configmap-reload container securityContext
+    containerSecurityContext: {}
+
   alertmanager:
     ## If false, the configmap-reload container will not be deployed
     ##
@@ -870,6 +872,8 @@ server:
     runAsNonRoot: true
     runAsGroup: 1001
     fsGroup: 1001
+
+  containerSecurityContext: {}
 
   service:
     annotations: {}


### PR DESCRIPTION
## What does this PR change?
Adding option to configure `securityContext` block on prometheus-server deployment's containers. Defaults to `{}`.


## Does this PR rely on any other PRs?
No.
- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
It does not, as the default stays `{}`.


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Tested locally via `helm template`

## Have you made an update to documentation?
Yes.
