### PR TITLE
update helm chart to support savings cache disable

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -764,8 +764,8 @@ spec:
               value: {{ (quote .Values.kubecostModel.outOfClusterPromMetricsEnabled) | default (quote false) }}
             - name: CACHE_WARMING_ENABLED
               value: {{ (quote .Values.kubecostModel.warmCache) | default (quote true) }}
-            - name: SAVINGS_CACHE_WARMING_ENABLED
               value: {{ (quote .Values.kubecostModel.warmSavingsCache) | default (quote true) }}
+            - name: SAVINGS_ENABLED
             - name: ETL_ENABLED
               value: {{ (quote .Values.kubecostModel.etl) | default (quote true) }}
             {{- if .Values.kubecostModel.etlReadOnlyMode }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -764,8 +764,8 @@ spec:
               value: {{ (quote .Values.kubecostModel.outOfClusterPromMetricsEnabled) | default (quote false) }}
             - name: CACHE_WARMING_ENABLED
               value: {{ (quote .Values.kubecostModel.warmCache) | default (quote true) }}
-              value: {{ (quote .Values.kubecostModel.warmSavingsCache) | default (quote true) }}
             - name: SAVINGS_ENABLED
+              value: {{ (quote .Values.kubecostModel.warmSavingsCache) | default (quote true) }}
             - name: ETL_ENABLED
               value: {{ (quote .Values.kubecostModel.etl) | default (quote true) }}
             {{- if .Values.kubecostModel.etlReadOnlyMode }}


### PR DESCRIPTION
## What does this PR change?

provides a way to disable the savings cache via helm vars

## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

re-introduces a way for users to disable the savings cache

## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?

placed in cluster, confirmed ram usage was lower with savings disabled

## Have you made an update to documentation?
none needed, this uses the existing documented parameters 
