### PR TITLE
fix: secret objects from csi secret provider

### DIFF
--- a/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
@@ -15,7 +15,11 @@ spec:
   provider: {{ required "Specify a valid provider." .Values.agentCsi.secretProvider.provider }}
   {{- if .Values.agentCsi.secretProvider.parameters }}
   parameters:
-    {{-  .Values.agentCsi.secretProvider.parameters | toYaml | nindent 4 }}
+    {{- .Values.agentCsi.secretProvider.parameters | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if .Values.agentCsi.secretProvider.secretObjects }}
+  secretObjects:
+  {{- .Values.agentCsi.secretProvider.secretObjects | toYaml | nindent 2 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -15,8 +15,6 @@ global:
   grafana:
     enabled: false
     proxy: false
-agentCsi:
-  enabled: false
 # Agent enables specific features designed to enhance the metrics exporter deployment
 # with enhancements designed for external hosting.
 agent: true
@@ -27,6 +25,7 @@ agentCsi:
     name: kubecost-agent-object-store-secretprovider
     provider:
     parameters: {}
+    secretObjects: {}
 
 
 # No Grafana configuration is required.


### PR DESCRIPTION
## What does this PR change?
Previously when using the csi secret provider, the agent key secret has only been mounted directly to the agent pod. The prometheus pods, however, need the agent key to be stored in an actual k8s secret.
This change offers the possibility to specify corresponding information in the secret provider class.

## Does this PR rely on any other PRs?
No.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users using the csi secret provider to retrieve the agent key yaml file from a secret store will have to specify secret object information in the secret provider class.

## How was this PR tested?
Test deployment in local cluster.

## Have you made an update to documentation?
No.
