### PR TITLE
Add the capability to override the key inside the GCP secret

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -137,7 +137,7 @@ spec:
           secret:
             secretName: {{ .Values.kubecostProductConfigs.gcpSecretName }}
             items:
-            - key: compute-viewer-kubecost-key.json
+            - key: {{ .Values.kubecostProductConfigs.gcpSecretKeyName | default "compute-viewer-kubecost-key.json" }}
               path: service-key.json
         {{- end }}
         {{- end -}}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -77,7 +77,7 @@ spec:
           secret:
             secretName: {{ .Values.kubecostProductConfigs.gcpSecretName }}
             items:
-            - key: compute-viewer-kubecost-key.json
+            - key: {{ .Values.kubecostProductConfigs.gcpSecretKeyName | default "compute-viewer-kubecost-key.json" }}
               path: service-key.json
         {{- end }}
         {{- if .Values.kubecostProductConfigs.serviceKeySecretName }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1035,6 +1035,7 @@ costEventsAudit:
 #  masterPayerARN: ""
 #  projectID: "123456789"  # Also known as AccountID on AWS -- the current account/project that this instance of Kubecost is deployed on.
 #  gcpSecretName: gcp-secret # Name of a secret representing the gcp service key
+#  gcpSecretKeyName: compute-viewer-kubecost-key.json # Name of the secret's key containing the gcp service key
 #  bigQueryBillingDataDataset: billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2
 #  labelMappingConfigs:  # names of k8s labels or annotations used to designate different allocation concepts
 #    enabled: true


### PR DESCRIPTION
## What does this PR change?
Adds the ability to override the previously hard-coded GCP secret key (compute-viewer-kubecost-key.json). The reasoning behind the change is that sometimes we don't control the creation of secrets. In our case, we created a GCP Service Account Key using the Config Connector (https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccountkey). The created K8s secret will always contain the key "key.json".


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds the ability to override the key inside the GCP secret. The default remains "compute-viewer-kubecost-key.json".


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Rendered the chart locally using multiple scenarios.

## Have you made an update to documentation?
To the values.yaml
