### PR TITLE
Disable `podSecurityPolicy`

### DIFF
--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -1,6 +1,6 @@
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
   pspUseAppArmor: true
 serviceAccount:
   create: true

--- a/cost-analyzer/values-cloud-agent.yaml
+++ b/cost-analyzer/values-cloud-agent.yaml
@@ -27,8 +27,14 @@ kubecostMetrics:
     exportClusterInfo: false
     exportClusterCache: false
 
+# Disable cost-analyzer PSP
+podSecurityPolicy: 
+  enabled: false
+
 # Disable KSM and NodeExporter (?)
 prometheus:
+  podSecurityPolicy: 
+    enabled: false
   nodeExporter:
     enabled: false
   kube-state-metrics:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -523,7 +523,7 @@ networkPolicy:
     #     - namespaceSelector: {}
 
 podSecurityPolicy:
-  enabled: true
+  enabled: false
 
 ## @param extraVolumes A list of volumes to be added to the pod
 ##
@@ -564,6 +564,8 @@ remoteWrite:
       password: admin # change me
 
 prometheus:
+  podSecurityPolicy:
+    enabled: false
   extraScrapeConfigs: |
     - job_name: kubecost
       honor_labels: true
@@ -863,7 +865,7 @@ grafana:
   # namespace_dashboards: kubecost # override the default namespace here
   rbac:
     # Manage the Grafana Pod Security Policy
-    pspEnabled: true
+    pspEnabled: false
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
## What does this PR change?

This PR disables all `podSecurityPolicy` to prevent Helm issues that occur when Kubernetes is upgraded to `v1.25`.

Upgrading Kubernetes from `v1.24` to `v1.25` with PSP enabled:
```
% helm upgrade -i kubecost kubecost/cost-analyzer --create-namespace --namespace kubecost

% kubectl get psp -n kubecost                                                         
Warning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
NAME                         PRIV    CAPS   SELINUX    RUNASUSER   FSGROUP    SUPGROUP   READONLYROOTFS   VOLUMES
eks.privileged               true    *      RunAsAny   RunAsAny    RunAsAny   RunAsAny   false            *
kubecost-cost-analyzer-psp   false          RunAsAny   RunAsAny    RunAsAny   RunAsAny   false            *
kubecost-grafana             false          RunAsAny   RunAsAny    RunAsAny   RunAsAny   false            configMap,emptyDir,projected,secret,downwardAPI,persistentVolumeClaim

% eksctl upgrade cluster --name=<REDACTED> --region us-east-1 --approve
2023-05-05 19:06:12 [ℹ]  will upgrade cluster "<REDACTED>" control plane from current version "1.24" to "1.25"

...

% kubectl get nodes
NAME                            STATUS   ROLES    AGE     VERSION
ip-192-168-49-87.ec2.internal   Ready    <none>   8m47s   v1.25.7-eks-a59e1f0

% kubectl get psp -n kubecost
Error from server (NotFound): Unable to list "policy/v1beta1, Resource=podsecuritypolicies": the server could not find the requested resource

% helm upgrade -i kubecost kubecost/cost-analyzer --create-namespace --namespace kubecost \
--set kubecostProductConfigs.productKey.key=<REDACTED> \
--set kubecostProductConfigs.productKey.enabled=true
Error: UPGRADE FAILED: unable to build kubernetes objects from current release manifest: [resource mapping not found for name: "kubecost-grafana" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "kubecost-cost-analyzer-psp" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first]
```

