### PR TITLE
remove ETL_TO_DISK_ENABLED

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -760,13 +760,8 @@ spec:
               value: "true"
             {{- end }}
             {{- if $etlBackupBucketSecret }}
-            - name: ETL_TO_DISK_ENABLED
-              value: "false"
             - name: ETL_BUCKET_CONFIG
               value: "/var/configs/etl/object-store.yaml"
-            {{- else }}
-            - name: ETL_TO_DISK_ENABLED
-              value: {{ (quote .Values.kubecostModel.etlToDisk) | default (quote true) }}
             {{- end }}
             {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
             - name: FEDERATED_STORE_CONFIG

--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -132,8 +132,6 @@ spec:
               value: "true"
               {{- end }}
             {{- end }}
-            - name: ETL_TO_DISK_ENABLED
-              value: "true"
             - name: ETL_PATH_PREFIX
               value: "/var/db"
             - name: CLOUD_PROVIDER_API_KEY

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -20950,8 +20950,6 @@ spec:
               value: "true"
             - name: ETL_ENABLED
               value: "true"
-            - name: ETL_TO_DISK_ENABLED
-              value: "true"
             - name: ETL_STORE_READ_ONLY
               value: "false"
             - name : ETL_CLOUD_USAGE_ENABLED


### PR DESCRIPTION
## What does this PR change?
ETL_TO_DISK_ENABLED is no longer in KCM, so remove it from the helm chart as well.

## Does this PR rely on any other PRs?
- https://github.com/kubecost/kubecost-cost-model/pull/1602

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- No impact; there is no customer facing variable to remove. 

## Links to Issues or ZD tickets this PR addresses or fixes
- https://kubecost.atlassian.net/browse/CORE-378

## How was this PR tested?

## Have you made an update to documentation?
- Not required. I did not find any references in the readme or kubecost docs.
