### PR TITLE
redirect bug and product support question to Zendesk

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Support Request
-    url: https://kubecost.zendesk.com/requests/new
+    url: https://support.kubecost.com
     about: Contact our support team for bugs and product inquiries.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support Request
+    url: https://kubecost.zendesk.com/requests/new
+    about: Contact our support team for bugs and product inquiries.


### PR DESCRIPTION
This addition will create a new Issue type of "Support Request" and, when selected, will redirect to the Kubecost Support Request Form.

## What does this PR change?
Adds a "Support Request" option to new issues

## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will now see the following options
![image](https://github.com/kubecost/cost-analyzer-helm-chart/assets/46360304/36d7117d-ac2a-4a72-876e-bd91a896205f)

## Links to Issues or ZD tickets this PR addresses or fixes
none

## How was this PR tested?
I repro-ed the entire experience in my own repository (see screenshot from my repository)

## Have you made an update to documentation?
n/a
