### PR TITLE
Apply semicolon to large_client_buffer_headers directive

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -117,7 +117,7 @@ data:
         {{- if.Values.kubecostFrontend.extraServerConfig }}
         {{- .Values.kubecostFrontend.extraServerConfig | toString | nindent 8 -}}
         {{- else }}
-        large_client_header_buffers 4 32k
+        large_client_header_buffers 4 32k;
         {{- end }}
 
         error_page 504 /custom_504.html;


### PR DESCRIPTION
## What does this PR change?

Fixes an error in nginx config by applying a semicolon to a directive.



## Does this PR rely on any other PRs?

- No
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?

