### PR TITLE
Allow query-service's fullname to be overriden

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -31,7 +31,11 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{- define "query-service.fullname" -}}
+{{- if .Values.queryServiceFullnameOverride -}}
+{{- .Values.queryServiceFullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name "query-service" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "federator.fullname" -}}


### PR DESCRIPTION
## What does this PR change?
It allows for `query-service.fullname` to be overridden in the deployment template using a new variable `queryServiceFullnameOverride`.


## Does this PR rely on any other PRs?
No.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No impact, the `query-service.fullname` is the same if `queryServiceFullnameOverride` is not specified. It only adds the option to override the name.


## Links to Issues or ZD tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/issues/2455


## How was this PR tested?

If the `queryServiceFullnameOverride` variable is not set, then no change happens:

```
$ helm template --set 'kubecostDeployment.queryServiceReplicas=1' cost-analyzer -s templates/query-service-deployment-template.yaml | yq '.metadata.name' 

release-name-query-service
```

If the `queryServiceFullnameOverride` variable is set, then it updates the fullname:

```
$ helm template --set 'kubecostDeployment.queryServiceReplicas=1' cost-analyzer --set 'queryServiceFullnameOverride=query-service' -s templates/query-service-deployment-template.yaml | yq '.metadata.name' 

query-service
```

## Have you made an update to documentation?
No need.