### PR TITLE
Continuous Cluster Sizing

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -65,6 +65,16 @@ rules:
       - ''
     resources:
       - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
       - namespaces
       - persistentvolumeclaims
       - persistentvolumes

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -218,6 +218,8 @@ spec:
           value: {{ .Values.clusterController.logLevel | default "info" }}
         - name: CC_KUBESCALER_COST_MODEL_PATH
           value: http://{{ $serviceName }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort | default 9090 }}/model
+        - name: CC_CCL_COST_MODEL_PATH
+          value: http://{{ $serviceName }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort | default 9090 }}/model
         {{- if .Values.clusterController.kubescaler }}
         - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
           value: {{ .Values.clusterController.kubescaler.defaultResizeAll | default "false" | quote }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -165,6 +165,14 @@ subjects:
     name: {{ template "kubecost.clusterControllerName" . }}
     namespace: {{ .Release.Namespace }}
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-controller-continuous-cluster-sizing
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
## What does this PR change?
Adds `cluster-controller-continuous-request-sizing` to Helm template of Cluster Controller. Adds the `CC_CCL_COST_MODEL_PATH` to the Cluster Controller Deployment.


## Does this PR rely on any other PRs?

- Required for https://github.com/kubecost/cluster-controller/pull/43


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
See https://github.com/kubecost/cluster-controller/pull/43 (private)


## Links to Issues or ZD tickets this PR addresses or fixes

- Part of https://kubecost.atlassian.net/browse/CORE-222



## How was this PR tested?
Deployed in cluster, observed CC#43 code working as expected.


## Have you made an update to documentation?
Not yet, but will be covered separately in https://kubecost.atlassian.net/browse/CORE-247
