### PR TITLE
Federator runs as separate deployment by default

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -252,11 +252,6 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- if and (.Values.federatedETL.federator) (.Values.federatedETL.federator.enabled) (not .Values.federatedETL.federator.deployment) }}
-        - name: federator-config
-          configMap:
-            name: {{ template "cost-analyzer.fullname" . }}-federator
-        {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
         {{- toYaml .Values.extraVolumes | nindent 8 }}
@@ -483,10 +478,6 @@ spec:
               mountPath: /certs
             {{- end }}
             {{- end }}
-            {{- end }}
-            {{- if and (.Values.federatedETL.federator) (.Values.federatedETL.federator.enabled) (not .Values.federatedETL.federator.deployment) }}
-            - name: federator-config
-              mountPath: /var/configs/federator
             {{- end }}
             {{- if .Values.kubecostProductConfigs }}
             {{- if .Values.kubecostProductConfigs.productKey }}
@@ -791,18 +782,6 @@ spec:
             {{- end}}
             {{- if .Values.federatedETL.redirectS3Backup }}
             - name: FEDERATED_REDIRECT_BACKUP
-              value: "true"
-            {{- end}}
-            {{- if .Values.federatedETL.useExistingS3Config }}
-            - name: FEDERATED_USE_EXISTING_CONFIG
-              value: "true"
-            {{- end}}
-            {{- if and (.Values.federatedETL.federator.enabled) (not .Values.federatedETL.federator.deployment) }}
-            - name: FEDERATED_FEDERATOR_ENABLED
-              value: "true"
-            {{- end}}
-            {{- if .Values.federatedETL.federator.useMultiClusterDB }}
-            - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             {{- end}}
             - name: ETL_STORE_READ_ONLY

--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -62,7 +62,8 @@ spec:
               value: "/var/configs/etl/federated/federated-store.yaml"
             {{- end }}
       restartPolicy: Always
-      volumes: 
+      serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
+      volumes:
         - name: federator-config
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-federator

--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -2,7 +2,7 @@
 {{- fail "ERROR: You are using a deprecated configuration `.Values.federatedETL.useExistingS3Config`. Please use `.Values.kubecostModel.federatedStorageConfigSecret` instead." -}}
 {{- end -}}
 
-{{- if and (.Values.federatedETL.federator) (.Values.federatedETL.federator.enabled) (.Values.federatedETL.federator.deployment) }}
+{{- if and (.Values.federatedETL.federator) (.Values.federatedETL.federator.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -981,7 +981,6 @@ federatedETL:
   useMultiClusterDB: false # set to true if you have a single federated PromQL DB with metrics from all monitored clusters but want to use federation for performance
   federator:
     enabled: false # enables the federator to run inside the costmodel container, federating the data in the Federated store
-    deployment: false # when true, will run the federator in a separate deployment outside of `deployment/kubecost-cost-analyzer`.
     clusters: [] # optional. Whitelist of clusters by cluster id. If not set, the federator will attempt to federated all clusters pushing to the federated storage.
     # primaryClusterID: "cluster_id" # optional. Used when reconciliation is expected to occur on the Primary.
     # federationCutoffDate: "2022-10-18T00:00:00.000Z" # an RFC 3339-formatted string. All ETL files with windows that fall before this time are not processed by the Federator. If this is not set, the Federator will process all files regardless of date.


### PR DESCRIPTION
## What does this PR change?

1. Federator runs as separate deployment **by default**.
2. Remove federator configs from cost-analyzer-deployment.

## Does this PR rely on any other PRs?

This PR amends the previous 2 PRs: https://github.com/kubecost/cost-analyzer-helm-chart/pull/2397 https://github.com/kubecost/cost-analyzer-helm-chart/pull/2315

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

If you are running the Federated ETL architecture, when upgrading to v1.105 you will see a new `deployment/kubecost-federator` which is a workload dedicated to federating Kubecost's ETL files.

## Links to Issues or ZD tickets this PR addresses or fixes

- 

## How was this PR tested?

As shown, if the Federator is enabled a new `federator-deployment-template.yaml` is rendered

```sh
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer --set federatedETL.federator.enabled=true | grep -C3 federator-deployment

            periodSeconds: 10
            failureThreshold: 200
---
# Source: cost-analyzer/templates/federator-deployment-template.yaml
apiVersion: apps/v1
kind: Deployment
metadata:

```

Created a new cluster running Kubecost Federated ETL. `gcloud container clusters get-credentials thomasn-federator-microservice --region us-west1-a`. Confirmed that the federator was running and placing federated ETL files in the `/combined` directory on the bucket.

```sh
$ helm upgrade -i kubecost ~/kubecost/cost-analyzer-helm-chart/cost-analyzer -f ./values.yaml
```

```yaml
# values.yaml
kubecostProductConfigs:
  clusterName: "thomasn-federator-microservice"
  cloudIntegrationSecret: "cloud-integration"
kubecostModel:
  federatedStorageConfigSecret: "kubecost-fedetl"
  fullImageName: "gcr.io/kubecost1/cost-model:prod-1.105.0-rc.10"
  extraEnv:
  - name: "LOG_LEVEL"
    value: "debug"
federatedETL:
  federatedCluster: true
  federator:
    enabled: true
    primaryClusterID: "thomasn-federator-microservice"
  primaryCluster: true
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "thomasn-federator-microservice"
```

## Have you made an update to documentation?

Not yet.
