### PR TITLE
Update regex for node exporter

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1297,7 +1297,7 @@ serverFiles:
             regex: true
           - source_labels: [__meta_kubernetes_endpoints_name]
             action: keep
-            regex: (.*kube-state-metrics|.*prometheus-node-exporter|kubecost-network-costs)
+            regex: (.*kube-state-metrics|.*node-exporter|kubecost-network-costs)
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
             action: replace
             target_label: __scheme__


### PR DESCRIPTION
## What does this PR change?

Reduces the strictness of regex for Prometheus to scrape the node-exporter.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Update prometheus scrape config to scrape existing node exporters. 


## Links to Issues or ZD tickets this PR addresses or fixes

- #1975 

## How was this PR tested?

Running kubecost directly with updated configmap.
## Have you made an update to documentation?

