### PR TITLE
Disable CA and Prom PSPs

### DIFF
--- a/cost-analyzer/values-cloud-agent.yaml
+++ b/cost-analyzer/values-cloud-agent.yaml
@@ -27,8 +27,14 @@ kubecostMetrics:
     exportClusterInfo: false
     exportClusterCache: false
 
-# Disable KSM and NodeExporter (?)
+# Disable cost-analyzer PSP
+podSecurityPolicy: 
+  enabled: false
+
+# Disable PSP, KSM and NodeExporter (?)
 prometheus:
+  podSecurityPolicy: 
+    enabled: false
   nodeExporter:
     enabled: false
   kube-state-metrics:


### PR DESCRIPTION
## What does this PR change?
Disables the Cost Analyzer and Prometheus Server PSPs as they are deprecated in v1.21+ and unavailable in v1.25+


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
PSPs will be disabled by default for Cloud Agent installs.


## Links to Issues or ZD tickets this PR addresses or fixes
n/a


## How was this PR tested?
Against demo clusters hooked up to the Demo team in KC cloud.

## Have you made an update to documentation?
No
