### PR TITLE
ELV-145 add setting to reenable CPU and RAM breakdown

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -989,6 +989,8 @@ spec:
             - name: COST_EVENTS_AUDIT_ENABLED
               value: {{ (quote .Values.costEventsAudit.enabled) | default (quote false) }}
             {{- end }}
+            - name: ASSET_MODE_BREAKDOWN_ENABLED
+              value: {{ (quote .Values.kubecostModel.assetModeBreakdownEnabled) | default (quote false) }}
             {{- /*
               Leader/Follower has baseline requirements before enabling:
                 * ETL FileStore Enabled


### PR DESCRIPTION
## What does this PR change?
* We are disabling costly Prometheus queries for CPU and RAM mode breakdown. This change allows those features to be re-enabled by helm configuration.

## Does this PR rely on any other PRs?
- https://github.com/opencost/opencost/pull/2049

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Less pressure on Prometheus

## Links to Issues or ZD tickets this PR addresses or fixes
* Closes https://github.com/opencost/opencost/issues/1883
* Closes https://kubecost.atlassian.net/browse/ELV-145

## How was this PR tested?
By default:
```
2023-07-19T20:57:12.324097149Z INF ELV-145: skipping node breakdown queries
2023-07-19T20:57:12.334288408Z INF ELV-145: skipping node breakdown queries
2023-07-19T20:57:12.462450038Z INF ELV-145: skipping node breakdown queries
```
![Screenshot from 2023-07-19 14-58-24](https://github.com/opencost/opencost/assets/8070055/c746d97e-e533-4593-a7de-08f855915169)

With the new setting enabled:
```
2023-07-19T21:03:06.363100429Z INF ELV-145: running node breakdown queries
2023-07-19T21:03:06.554459558Z INF ELV-145: running node breakdown queries
2023-07-19T21:03:06.749878635Z INF ELV-145: running node breakdown queries
```
![Screenshot from 2023-07-19 15-07-59](https://github.com/opencost/opencost/assets/8070055/00da64a6-fda8-4716-a1ec-0c0570bf04b2)

## Have you made an update to documentation?
No, but I will.
