### PR TITLE
To meet node exporter customized values

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1297,7 +1297,7 @@ serverFiles:
             regex: true
           - source_labels: [__meta_kubernetes_endpoints_name]
             action: keep
-            regex: (.*kube-state-metrics|.*prometheus-node-exporter|kubecost-network-costs)
+            regex: (.*kube-state-metrics|.*node-exporter|kubecost-network-costs)
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
             action: replace
             target_label: __scheme__


### PR DESCRIPTION
## What does this PR change?

To meet node exporter customized values. During every kubecost upgrade, to avoid manual update of node exporter endpoint

## Does this PR rely on any other PRs?

-  No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
This will ease maintenance efforts that has dependency on node-exporter name


## Links to Issues or ZD tickets this PR addresses or fixes

- NA
- NA


## How was this PR tested?
This regex expression change, hence this should not cause any issue

## Have you made an update to documentation?
No
