### PR TITLE
explicitly cast query service replicas to int

### DIFF
--- a/cost-analyzer/templates/query-service-cluster-role-binding-template.yaml
+++ b/cost-analyzer/templates/query-service-cluster-role-binding-template.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
-{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+{{- if gt (.Values.kubecostDeployment.queryServiceReplicas | toString | atoi) 0 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/cost-analyzer/templates/query-service-cluster-role-template.yaml
+++ b/cost-analyzer/templates/query-service-cluster-role-template.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
-{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+{{- if gt (.Values.kubecostDeployment.queryServiceReplicas | toString | atoi) 0 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
-{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+{{- if gt (.Values.kubecostDeployment.queryServiceReplicas | toString | atoi) 0 }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cost-analyzer/templates/query-service-service-account-template.yaml
+++ b/cost-analyzer/templates/query-service-service-account-template.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
-{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+{{- if gt (.Values.kubecostDeployment.queryServiceReplicas | toString | atoi) 0 }}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/cost-analyzer/templates/query-service-service-template.yaml
+++ b/cost-analyzer/templates/query-service-service-template.yaml
@@ -1,5 +1,5 @@
 {{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) }}
-{{- if gt .Values.kubecostDeployment.queryServiceReplicas 0 }}
+{{- if gt (.Values.kubecostDeployment.queryServiceReplicas | toString | atoi) 0 }}
 kind: Service
 apiVersion: v1
 metadata:


### PR DESCRIPTION
## What does this PR change?
Updates some calls for `.Values.kubecostDeployment.queryServiceReplicas` to be integers to resolve issues with specific helm versions. Similar to the issue here: https://github.com/helm/helm/issues/6708

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can implement Query Service regardless of Helm version.

## Links to Issues or ZD tickets this PR addresses or fixes
N/A

## How was this PR tested?
After updating the failing template files, I ran the following to verify I was able to deploy the correct number of replicas successfully:

1. `helm upgrade kubecost $LOCAL_KCHC_REPO -n kubecost --create-namespace -i --set kubecostDeployment.queryServiceReplicas=1`
2. `helm upgrade kubecost $LOCAL_KCHC_REPO -n kubecost --create-namespace -i --set kubecostDeployment.queryServiceReplicas=2`
3. `helm upgrade kubecost $LOCAL_KCHC_REPO -n kubecost --create-namespace -i --set kubecostDeployment.queryServiceReplicas=0`

## Have you made an update to documentation?
N/a
