### PR TITLE
grafana- default datasource for thanos / update datasources logic

### DIFF
--- a/cost-analyzer/charts/grafana/templates/configmap.yaml
+++ b/cost-analyzer/charts/grafana/templates/configmap.yaml
@@ -53,16 +53,16 @@ data:
         prometheusVersion: 2.35.0
         timeInterval: 1m
 {{- else }}
-  - access: proxy
-    isDefault: true
-    name: Prometheus
-    type: prometheus
-    url: {{ .Values.global.prometheus.fqdn }}
-    jsonData:
-      httpMethod: POST
-      prometheusType: Prometheus
-      prometheusVersion: 2.35.0
-      timeInterval: 1m
+    - access: proxy
+      isDefault: true
+      name: Prometheus
+      type: prometheus
+      url: {{ .Values.global.prometheus.fqdn }}
+      jsonData:
+        httpMethod: POST
+        prometheusType: Prometheus
+        prometheusVersion: 2.35.0
+        timeInterval: 1m
 {{- end -}}
 
 {{- if .Values.dashboardProviders }}

--- a/cost-analyzer/charts/grafana/templates/configmap.yaml
+++ b/cost-analyzer/charts/grafana/templates/configmap.yaml
@@ -26,19 +26,43 @@ data:
   {{ $key }}: |
 {{ toYaml $value | trim | indent 4 }}
   {{- end -}}
-{{- end -}}
-{{- if .Values.global.prometheus.enabled }}
+{{- end }}
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+{{- if .Values.global.thanos.enabled }}
+    - access: proxy
+      isDefault: true
+      name: Thanos
+      type: prometheus
+      url:  http://{{ .Release.Name }}-thanos-query-frontend-http.{{ .Release.Namespace }}:10902
+      jsonData:
+        timeInterval: 1m
+        prometheusType: Thanos
+        prometheusVersion: 0.29.0
+        httpMethod: POST
+{{- else if .Values.global.prometheus.enabled }}
     - access: proxy
       isDefault: true
       name: Prometheus
       type: prometheus
       url: http://{{ template "cost-analyzer.prometheus.server.name" . }}.{{ .Release.Namespace }}.svc
-{{ else }}
-    - access: proxy
-      isDefault: true
-      name: Prometheus
-      type: prometheus
-      url: {{ .Values.global.prometheus.fqdn }}
+      jsonData:
+        httpMethod: POST
+        prometheusType: Prometheus
+        prometheusVersion: 2.35.0
+        timeInterval: 1m
+{{- else }}
+  - access: proxy
+    isDefault: true
+    name: Prometheus
+    type: prometheus
+    url: {{ .Values.global.prometheus.fqdn }}
+    jsonData:
+      httpMethod: POST
+      prometheusType: Prometheus
+      prometheusVersion: 2.35.0
+      timeInterval: 1m
 {{- end -}}
 
 {{- if .Values.dashboardProviders }}

--- a/cost-analyzer/charts/grafana/templates/configmap.yaml
+++ b/cost-analyzer/charts/grafana/templates/configmap.yaml
@@ -27,9 +27,11 @@ data:
 {{ toYaml $value | trim | indent 4 }}
   {{- end -}}
 {{- end }}
+{{- if not .Values.datasources }}
   datasources.yaml: |
     apiVersion: 1
     datasources:
+{{- end }}
 {{- if .Values.global.thanos.enabled }}
     - access: proxy
       isDefault: true

--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
               mountPath: "/var/lib/grafana/dashboards/{{ . }}"
   {{- end }}
 {{- end }}
-{{- if or .Values.global.grafana.enabled  }}
+{{- if or .Values.datasources .Values.global.grafana.enabled }}
             - name: config
               mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
               subPath: datasources.yaml

--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     type: {{ .Values.deploymentStrategy }}
   {{- if ne .Values.deploymentStrategy "RollingUpdate" }}
     rollingUpdate: null
-  {{- end }}    
+  {{- end }}
   template:
     metadata:
       labels:
@@ -135,7 +135,7 @@ spec:
               mountPath: "/var/lib/grafana/dashboards/{{ . }}"
   {{- end }}
 {{- end }}
-{{- if .Values.datasources }}
+{{- if or .Values.global.grafana.enabled  }}
             - name: config
               mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
               subPath: datasources.yaml

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -935,6 +935,15 @@ grafana:
   rbac:
     # Manage the Grafana Pod Security Policy
     pspEnabled: false
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: prometheus-kubecost
+          type: prometheus
+          url: http://kubecost-prometheus-server.kubecost.svc.cluster.local
+          access: proxy
+          isDefault: false
   sidecar:
     dashboards:
       enabled: true

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -863,9 +863,9 @@ kubecostDeployment:
   # Ref: https://docs.kubecost.com/install-and-configure/advanced-configuration/query-service-replicas
   queryServiceReplicas: 0
   queryService:
-    resources: 
-      requests: 
-        # You can use the Kubecost savings report for 'Right-size your container requests' to determine the recommended resource requests once the pod has run for 24 hours. 
+    resources:
+      requests:
+        # You can use the Kubecost savings report for 'Right-size your container requests' to determine the recommended resource requests once the pod has run for 24 hours.
         cpu: 1000m
         memory: 500Mi
     # default storage class
@@ -935,15 +935,6 @@ grafana:
   rbac:
     # Manage the Grafana Pod Security Policy
     pspEnabled: false
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        - name: prometheus-kubecost
-          type: prometheus
-          url: http://kubecost-prometheus-server.kubecost.svc.cluster.local
-          access: proxy
-          isDefault: false
   sidecar:
     dashboards:
       enabled: true

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -935,20 +935,20 @@ grafana:
   rbac:
     # Manage the Grafana Pod Security Policy
     pspEnabled: false
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        - name: prometheus-kubecost
-          type: prometheus
-          url: http://kubecost-prometheus-server.kubecost.svc.cluster.local
-          access: proxy
-          isDefault: false
-          jsonData:
-            httpMethod: POST
-            prometheusType: Prometheus
-            prometheusVersion: 2.35.0
-            timeInterval: 1m
+  # datasources:
+  #   datasources.yaml:
+  #     apiVersion: 1
+  #     datasources:
+  #       - name: prometheus-kubecost
+  #         type: prometheus
+  #         url: http://kubecost-prometheus-server.kubecost.svc.cluster.local
+  #         access: proxy
+  #         isDefault: false
+  #         jsonData:
+  #           httpMethod: POST
+  #           prometheusType: Prometheus
+  #           prometheusVersion: 2.35.0
+  #           timeInterval: 1m
   sidecar:
     dashboards:
       enabled: true

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -944,6 +944,11 @@ grafana:
           url: http://kubecost-prometheus-server.kubecost.svc.cluster.local
           access: proxy
           isDefault: false
+          jsonData:
+            httpMethod: POST
+            prometheusType: Prometheus
+            prometheusVersion: 2.35.0
+            timeInterval: 1m
   sidecar:
     dashboards:
       enabled: true


### PR DESCRIPTION
## What does this PR change?

Change default Grafana datasource to thanos if enabled. 
Update Grafana datasource for Prometheus to allow for Grafana interval variables to work properly

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Change default Grafana datasource to thanos if enabled. 
Update Grafana datasource for Prometheus to allow for Grafana interval variables to work properly

## Links to Issues or ZD tickets this PR addresses or fixes


## How was this PR tested?

1. Thanos install
2. Prometheus install
3. BYO Prometheus install

## Have you made an update to documentation?

No changes needed