### PR TITLE
Add ability to set resource requests/limits for Federator deployment

### DIFF
--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -52,6 +52,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 200
+          resources:
+{{ toYaml .Values.federatedETL.federator.resources | indent 12}} 
           env:
             - name: CONFIG_PATH
               value: /var/configs/

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -984,6 +984,10 @@ federatedETL:
     clusters: [] # optional. Whitelist of clusters by cluster id. If not set, the federator will attempt to federated all clusters pushing to the federated storage.
     # primaryClusterID: "cluster_id" # optional. Used when reconciliation is expected to occur on the Primary.
     # federationCutoffDate: "2022-10-18T00:00:00.000Z" # an RFC 3339-formatted string. All ETL files with windows that fall before this time are not processed by the Federator. If this is not set, the Federator will process all files regardless of date.
+    resources: {} # you can use the Kubecost savings report for 'Right-size your container requests' to determine the recommended resource requests once the pod has run for 24 hours.
+      # requests:
+      #   cpu: 100m
+      #   memory: 500Mi
 
 kubecostAdmissionController:
   enabled: false


### PR DESCRIPTION
## What does this PR change?

Creates the `.Values.federatedETL.federator.resources` config which allows users to adjust requests/limits for the Federator deployment.

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- New Helm configuration for the Federator deployment's resource request/limit

## Links to Issues or ZD tickets this PR addresses or fixes

- None

## How was this PR tested?

Templates are rendering as expected.

```sh
# No defaults set
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer --set federatedETL.federator.enabled=true
...
            periodSeconds: 10
            failureThreshold: 200
          resources:
            {}
          env:
            - name: CONFIG_PATH
              value: /var/configs/
...

# Explicitly set memory request
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer --set federatedETL.federator.enabled=true --set federatedETL.federator.resources.requests.memory=500Mi
...
            initialDelaySeconds: 30
            periodSeconds: 10
            failureThreshold: 200
          resources:
            requests:
              memory: 500Mi
          env:
            - name: CONFIG_PATH
              value: /var/configs/
...
```

And below is a successful deployment.

```yaml
# values.yaml
kubecostModel:
  federatedStorageConfigSecret: "kubecost-fedetl"
federatedETL:
  federatedCluster: true
  federator:
    enabled: true
    primaryClusterID: "kubecost-fedetl-primary"
    resources:
      requests:
        memory: "5Mi"
        cpu: "0.1"
      limits:
        memory: "1Gi"
        cpu: "1"
  primaryCluster: true
```

```sh
helm upgrade -i kubecost ~/kubecost/cost-analyzer-helm-chart/cost-analyzer -f ./values.yaml
```

## Have you made an update to documentation?

Comments in `values.yaml`