### PR TITLE
Move multi cloud secret mount path

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -509,7 +509,7 @@ spec:
             {{- end }}
             {{- if .Values.kubecostProductConfigs.cloudIntegrationSecret }}
             - name: cloud-integration
-              mountPath: /var/cloud-integration
+              mountPath: /var/configs/cloud-integration
             {{- end }}
             {{- if or .Values.kubecostProductConfigs.serviceKeySecretName .Values.kubecostProductConfigs.createServiceKeySecret }}
             - name: service-key-secret

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -192,7 +192,7 @@ spec:
             {{- end }}
             {{- if .Values.kubecostProductConfigs.cloudIntegrationSecret }}
             - name: cloud-integration
-              mountPath: /var/cloud-integration
+              mountPath: /var/configs/cloud-integration
             {{- end }}
             {{- if or .Values.kubecostProductConfigs.serviceKeySecretName .Values.kubecostProductConfigs.createServiceKeySecret }}
             - name: service-key-secret


### PR DESCRIPTION
## What does this PR change?
This PR changes the location where the multi-cloud configuration is mounted


## Does this PR rely on any other PRs?
- https://github.com/kubecost/kubecost-cost-model/pull/1450



## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Tested on multi-cloud deployment by checking file path and ensuring functionality with new image
```
/var/configs/cloud-integration $ ls
cloud-integration.json
```


## Have you made an update to documentation?

