### PR TITLE
Expose port 9004 if OIDC enabled

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -66,4 +66,11 @@ spec:
       targetPort: 9004
     {{- end }}
     {{- end }}
+    {{- if .Values.oidc }}
+    {{- if .Values.oidc.enabled }}
+    - name: apiserver
+      port: 9004
+      targetPort: 9004
+    {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?

Similar to SAML, OIDC should also expose port 9004 for unauthenticated requests (typically only used for administrative purposes).

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- N/a

## Links to Issues or ZD tickets this PR addresses or fixes

- N/a

## How was this PR tested?

```sh
$ helm template ./cost-analyzer --set oidc.enabled=true | grep apiserver -C5
      port: 9003
      targetPort: 9003
    - name: tcp-frontend
      port: 9090
      targetPort: 9090
    - name: apiserver
      port: 9004
      targetPort: 9004
---
# Source: cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
apiVersion: apps/v1
```

I also manually edited the `service/kubecost-cost-analyzer` in my environment which has OIDC configured, and am successfully able to query the cost-model through port 9004.

## Have you made an update to documentation?

Not needed