### PR TITLE
optionally use federated store secret

### DIFF
--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -119,7 +119,7 @@ spec:
               {{- else  }}
               value: "/var/configs/etl/federated-store.yaml"
             - name: CLUSTER_ID
-              value: {{ .Values.federatedETL.federator.primaryClusterID }}
+              value: "combined"
             - name: FEDERATED_CLUSTER
               value: "true"
             - name: FEDERATED_PRIMARY_CLUSTER

--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -40,7 +40,7 @@ spec:
         app: query-service
     spec:
       restartPolicy: Always
-      
+
       serviceAccountName: {{ template "query-service.serviceAccountName" . }}
       volumes:
         {{- $etlBackupBucketSecret := "" }}
@@ -48,6 +48,8 @@ spec:
             {{- $etlBackupBucketSecret = .Values.kubecostModel.queryServiceConfigSecret }}
         {{- else if .Values.kubecostModel.etlBucketConfigSecret }}
             {{- $etlBackupBucketSecret = .Values.kubecostModel.etlBucketConfigSecret }}
+        {{- else if .Values.kubecostModel.federatedStorageConfigSecret }}
+            {{- $etlBackupBucketSecret = .Values.kubecostModel.federatedStorageConfigSecret }}
         {{- else if and .Values.global.thanos.enabled (ne (typeOf .Values.kubecostModel.etlBucketConfigSecret) "string") }}
             {{- $etlBackupBucketSecret = .Values.thanos.storeSecretName }}
         {{- end }}
@@ -112,7 +114,17 @@ spec:
               value: "true"
             {{- if $etlBackupBucketSecret }}
             - name: ETL_BUCKET_CONFIG
+              {{- if not .Values.kubecostModel.federatedStorageConfigSecret}}
               value: "/var/configs/etl/object-store.yaml"
+              {{- else  }}
+              value: "/var/configs/etl/federated-store.yaml"
+            - name: CLUSTER_ID
+              value: {{ .Values.federatedETL.federator.primaryClusterID }}
+            - name: FEDERATED_CLUSTER
+              value: "true"
+            - name: FEDERATED_PRIMARY_CLUSTER
+              value: "true"
+              {{- end }}
             {{- end }}
             - name: ETL_TO_DISK_ENABLED
               value: "true"


### PR DESCRIPTION
## What does this PR change?

add ability to optionally use federated store secret


## Does this PR rely on any other PRs?

- cost-model change by Nik and Alex
## How does this PR impact users? (This is the kind of thing that goes in release notes!)

add ability to optionally use federated store secret

## How was this PR tested?
local helm install on federated cluster

## Have you made an update to documentation?

TBD