### PR TITLE
Add an option to add containersecuritycontext and healthcheck probes …

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -80,6 +80,9 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if .Values.networkCosts.healthCheckProbes }}
+        {{- toYaml .Values.networkCosts.healthCheckProbes | nindent 8 }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.networkCosts.hostProc }}
         - mountPath: {{ .Values.networkCosts.hostProc.mountPath }}
@@ -96,6 +99,9 @@ spec:
         {{- end }}
         securityContext:
           privileged: true
+        {{- if .Values.networkCosts.additionalSecurityContext }}
+        {{- toYaml .Values.networkCosts.additionalSecurityContext | nindent 10 }}
+        {{- end }}
         ports:
         - name: http-server
           containerPort: {{ .Values.networkCosts.port | default 3001 }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -810,6 +810,21 @@ networkCosts:
   additionalLabels: {}
   nodeSelector: {}
   annotations: {}
+  healthCheckProbes: {}
+    # readinessProbe:
+    #   tcpSocket:
+    #     port: 3001
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 10
+    #   failureThreshold: 5
+    # livenessProbe:
+    #   tcpSocket:
+    #     port: 3001
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 10
+    #   failureThreshold: 5
+  additionalSecurityContext: {}
+    # readOnlyRootFilesystem: true
 
 # Kubecost Deployment Configuration
 # Used for HA mode in Business & Enterprise tier


### PR DESCRIPTION
…for network-cost daemonsets

## What does this PR change?

This PR will give the option to configure securitycontext, readiness and liveness probes. Now this is blocking our pipeline and release getting failed since the network-cost daemonset pods doesnt have the options to configure those specs.
Changes wont affect anything and users can enable the options if they want.



## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Ensure k8s best practices for network-cost daemonset pods.

## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?

Tested with local k8s cluster


## Have you made an update to documentation?

N/A

