### PR TITLE
Add capability to use AzureAD for OIDC RBAC

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -12,6 +12,7 @@ data:
     oidc.json: |-
       {
         "enabled" : {{ .Values.oidc.enabled }},
+        "idToken" : {{ .Values.oidc.idToken | default "false" }},
         "clientID" : "{{ .Values.oidc.clientID }}",
         "secretName" : "{{ .Values.oidc.secretName }}",
         "authURL" : "{{ .Values.oidc.authURL }}",

--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -12,7 +12,7 @@ data:
     oidc.json: |-
       {
         "enabled" : {{ .Values.oidc.enabled }},
-        "idToken" : {{ .Values.oidc.idToken | default "false" }},
+        "useIDToken" : {{ .Values.oidc.useIDToken | default "false" }},
         "clientID" : "{{ .Values.oidc.clientID }}",
         "secretName" : "{{ .Values.oidc.secretName }}",
         "authURL" : "{{ .Values.oidc.authURL }}",


### PR DESCRIPTION
## What does this PR change?

AzureAD configuration will require `.Values.oidc.useIDToken=true` to parse the id_token instead of the access_token.

Open to any opinions as to whether I should expose `idToken` in the `values.yaml` or keep it hidden and apply a default. In most use cases, I anticipate this config won't need to be set. For those that do need it, it will be mentioned in the corresponding docs.

## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/1566

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Add capability to use AzureAD for OIDC RBAC

## Links to Issues or ZD tickets this PR addresses or fixes

## How was this PR tested?

```
$ helm template ./cost-analyzer --set oidc.enabled=true
...
data:
    oidc.json: |-
      {
        "enabled" : true,
        "useIDToken" : false,
        "clientID" : "",
...

$ helm template ./cost-analyzer --set oidc.enabled=true --set oidc.useIDToken=true
...
data:
    oidc.json: |-
      {
        "enabled" : true,
        "useIDToken" : true,
        "clientID" : "",
...
```

## Have you made an update to documentation?

Not yet