### PR TITLE
[Cherry-pick] Federator runs as separate deployment by default (#2438)

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -252,11 +252,6 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- if and (.Values.federatedETL.federator) (.Values.federatedETL.federator.enabled) (not .Values.federatedETL.federator.deployment) }}
-        - name: federator-config
-          configMap:
-            name: {{ template "cost-analyzer.fullname" . }}-federator
-        {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
         {{- toYaml .Values.extraVolumes | nindent 8 }}
@@ -483,10 +478,6 @@ spec:
               mountPath: /certs
             {{- end }}
             {{- end }}
-            {{- end }}
-            {{- if and (.Values.federatedETL.federator) (.Values.federatedETL.federator.enabled) (not .Values.federatedETL.federator.deployment) }}
-            - name: federator-config
-              mountPath: /var/configs/federator
             {{- end }}
             {{- if .Values.kubecostProductConfigs }}
             {{- if .Values.kubecostProductConfigs.productKey }}
@@ -791,18 +782,6 @@ spec:
             {{- end}}
             {{- if .Values.federatedETL.redirectS3Backup }}
             - name: FEDERATED_REDIRECT_BACKUP
-              value: "true"
-            {{- end}}
-            {{- if .Values.federatedETL.useExistingS3Config }}
-            - name: FEDERATED_USE_EXISTING_CONFIG
-              value: "true"
-            {{- end}}
-            {{- if and (.Values.federatedETL.federator.enabled) (not .Values.federatedETL.federator.deployment) }}
-            - name: FEDERATED_FEDERATOR_ENABLED
-              value: "true"
-            {{- end}}
-            {{- if .Values.federatedETL.federator.useMultiClusterDB }}
-            - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             {{- end}}
             - name: ETL_STORE_READ_ONLY

--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -2,7 +2,7 @@
 {{- fail "ERROR: You are using a deprecated configuration `.Values.federatedETL.useExistingS3Config`. Please use `.Values.kubecostModel.federatedStorageConfigSecret` instead." -}}
 {{- end -}}
 
-{{- if and (.Values.federatedETL.federator) (.Values.federatedETL.federator.enabled) (.Values.federatedETL.federator.deployment) }}
+{{- if and (.Values.federatedETL.federator) (.Values.federatedETL.federator.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,7 +62,8 @@ spec:
               value: "/var/configs/etl/federated/federated-store.yaml"
             {{- end }}
       restartPolicy: Always
-      volumes: 
+      serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
+      volumes:
         - name: federator-config
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-federator

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -974,7 +974,6 @@ federatedETL:
   useMultiClusterDB: false # set to true if you have a single federated PromQL DB with metrics from all monitored clusters but want to use federation for performance
   federator:
     enabled: false # enables the federator to run inside the costmodel container, federating the data in the Federated store
-    deployment: false # when true, will run the federator in a separate deployment outside of `deployment/kubecost-cost-analyzer`.
     clusters: [] # optional. Whitelist of clusters by cluster id. If not set, the federator will attempt to federated all clusters pushing to the federated storage.
     # primaryClusterID: "cluster_id" # optional. Used when reconciliation is expected to occur on the Primary.
     # federationCutoffDate: "2022-10-18T00:00:00.000Z" # an RFC 3339-formatted string. All ETL files with windows that fall before this time are not processed by the Federator. If this is not set, the Federator will process all files regardless of date.


### PR DESCRIPTION
Cherry-pick #2438 into v1.105 branch

* Federator runs as separate deployment by default. Remove federator configs from cost-analyzer-deployment.
* serviceAccount for irsa