### PR TITLE
fix(query-service): truncate service name

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -73,6 +73,10 @@ Create the fully qualified name for Prometheus alertmanager service.
 {{- printf "%s-%s" .Release.Name "cost-analyzer" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "query-service.serviceName" -}}
+{{- printf "%s-%s" .Release.Name "query-service-load-balancer" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Network Costs name used to tie autodiscovery of metrics to daemon set pods
 */}}

--- a/cost-analyzer/templates/query-service-service-template.yaml
+++ b/cost-analyzer/templates/query-service-service-template.yaml
@@ -3,7 +3,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-query-service-load-balancer
+  name: {{ template "query-service.serviceName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "query-service.commonLabels" . | nindent 4 }}


### PR DESCRIPTION
## What does this PR change?
It truncates the service name by defining a `serviceName` herlper, truncated to 63 characters.

## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No impact, the service name is the same. It only truncates to 63 characters.

## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/2365

## How was this PR tested?
Locally by creating a new deployment with a release name longer than 63 characters.

## Have you made an update to documentation?
No need.