### PR TITLE
Update QSR config to fix federated data queries.

### DIFF
--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -126,6 +126,8 @@ spec:
               value: "true"
             - name: FEDERATED_PRIMARY_CLUSTER
               value: "true"
+            - name: FEDERATED_REDIRECT_BACKUP
+              value: "true"
               {{- end }}
             {{- end }}
             - name: ETL_TO_DISK_ENABLED


### PR DESCRIPTION
## What does this PR change?
Adds `FEDERATED_REDIRECT_BACKUP` to the QSR StatefulSet config to allow queries to look for ETL files in the correct location on disk


## Does this PR rely on any other PRs?

- [Yup](https://github.com/kubecost/kubecost-cost-model/pull/1573).


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Will allow for federated QSR.


## How was this PR tested?
See accompanying PR.

## Have you made an update to documentation?
Nope.
