### PR TITLE
Fix values.yaml for OIDC RBAC

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -418,16 +418,6 @@ kubecostModel:
   # For deploying kubecost in a cluster that does not self-monitor
   etlReadOnlyMode: false
 
-  ## Feature to view your out-of-cluster costs and their k8s utilization
-  ## Ref: https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer
-  cloudCost:
-    enabled: false
-    labelList:
-      isIncludeList: false
-      # format labels as comma separated string (ex. "label1,label2,label3")
-      labels: ""
-    topNItems: 1000
-
   allocation:
     # Enables or disables adding node labels to allocation data (i.e. workloads).
     # Defaults to "true" and starts with a sensible includeList for basics like

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -418,6 +418,16 @@ kubecostModel:
   # For deploying kubecost in a cluster that does not self-monitor
   etlReadOnlyMode: false
 
+  ## Feature to view your out-of-cluster costs and their k8s utilization
+  ## Ref: https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer
+  cloudCost:
+    enabled: false
+    labelList:
+      isIncludeList: false
+      # format labels as comma separated string (ex. "label1,label2,label3")
+      labels: ""
+    topNItems: 1000
+
   allocation:
     # Enables or disables adding node labels to allocation data (i.e. workloads).
     # Defaults to "true" and starts with a sensible includeList for basics like

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -263,24 +263,24 @@ oidc:
   discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
 #  hostedDomain: "example.com" # optional, blocks access to the auth domain specified in the hd claim of the provider ID token
   rbac:
-      enabled: false
-      groups:
-        - name: admin
-          enabled: false # if admin is disabled, all SAML users will be able to make configuration changes to the kubecost frontend
-          assertionName: "preferred_username" # field used for role matching in the OIDC access token
-          assertionValues:
-            - "admin"
-            - "superusers"
-        - name: readonly
-          enabled: false # if readonly is disabled, all users authorized on SAML will default to readonly
-          assertionName:  "preferred_username"
-          assertionValues:
-            - "readonly"
-        - name: editor
-          enabled: false # if editor is enabled, editors will be allowed to edit reports/alerts scoped to them, and act as readers otherwise. Users will never default to editor.
-          assertionName: "preferred_username"
-          assertionValues:
-            - "editor"
+    enabled: false
+    groups:
+      - name: admin
+        enabled: false # if admin is disabled, all authenticated users will be able to make configuration changes to the kubecost frontend
+        claimName: "roles" # Kubecost matches this string against the JWT's payload key containing RBAC info (this value is unique across identity providers)
+        claimValues: # Kubecost matches these strings with the roles created in your identity provider
+          - "admin"
+          - "superusers"
+      - name: readonly
+        enabled: false # if readonly is disabled, all authenticated users will default to readonly
+        claimName:  "roles"
+        claimValues:
+          - "readonly"
+      - name: editor
+        enabled: false # if editor is enabled, editors will be allowed to edit reports/alerts scoped to them, and act as readers otherwise. Users will never default to editor.
+        claimName: "roles"
+        claimValues:
+          - "editor"
 
 # Adds an httpProxy as an environment variable. systemProxy.enabled must be `true`to have any effect.
 # Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml


### PR DESCRIPTION
## What does this PR change?

Currently, the default `values.yaml` is presenting `assertionName` and `assertionValues` under the OIDC configuration section. I believe this is incorrect, and should be `claimName` and `claimValues` according to [this template](https://github.com/kubecost/cost-analyzer-helm-chart/blob/v1.103/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml#L29-L35).

This PR also modifies the comments for increased clarity.

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- More clarity when configuring OIDC RBAC

## Links to Issues or ZD tickets this PR addresses or fixes

- n/a

## How was this PR tested?

With the following `values.yaml`:

```yaml
oidc:
  enabled: true
  rbac:
    enabled: true
    groups:
      - name: admin
        enabled: true
        claimName: "roles"
        claimValues:
          - "admins"
          - "superusers"
      - name: readonly
        enabled: true
        claimName: "roles"
        claimValues:
          - "readonly"
      - name: editor
        enabled: false
```

I ran `helm template ./cost-analyzer -f values.yaml`, and saw the following:

```
# Source: cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-cost-analyzer-oidc
  namespace: kubecost
  labels:

    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.102.1
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
data:
    oidc.json: |-
      {
        "enabled" : true,
        "clientID" : "",
        "secretName" : "kubecost-oidc-secret",
        "authURL" : "https://my.auth.server/authorize",
        "loginRedirectURL" : "http://my.kubecost.url/model/oidc/authorize",
        "discoveryURL" : "https://my.auth.server/.well-known/openid-configuration",
        "hostedDomain" : "",
        "rbac" : {
          "enabled" : true,
          "groups" : [
          {
            "roleName": "admin",
            "enabled": true,
            "claimName": "roles",
            "claimValues": [
              "admins",
              "superusers"
            ]
          },
          {
            "roleName": "readonly",
            "enabled": true,
            "claimName": "roles",
            "claimValues": [
              "readonly"
            ]
          },
          {
            "roleName": "editor",
            "enabled": false,
            "claimName": "",
            "claimValues": [
            ]
          }
          ]
        }
      }
```

## Have you made an update to documentation?

Not yet