Upgrading Kubernetes from `v1.24` to `v1.25` with PSP disabled:
```
% helm upgrade -i kubecost kubecost/cost-analyzer --create-namespace --namespace kubecost \
    --set podSecurityPolicy.enabled=false \
    --set networkCosts.podSecurityPolicy.enabled=false \
    --set prometheus.podSecurityPolicy.enabled=false \
    --set grafana.rbac.pspEnabled=false

% kubectl get psp -n kubecost
Warning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
NAME             PRIV   CAPS   SELINUX    RUNASUSER   FSGROUP    SUPGROUP   READONLYROOTFS   VOLUMES
eks.privileged   true   *      RunAsAny   RunAsAny    RunAsAny   RunAsAny   false            *

% eksctl upgrade cluster --name=<REDACTED> --region us-west-1 --approve
2023-05-05 19:07:30 [ℹ]  will upgrade cluster "<REDACTED>" control plane from current version "1.24" to "1.25"

...

% kubectl get nodes                                                        
NAME                                           STATUS                     ROLES    AGE     VERSION
ip-192-168-45-29.us-west-1.compute.internal    Ready                      <none>   5m23s   v1.25.7-eks-a59e1f0

% kubectl get psp -n kubecost                                             
Error from server (NotFound): Unable to list "policy/v1beta1, Resource=podsecuritypolicies": the server could not find the requested resource

% helm upgrade -i kubecost kubecost/cost-analyzer --create-namespace --namespace kubecost \
--set kubecostProductConfigs.productKey.key=<REDACTED> \
--set kubecostProductConfigs.productKey.enabled=true
Release "kubecost" has been upgraded. Happy Helming!
NAME: kubecost
LAST DEPLOYED: Fri May  5 20:13:17 2023
NAMESPACE: kubecost
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed.

WARNING: ON EKS v1.23+ INSTALLATION OF EBS-CSI DRIVER IS REQUIRED TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.kubecost.com/install-and-configure/install/provider-installations/aws-eks-cost-monitoring#prerequisites

Please allow 5-10 minutes for Kubecost to gather metrics.

If you have configured cloud-integrations, it can take up to 48 hours for cost reconciliation to occur.

When using Durable storage (Enterprise Edition), please allow up to 4 hours for data to be collected and the UI to be healthy.

When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090

Next, navigate to http://localhost:9090/ in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install


% kubectl get pods -n kubecost                                                             
NAME                                          READY   STATUS    RESTARTS   AGE
kubecost-cost-analyzer-596df6c9f7-glqpn       2/2     Running   0          64s
kubecost-grafana-867bbf59c7-2r7tk             2/2     Running   0          3m58s
kubecost-kube-state-metrics-d6d9b7594-r75hg   1/1     Running   0          3m58s
kubecost-prometheus-node-exporter-wffbm       1/1     Running   0          7m37s
kubecost-prometheus-server-77bd8b8d6f-t5dzf   2/2     Running   0          3m58s
```


## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Disables all `podSecurityPolicy` as default to prevent Helm issues that occur if Kubernetes is upgraded to `v1.25` without first manually disabling them.

## Links to Issues or ZD tickets this PR addresses or fixes

- [https://github.com/kubecost/cost-analyzer-helm-chart/issues/2225](https://github.com/kubecost/cost-analyzer-helm-chart/issues/2225#issuecomment-1536746041)
- https://kubecost.zendesk.com/agent/tickets/4068


## How was this PR tested?
Tested install, confirmed PSP are disabled.

```
$ helm upgrade -i kubecost cost-analyzer-helm-chart/cost-analyzer --create-namespace --namespace kubecost 
Release "kubecost" does not exist. Installing it now.
NAME: kubecost
LAST DEPLOYED: Fri May  5 21:05:13 2023
NAMESPACE: kubecost
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
--------------------------------------------------Kubecost has been successfully installed.

WARNING: ON EKS v1.23+ INSTALLATION OF EBS-CSI DRIVER IS REQUIRED TO MANAGE PERSISTENT VOLUMES. LEARN MORE HERE: https://docs.kubecost.com/install-and-configure/install/provider-installations/aws-eks-cost-monitoring#prerequisites

Please allow 5-10 minutes for Kubecost to gather metrics.

If you have configured cloud-integrations, it can take up to 48 hours for cost reconciliation to occur.

When using Durable storage (Enterprise Edition), please allow up to 4 hours for data to be collected and the UI to be healthy.

When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090

Next, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install


$ kubectl get psp -n kubecost                                                                            
Warning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
NAME             PRIV   CAPS   SELINUX    RUNASUSER   FSGROUP    SUPGROUP   READONLYROOTFS   VOLUMES
eks.privileged   true   *      RunAsAny   RunAsAny    RunAsAny   RunAsAny   false            *
```


## Have you made an update to documentation?
No
