### PR TITLE
Merge pull request #2379 from kubecost/disable-savings-cache

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -764,7 +764,7 @@ spec:
               value: {{ (quote .Values.kubecostModel.outOfClusterPromMetricsEnabled) | default (quote false) }}
             - name: CACHE_WARMING_ENABLED
               value: {{ (quote .Values.kubecostModel.warmCache) | default (quote true) }}
-            - name: SAVINGS_CACHE_WARMING_ENABLED
+            - name: SAVINGS_ENABLED
               value: {{ (quote .Values.kubecostModel.warmSavingsCache) | default (quote true) }}
             - name: ETL_ENABLED
               value: {{ (quote .Values.kubecostModel.etl) | default (quote true) }}


### PR DESCRIPTION
update helm chart to support savings cache disable

(cherry picked from commit a8986d0050218d8bf257e928a8703c04a647c22e)
cherry pick of https://github.com/kubecost/cost-analyzer-helm-chart/pull/2379

