### PR TITLE
Add ability to configure Prometheus retention based on size

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
@@ -93,6 +93,9 @@ spec:
           {{- if .Values.server.retention }}
             - --storage.tsdb.retention.time={{ .Values.server.retention }}
           {{- end }}
+          {{- if .Values.server.retentionSize }}
+            - --storage.tsdb.retention.size={{ .Values.server.retentionSize }}
+          {{- end }}
             - --config.file={{ .Values.server.configPath }}
             - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
             - --web.console.libraries=/etc/prometheus/console_libraries


### PR DESCRIPTION
## What does this PR change?
Adds a helm value to set `--storage.tsdb.retention.size`

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds the ability to set Prometheus Server retention based on storage size.

## Links to Issues or ZD tickets this PR addresses or fixes
None

## How was this PR tested?
helm template

## Have you made an update to documentation?
No
