### PR TITLE
Add comment to defaultModelPricing

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1017,7 +1017,7 @@ costEventsAudit:
 #       pass: admin
 #   - name: "Cluster B"
 #     address: http://cluster-b.kubecost.com:9090
-#  defaultModelPricing: # default monthly resource prices, used predominately for on-prem clusters
+#  defaultModelPricing: # default monthly resource prices, used predominately for on-prem clusters. Use quotes if setting "0.00" for any item.
 #    CPU: 28.0
 #    spotCPU: 4.86
 #    RAM: 3.09


### PR DESCRIPTION
If defaultModelPricing is set to 0. it must to be in quotes "0.00"

Failure to do so will result in the value(s) not being written to the Kubecost cost-model's PV

## What does this PR change?
Add one comment to defaultModelPricing


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
It provides some clarity on using zero default costs via defaultModelPricing


## Links to Issues or ZD tickets this PR addresses or fixes
https://kubecost.zendesk.com/agent/tickets/4433


## How was this PR tested?
Locally

## Have you made an update to documentation?
N/A
