### PR TITLE
feat: Add support for ServiceMonitor relabelings and metricRelabelings

### DIFF
--- a/cost-analyzer/README.md
+++ b/cost-analyzer/README.md
@@ -8,51 +8,52 @@ While Helm is the [recommended install path](http://kubecost.com/install), these
 <a name="config-options"></a><br/>
 The following table lists the commonly used configurable parameters of the Kubecost Helm chart and their default values.
 
-Parameter | Description | Default
---------- | ----------- | -------
-`global.prometheus.enabled` | If false, use an existing Prometheus install. [More info](http://docs.kubecost.com/custom-prom). | `true`
-`prometheus.kube-state-metrics.disabled` | If false, deploy [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) for Kubernetes metrics | `false`
-`prometheus.kube-state-metrics.resources` | Set kube-state-metrics resource requests and limits. | `{}`
-`prometheus.server.persistentVolume.enabled` | If true, Prometheus server will create a Persistent Volume Claim. | `true`
-`prometheus.server.persistentVolume.size` | Prometheus server data Persistent Volume size. Default set to retain ~6000 samples per second for 15 days. | `32Gi`
-`prometheus.server.retention` | Determines when to remove old data. | `15d`
-`prometheus.server.resources` | Prometheus server resource requests and limits. | `{}`
-`prometheus.nodeExporter.resources` | Node exporter resource requests and limits. | `{}`
-`prometheus.nodeExporter.enabled` `prometheus.serviceAccounts.nodeExporter.create` | If false, do not crate NodeExporter daemonset.  | `true`
-`prometheus.alertmanager.persistentVolume.enabled` | If true, Alertmanager will create a Persistent Volume Claim. | `true`
-`prometheus.pushgateway.persistentVolume.enabled` | If true, Prometheus Pushgateway will create a Persistent Volume Claim. | `true`
-`persistentVolume.enabled` | If true, Kubecost will create a Persistent Volume Claim for product config data.  | `true`
-`persistentVolume.size` | Define PVC size for cost-analyzer  | `32.0Gi`
-`persistentVolume.dbSize` | Define PVC size for cost-analyzer's flat file database  | `32.0Gi`
-`ingress.enabled` | If true, Ingress will be created | `false`
-`ingress.annotations` | Ingress annotations | `{}`
-`ingress.className` | Ingress class name | `{}`
-`ingress.paths` | Ingress paths | `["/"]`
-`ingress.hosts` | Ingress hostnames | `[cost-analyzer.local]`
-`ingress.tls` | Ingress TLS configuration (YAML) | `[]`
-`networkPolicy.enabled` | If true, create a NetworkPolicy to deny egress  | `false`
-`networkPolicy.costAnalyzer.enabled` | If true, create a newtork policy for cost-analzyer | `false`
-`networkPolicy.costAnalyzer.annotations` | Annotations to be added to the network policy | `{}`
-`networkPolicy.costAnalyzer.additionalLabels` | Additional labels to be added to the network policy | `{}`
-`networkPolicy.costAnalyzer.ingressRules` | A list of network policy ingress rules | `null`
-`networkPolicy.costAnalyzer.egressRules` | A list of network policy egress rules | `null`
-`networkCosts.enabled` | If true, collect network allocation metrics [More info](http://docs.kubecost.com/network-allocation) | `false`
-`networkCosts.podMonitor.enabled` | If true, a [PodMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#podmonitor) for the network-cost daemonset is created | `false`
-`serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
-`serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
-`prometheusRule.enabled` | Set this to `true` to create PrometheusRule for Prometheus operator | `false`
-`prometheusRule.additionalLabels` | Additional labels that can be used so PrometheusRule will be discovered by Prometheus | `{}`
-`grafana.resources` | Grafana resource requests and limits. | `{}`
-`grafana.sidecar.datasources.defaultDatasourceEnabled` | Set this to `false` to disable creation of Prometheus datasource in Grafana | `true`
-`serviceAccount.create` | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own | `true`
-`tolerations` | node taints to tolerate | `[]`
-`affinity` | pod affinity | `{}`
-`kubecostProductConfigs.productKey.mountPath` | Use instead of `kubecostProductConfigs.productKey.secretname` to declare the path at which the product key file is mounted (eg. by a secrets provisioner) | `N/A`
-`kubecostFrontend.api.fqdn` | Customize the upstream api FQDN | `computed in terms of the service name and namespace`
-`kubecostFrontend.model.fqdn` | Customize the upstream model FQDN | `computed in terms of the service name and namespace`
-`clusterController.fqdn` | Customize the upstream cluster controller FQDN | `computed in terms of the service name and namespace`
-`global.grafana.fqdn` | Customize the upstream grafana FQDN | `computed in terms of the release name and namespace`
-
+| Parameter                                                                          | Description                                                                                                                                                  | Default                                               |
+|------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `global.prometheus.enabled`                                                        | If false, use an existing Prometheus install. [More info](http://docs.kubecost.com/custom-prom).                                                             | `true`                                                |
+| `prometheus.kube-state-metrics.disabled`                                           | If false, deploy [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) for Kubernetes metrics                                               | `false`                                               |
+| `prometheus.kube-state-metrics.resources`                                          | Set kube-state-metrics resource requests and limits.                                                                                                         | `{}`                                                  |
+| `prometheus.server.persistentVolume.enabled`                                       | If true, Prometheus server will create a Persistent Volume Claim.                                                                                            | `true`                                                |
+| `prometheus.server.persistentVolume.size`                                          | Prometheus server data Persistent Volume size. Default set to retain ~6000 samples per second for 15 days.                                                   | `32Gi`                                                |
+| `prometheus.server.retention`                                                      | Determines when to remove old data.                                                                                                                          | `15d`                                                 |
+| `prometheus.server.resources`                                                      | Prometheus server resource requests and limits.                                                                                                              | `{}`                                                  |
+| `prometheus.nodeExporter.resources`                                                | Node exporter resource requests and limits.                                                                                                                  | `{}`                                                  |
+| `prometheus.nodeExporter.enabled` `prometheus.serviceAccounts.nodeExporter.create` | If false, do not crate NodeExporter daemonset.                                                                                                               | `true`                                                |
+| `prometheus.alertmanager.persistentVolume.enabled`                                 | If true, Alertmanager will create a Persistent Volume Claim.                                                                                                 | `true`                                                |
+| `prometheus.pushgateway.persistentVolume.enabled`                                  | If true, Prometheus Pushgateway will create a Persistent Volume Claim.                                                                                       | `true`                                                |
+| `persistentVolume.enabled`                                                         | If true, Kubecost will create a Persistent Volume Claim for product config data.                                                                             | `true`                                                |
+| `persistentVolume.size`                                                            | Define PVC size for cost-analyzer                                                                                                                            | `32.0Gi`                                              |
+| `persistentVolume.dbSize`                                                          | Define PVC size for cost-analyzer's flat file database                                                                                                       | `32.0Gi`                                              |
+| `ingress.enabled`                                                                  | If true, Ingress will be created                                                                                                                             | `false`                                               |
+| `ingress.annotations`                                                              | Ingress annotations                                                                                                                                          | `{}`                                                  |
+| `ingress.className`                                                                | Ingress class name                                                                                                                                           | `{}`                                                  |
+| `ingress.paths`                                                                    | Ingress paths                                                                                                                                                | `["/"]`                                               |
+| `ingress.hosts`                                                                    | Ingress hostnames                                                                                                                                            | `[cost-analyzer.local]`                               |
+| `ingress.tls`                                                                      | Ingress TLS configuration (YAML)                                                                                                                             | `[]`                                                  |
+| `networkPolicy.enabled`                                                            | If true, create a NetworkPolicy to deny egress                                                                                                               | `false`                                               |
+| `networkPolicy.costAnalyzer.enabled`                                               | If true, create a newtork policy for cost-analzyer                                                                                                           | `false`                                               |
+| `networkPolicy.costAnalyzer.annotations`                                           | Annotations to be added to the network policy                                                                                                                | `{}`                                                  |
+| `networkPolicy.costAnalyzer.additionalLabels`                                      | Additional labels to be added to the network policy                                                                                                          | `{}`                                                  |
+| `networkPolicy.costAnalyzer.ingressRules`                                          | A list of network policy ingress rules                                                                                                                       | `null`                                                |
+| `networkPolicy.costAnalyzer.egressRules`                                           | A list of network policy egress rules                                                                                                                        | `null`                                                |
+| `networkCosts.enabled`                                                             | If true, collect network allocation metrics [More info](http://docs.kubecost.com/network-allocation)                                                         | `false`                                               |
+| `networkCosts.podMonitor.enabled`                                                  | If true, a [PodMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#podmonitor) for the network-cost daemonset is created | `false`                                               |
+| `serviceMonitor.enabled`                                                           | Set this to `true` to create ServiceMonitor for Prometheus operator                                                                                          | `false`                                               |
+| `serviceMonitor.additionalLabels`                                                  | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                                                        | `{}`                                                  |
+| `serviceMonitor.relabelings`                                                       | Sets Prometheus metric_relabel_configs on the scrape job                                                                                                     | `[]`                                                  |
+| `serviceMonitor.metricRelabelings`                                                 | Sets Prometheus relabel_configs on the scrape job                                                                                                            | `[]`                                                  |
+| `prometheusRule.enabled`                                                           | Set this to `true` to create PrometheusRule for Prometheus operator                                                                                          | `false`                                               |
+| `prometheusRule.additionalLabels`                                                  | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                                                        | `{}`                                                  |
+| `grafana.resources`                                                                | Grafana resource requests and limits.                                                                                                                        | `{}`                                                  |
+| `grafana.sidecar.datasources.defaultDatasourceEnabled`                             | Set this to `false` to disable creation of Prometheus datasource in Grafana                                                                                  | `true`                                                |
+| `serviceAccount.create`                                                            | Set this to `false` if you want to create the service account `kubecost-cost-analyzer` on your own                                                           | `true`                                                |
+| `tolerations`                                                                      | node taints to tolerate                                                                                                                                      | `[]`                                                  |
+| `affinity`                                                                         | pod affinity                                                                                                                                                 | `{}`                                                  |
+| `kubecostProductConfigs.productKey.mountPath`                                      | Use instead of `kubecostProductConfigs.productKey.secretname` to declare the path at which the product key file is mounted (eg. by a secrets provisioner)    | `N/A`                                                 |
+| `kubecostFrontend.api.fqdn`                                                        | Customize the upstream api FQDN                                                                                                                              | `computed in terms of the service name and namespace` |
+| `kubecostFrontend.model.fqdn`                                                      | Customize the upstream model FQDN                                                                                                                            | `computed in terms of the service name and namespace` |
+| `clusterController.fqdn`                                                           | Customize the upstream cluster controller FQDN                                                                                                               | `computed in terms of the service name and namespace` |
+| `global.grafana.fqdn`                                                              | Customize the upstream grafana FQDN                                                                                                                          | `computed in terms of the release name and namespace` |
 
 ## Testing
 To perform local testing do next:

--- a/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
@@ -18,6 +18,12 @@ spec:
       scrapeTimeout: 10s
       path: /metrics
       scheme: http
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
@@ -21,6 +21,12 @@ spec:
       scrapeTimeout: 10s
       path: /metrics
       scheme: http
+      {{- with .Values.kubecostMetrics.exporter.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kubecostMetrics.exporter.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
@@ -17,6 +17,12 @@ spec:
       scrapeTimeout: {{ .Values.serviceMonitor.networkCosts.scrapeTimeout }}
       path: /metrics
       scheme: http
+      {{- with .Values.serviceMonitor.networkCosts.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.networkCosts.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -361,10 +361,8 @@ kubecostMetrics:
     serviceMonitor: # the kubecost included prometheus uses scrapeConfigs and does not support service monitors. The following options assume an existing prometheus that supports serviceMonitors.
       enabled: false
       additionalLabels: {}
-      networkCosts:
-        enabled: false
-        scrapeTimeout: 10s
-        additionalLabels: {}
+      metricRelabelings: []
+      relabelings: []
     ## PriorityClassName
     ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
     priorityClassName: []
@@ -839,10 +837,14 @@ reporting:
 serviceMonitor: # the kubecost included prometheus uses scrapeConfigs and does not support service monitors. The following options assume an existing prometheus that supports serviceMonitors.
   enabled: false
   additionalLabels: {}
+  metricRelabelings: []
+  relabelings: []
   networkCosts:
     enabled: false
     scrapeTimeout: 10s
     additionalLabels: {}
+    metricRelabelings: []
+    relabelings: []
 
 prometheusRule:
   enabled: false


### PR DESCRIPTION
## What does this PR change?

Exposes the following ServiceMonitor endpoint options, allowing operations on exported metric labels and series:
* [relabelings](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
* [metricRelabelings](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs)


## Does this PR rely on any other PRs?

* No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

* Add support for relabelings and metricRelabelings to ServiceMonitors

## Links to Issues or ZD tickets this PR addresses or fixes

No

## How was this PR tested?

Deployed to live test environment clusters using this release rather than the latest upstream release. 

Seeing no changes with the default values, and a valid deployment with the appropriate values when setting up relabelings or metricRelabelings

## Have you made an update to documentation?

README.md updated with the relevant values
