### PR TITLE
InitContainer Default Value Correction on KubeCost Deployment

### DIFF
--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -20873,7 +20873,7 @@ spec:
         - name: persistent-configs
           persistentVolumeClaim:
             claimName: kubecost-cost-analyzer
-      initContainers:
+      initContainers: []
       containers:
         - image: gcr.io/kubecost1/cost-model:prod-1.103.2
 


### PR DESCRIPTION
## What does this PR change?
Only Fix missed empty array in front of initContainers


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
IDE Linters does not show errors anymore on this line.


## Links to Issues or ZD tickets this PR addresses or fixes
None


## How was this PR tested?
Tested on Self Hosted OKD

## Have you made an update to the documentation?
No need.
