### PR TITLE
Enable Cloud Cost by default

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -857,7 +857,7 @@ spec:
             {{- end }}
             {{- with .Values.kubecostModel.cloudCost }}
             - name: CLOUD_COST_ENABLED
-              value: {{ (quote .enabled) | default (quote false) }}
+              value: {{ (quote .enabled) | default (quote true) }}
             {{- with .labelList }}
             - name: CLOUD_COST_IS_INCLUDE_LIST
               value: {{ (quote .IsIncludeList) | default (quote false) }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -419,7 +419,7 @@ kubecostModel:
   ## Feature to view your out-of-cluster costs and their k8s utilization
   ## Ref: https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer
   cloudCost:
-    enabled: false
+    enabled: true
     labelList:
       IsIncludeList: false
       # format labels as comma separated string (ex. "label1,label2,label3")


### PR DESCRIPTION
## What does this PR change?
This PR enables CloudCost by default


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users who have not manually disabled Cloud Cost will have it enabled


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Tested by running Helm Chart on a cluster that has never had CloudCost enabled and without adding a setting for it

![Screenshot 2023-05-22 at 3 21 13 PM](https://github.com/kubecost/cost-analyzer-helm-chart/assets/12225425/c97ee3ca-271d-482f-86ae-20cd6fd2a230)

## Have you made an update to documentation?

