### PR TITLE
Update cluster-controller ClusterRole RBAC permissions.

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -71,6 +71,7 @@ rules:
       - watch
       - update
       - patch
+      - delete
   - apiGroups:
       - ''
     resources:
@@ -169,6 +170,63 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - list
+      - delete
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - clusterroles
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - clusterrolebindings
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - roles
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - rolebindings
+    verbs:
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -170,63 +170,17 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - ''
-    resources:
-      - namespaces
+  # Used for namespace turndown 
+  # When cleaning a namespace, we need the ability to remove
+  # arbitrary resources (since we helm uninstall all releases in that NS first)
+  {{- if .Values.clusterController.namespaceTurndown.rbac.enabled }}
+  - apiGroups: ["*"]
+    resources: ["*"]
     verbs:
       - list
+      - get
       - delete
-  - apiGroups:
-      - ''
-    resources:
-      - secrets
-    verbs:
-      - list
-      - delete
-      - update
-  - apiGroups:
-      - ''
-    resources:
-      - serviceaccounts
-    verbs:
-      - delete
-  - apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-    verbs:
-      - delete
-  - apiGroups:
-      - ''
-    resources:
-      - clusterroles
-    verbs:
-      - delete
-  - apiGroups:
-      - ''
-    resources:
-      - clusterrolebindings
-    verbs:
-      - delete
-  - apiGroups:
-      - ''
-    resources:
-      - roles
-    verbs:
-      - delete
-  - apiGroups:
-      - ''
-    resources:
-      - rolebindings
-    verbs:
-      - delete
-  - apiGroups:
-      - ''
-    resources:
-      - services
-    verbs:
-      - delete
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -837,6 +837,9 @@ clusterController:
     # automatically right-sized on a regular basis.
     defaultResizeAll: false
 #  fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
+  namespaceTurndown:
+    rbac: 
+      enabled: true
 
 reporting:
   # Kubecost bug report feature: Logs access/collection limited to .Release.Namespace


### PR DESCRIPTION
## What does this PR change?

- Updates cluster-controlloer ClusterRole RBAC permissions for NS Turndown.

## Does this PR rely on any other PRs?

- [Yes](https://github.com/kubecost/cluster-controller/pull/48).


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

TODO

## Links to Issues or ZD tickets this PR addresses or fixes

- [Yup.](https://kubecost.atlassian.net/browse/CORE-233)


## How was this PR tested?


## Have you made an update to documentation?

