### PR TITLE
update values.yaml to reflect right aggregate by option for cloudcost report

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -207,11 +207,11 @@ global:
     reports:
       - title: "Cloud Cost Report 0"
         window: "today"
-        aggregateBy: "type"
-        accumulate: false # daily resolution
-        filters:
-          - property: "cluster"
-            value: "cluster-one"
+        aggregateBy: "service"
+        accumulate: false  # daily resolution
+        # filters:
+        #   - property: "service"
+        #     value: "service1" # corresponds to a value to filter cloud cost aggregate by service data on.
 
   podAnnotations: {}
     # iam.amazonaws.com/role: role-arn


### PR DESCRIPTION
## What does this PR change?

Aggregate by type is not a valid aggregate by option for cloud cost. It should be one of service, accountID,  provider, providerID or label. When user gives current option in values.yaml in case of [2425](https://github.com/kubecost/cost-analyzer-helm-chart/issues/2425) it leads to a log error in cost-model pod. This is the PR to provide right example in values.yaml.

## Does this PR rely on any other PRs?
None
- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
None


## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/2425
- 
- 


## How was this PR tested?
On Azure cluster creating a cloud cost report with a yaml satisfying below values
```
  cloudCostReports:
    enabled: true # If true, overwrites report parameters set through UI
    reports:
      - title: "Cloud Cost Report 0"
        window: "7d"
        aggregateBy: "service"
        # filters: 
        #   - property: "cluster"
        #     value: "cluster-one"
```

## Have you made an update to documentation?
No need
