### PR TITLE
feat: Support priority class in various cost-analyzer components and thanos

### DIFF
--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
 {{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
 {{- if .Values.dashboards }}
       initContainers:
         - name: download-dashboards

--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -274,3 +274,7 @@ sidecar:
     enabled: false
     # label that the configmaps with datasources are marked with
     label: grafana_datasource
+
+## PriorityClassName
+## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""

--- a/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/bucket-deployment.yaml
@@ -41,6 +41,9 @@ spec:
       imagePullSecrets:
        {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+    {{- end }}
       containers:
       - name: thanos-bucket
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/compact-deployment.yaml
@@ -45,6 +45,9 @@ spec:
       imagePullSecrets:
        {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+    {{- end }}
       containers:
       - name: thanos-compact
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/charts/thanos/templates/query-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-deployment.yaml
@@ -47,6 +47,9 @@ spec:
       imagePullSecrets:
        {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+    {{- end }}
       containers:
       - name: thanos-query
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/query-frontend-deployment.yaml
@@ -47,6 +47,9 @@ spec:
       imagePullSecrets:
        {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+    {{- end }}
       containers:
       - name: thanos-query-frontend
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/charts/thanos/templates/store-deployment.yaml
+++ b/cost-analyzer/charts/thanos/templates/store-deployment.yaml
@@ -45,6 +45,9 @@ spec:
       imagePullSecrets:
        {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+    {{- end }}
       containers:
       - name: thanos-store
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cost-analyzer/charts/thanos/values.yaml
+++ b/cost-analyzer/charts/thanos/values.yaml
@@ -3,6 +3,10 @@ image:
   tag: v0.29.0
   pullPolicy: IfNotPresent
 
+## PriorityClassName
+## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""
+
 store:
   enabled: true
   # Maximum size of items held in the index cache.

--- a/cost-analyzer/templates/awsstore-deployment-template.yaml
+++ b/cost-analyzer/templates/awsstore-deployment-template.yaml
@@ -20,12 +20,15 @@ spec:
       labels:
         app: awsstore
     spec:
-        serviceAccountName: awsstore-serviceaccount
-        containers:
-            - image: {{ .Values.awsstore.imageNameAndVersion }}
-              name: awsstore
-              # Just sleep forever
-              command: [ "sleep" ]
-              args: [ "infinity" ]
+      serviceAccountName: awsstore-serviceaccount
+      {{- if .Values.awsstore.priorityClassName }}
+      priorityClassName: "{{ .Values.awsstore.priorityClassName }}"
+      {{- end }}
+      containers:
+        - image: {{ .Values.awsstore.imageNameAndVersion }}
+          name: awsstore
+          # Just sleep forever
+          command: [ "sleep" ]
+          args: [ "infinity" ]
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-prometheus-postgres-adapter-deployment.yaml
+++ b/cost-analyzer/templates/cost-analyzer-prometheus-postgres-adapter-deployment.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         app: adapter
     spec:
+      {{- if .Values.remoteWrite.postgres.priorityClassName }}
+      priorityClassName: "{{ .Values.remoteWrite.postgres.priorityClassName }}"
+      {{- end }}
       initContainers:
         - name: kubecost-sql-init
           image: {{ .Values.remoteWrite.postgres.initImage }}:prod-{{ $.Chart.AppVersion }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -184,6 +184,9 @@ spec:
       labels:
         app: {{ template "kubecost.clusterControllerName" . }}
     spec:
+      {{- if .Values.clusterController.priorityClassName }}
+      priorityClassName: "{{ .Values.clusterController.priorityClassName }}"
+      {{- end }}
       containers:
       - name: {{ template "kubecost.clusterControllerName" . }}
         image: {{ .Values.clusterController.image }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -450,6 +450,9 @@ remoteWrite:
     initImagePullPolicy: Always
     installLocal: true
     remotePostgresAddress: "" # ignored if installing locally
+    ## PriorityClassName
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+    priorityClassName: ""
     persistentVolume:
       size: 200Gi
     auth:
@@ -698,6 +701,9 @@ clusterController:
   enabled: false
   image: gcr.io/kubecost1/cluster-controller:v0.3.0
   imagePullPolicy: Always
+  ## PriorityClassName
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  priorityClassName: ""
   kubescaler:
     # If true, will cause all (supported) workloads to be have their requests
     # automatically right-sized on a regular basis.
@@ -739,7 +745,6 @@ initChownData:
     #  cpu: "50m"
     #  memory: "20Mi"
 
-
 grafana:
   # namespace_datasources: kubecost # override the default namespace here
   # namespace_dashboards: kubecost # override the default namespace here
@@ -779,6 +784,9 @@ serviceAccount:
 awsstore:
   useAwsStore: false
   createServiceAccount: false
+  ## PriorityClassName
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  priorityClassName: ""
 
 federatedETL:
   # federatedCluster indicates whether this cluster should push data to the Federated store

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -281,7 +281,7 @@ kubecostMetrics:
         additionalLabels: {}
     ## PriorityClassName
     ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-    priorityClassName: []
+    priorityClassName: ""
     additionalLabels: {}
     nodeSelector: {}
     extraArgs: []
@@ -671,7 +671,7 @@ networkCosts:
 
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-  priorityClassName: []
+  priorityClassName: ""
   ## PodMonitor
   ## Allows scraping of network metrics from a dedicated prometheus operator setup
   podMonitor:


### PR DESCRIPTION
## What does this PR change?
- Fix `priorityClassName` default values to empty strings `""` (instead of `[]`)
- Add `priorityClassName` support to cost-analyzer `awsstore`, `remoteWrite.postgres` and `clusterController` deployments
- Add `priorityClassName` support to thanos deployments
- Add `priorityClassName` support to grafana deployment


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds the ability to set priority class on awsstore, postgres, cluster controller and thanos deployments.


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?

