### PR TITLE
fix(2325): Add extra manifests

### DIFF
--- a/cost-analyzer/templates/extra-manifests.yaml
+++ b/cost-analyzer/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1069,3 +1069,22 @@ costEventsAudit:
 #  enabled: true
 #  secretName: webhook-server-tls
 #  caBundle: ${CA_BUNDLE}
+
+# -- Array of extra K8s manifests to deploy
+## Note: Supports use of custom Helm templates
+extraObjects: []
+#- apiVersion: networking.istio.io/v1alpha3
+#  kind: VirtualService
+#  metadata:
+#    name: my-virtualservice
+#  spec:
+#    hosts:
+#    - kubecost.myorg.com
+#    gateways:
+#    - my-gateway
+#    http:
+#    - route:
+#      - destination:
+#          host: kubecost.kubecost.svc.cluster.local
+#          port:
+#            number: 80


### PR DESCRIPTION
## What does this PR change?

Add extra manifests to the chart

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Add helm template to allow extra manifests to be passed during install/upgrades.


## Links to Issues or ZD tickets this PR addresses or fixes

- #2325 


## How was this PR tested?

Yes. 
- No extra manifests in the values: no new manifests
- Extra manifests in the values: new manifests appended at the end

## Have you made an update to documentation?

In the values

