### PR TITLE
federator pod template

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -252,13 +252,6 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- if .Values.federatedETL.federator }}
-        {{- if .Values.federatedETL.federator.enabled }}
-        - name: federator-config
-          configMap:
-            name: {{ template "cost-analyzer.fullname" . }}-federator
-        {{- end }}
-        {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
         {{- toYaml .Values.extraVolumes | nindent 8 }}
@@ -484,12 +477,6 @@ spec:
             - name: {{ .Values.kubecostAdmissionController.secretName }}
               mountPath: /certs
             {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.federatedETL }}
-            {{- if .Values.federatedETL.federator.enabled }}
-            - name: federator-config
-              mountPath: /var/configs/federator
             {{- end }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs }}
@@ -795,18 +782,6 @@ spec:
             {{- end}}
             {{- if .Values.federatedETL.redirectS3Backup }}
             - name: FEDERATED_REDIRECT_BACKUP
-              value: "true"
-            {{- end}}
-            {{- if .Values.federatedETL.useExistingS3Config }}
-            - name: FEDERATED_USE_EXISTING_CONFIG
-              value: "true"
-            {{- end}}
-            {{- if .Values.federatedETL.federator.enabled }}
-            - name: FEDERATED_FEDERATOR_ENABLED
-              value: "true"
-            {{- end}}
-            {{- if .Values.federatedETL.federator.useMultiClusterDB }}
-            - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             {{- end}}
             - name: ETL_STORE_READ_ONLY

--- a/cost-analyzer/templates/federator-pod-template.yaml
+++ b/cost-analyzer/templates/federator-pod-template.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.federatedETL.federator }}
+{{- if .Values.federatedETL.federator.enabled }}
+apiVersion: v1
+kind: Pod
+metadata: 
+  name: {{ template "cost-analyzer.fullname" . }}-federator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: federator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: federator
+spec: 
+  restartPolicy: Always
+  volumes: 
+    - name: federator-config
+      configMap:
+        name: {{ template "cost-analyzer.fullname" . }}-federator
+    {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+    - name: federated-storage-config
+      secret:
+        defaultMode: 420
+        secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
+    {{- end }}
+  containers:
+    - name: federator
+      {{- if .Values.kubecostModel }}
+      {{- if .Values.kubecostModel.fullImageName }}
+      image: {{ .Values.kubecostModel.fullImageName }}
+      {{- else if .Values.imageVersion }}
+      image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
+      {{- else }}
+      image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+      {{ end }}
+      {{- else }}
+      image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+      {{ end }}
+      imagePullPolicy: Always
+      args: ["federator"]
+      ports:
+        - name: tcp-model
+          containerPort: 9001
+          protocol: TCP
+      volumeMounts:
+        - name: federator-config
+          mountPath: /var/configs/federator
+        - name: federated-storage-config
+          mountPath: /var/configs/etl/federated
+          readOnly: true
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: 9001
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        failureThreshold: 200
+      env:
+        - name: CONFIG_PATH
+          value: /var/configs/
+        - name: DB_PATH
+          value: /var/db/
+        {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+        - name: FEDERATED_STORE_CONFIG
+          value: "/var/configs/etl/federated/federated-store.yaml"
+        {{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## What does this PR change?
Removed federator from cost-model, now runs in own pod


## Does this PR rely on any other PRs?
- https://github.com/kubecost/kubecost-cost-model/pull/1554


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A


## Links to Issues or ZD tickets this PR addresses or fixes
- https://kubecost.atlassian.net/browse/CORE-313


## How was this PR tested?
* Updated helm chart
* Observed typical federator logs in new federator pod
* Did not observe typical federator logs in cost-analyzer pod

## Have you made an update to documentation?

