### PR TITLE
Add cluster-controller-turndown-config ConfigMap.

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -245,9 +245,6 @@ spec:
           # partially or fully initialize based on the presence of these keys
           # and their validity.
           optional: true
-      - name: cluster-controller-turndown-conf
-        configMap:
-          name: cluster-controller-turndown-conf
 ---
 apiVersion: v1
 kind: Service

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -168,7 +168,7 @@ subjects:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-controller-turndown-config
+  name: cluster-controller-nsturndown-config
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -165,6 +165,14 @@ subjects:
     name: {{ template "kubecost.clusterControllerName" . }}
     namespace: {{ .Release.Namespace }}
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-controller-turndown-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -237,6 +245,9 @@ spec:
           # partially or fully initialize based on the presence of these keys
           # and their validity.
           optional: true
+      - name: cluster-controller-turndown-conf
+        configMap:
+          name: cluster-controller-turndown-conf
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Release notes headline
* Adds the ConfigMap for nsturndown, to allow for the frontend to start work on their end.

## Does this PR relate to any other PRs?
* https://github.com/kubecost/cluster-controller/pull/40

## Does this PR address any GitHub or Zendesk issues?
* https://kubecost.atlassian.net/jira/software/c/projects/CORE/boards/1?modal=detail&selectedIssue=CORE-231

## How was this PR tested?
* Tested in new turndown test cluster, verified ConfigMap is created properly and handler returns 200.
