### PR TITLE
Advance Network Costs to v0.16.7

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -695,7 +695,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v0.16.6
+  image: gcr.io/kubecost1/kubecost-network-costs:v0.16.7
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
## What does this PR change?
* Updates Network Costs to `v0.16.7` -- dependency updates for CVE resolution.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Bump golang.org/x/net from 0.0.0-20220225172249-27dd8689420f to 0.7.0 by https://github.com/dependabot
