### PR TITLE
Add schema for status to TurndownSchedule CRD

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -294,6 +294,34 @@ spec:
                 repeat:
                   type: string
                   enum: [none, daily, weekly]
+            status:
+              type: object
+              properties:
+                state:
+                  type: string
+                lastUpdated:
+                  format: date-time
+                  type: string
+                current:
+                  type: string
+                scaleDownId:
+                  type: string
+                nextScaleDownTime:
+                  format: date-time
+                  type: string
+                scaleDownMetadata:
+                  additionalProperties:
+                    type: string
+                  type: object
+                scaleUpID:
+                  type: string
+                nextScaleUpTime:
+                  format: date-time
+                  type: string
+                scaleUpMetadata:
+                  additionalProperties:
+                    type: string
+                  type: object
       additionalPrinterColumns:
       - name: State
         type: string


### PR DESCRIPTION
## What does this PR change?
Fixes a bug where the CR (turndownschedule) status would never be updated because calls to UpdateStatus were no-ops. The "bad state" cleanup routine for turndownschedules would then delete the schedule because it thought it was in a bad state, but in fact we just failed to update the CR with the state being held by the controller.

With the schema, they are no longer no-ops and turndown completes successfully.


## Does this PR rely on any other PRs?

- Mirrors OSS: https://github.com/kubecost/cluster-turndown/pull/55


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- https://kubecost.atlassian.net/browse/CORE-195


## How was this PR tested?

Installed Helm chart with CC enabled on a fresh GKE cluster. Scheduled turndown. Observed correct full schedule success -> turn down -> turn up -> reschedule cycle, including statuses on the TDS in-cluster.

GKE cluster config:
```
gcloud container clusters create \
    "<redacted>" \
    --project "<redacted>" \
    --region "us-central1-c" \
    --network "<redacted>" \
    --subnetwork "us-central1" \
    --release-channel "stable" \
    --num-nodes 2
```

I can provide other specific testing commands if desired.

## Have you made an update to documentation?
Not necessary.