### PR TITLE
Add ability to set `containerSecurityContext` for Grafana and override `securityContext` for cost-analyzer

### DIFF
--- a/cost-analyzer/charts/grafana/README.md
+++ b/cost-analyzer/charts/grafana/README.md
@@ -36,6 +36,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `livenessProbe`            | Liveness Probe settings                           | `{ "httpGet": { "path": "/api/health", "port": 3000 } "initialDelaySeconds": 60, "timeoutSeconds": 30, "failureThreshold": 10 }` |
 | `readinessProbe`            | Rediness Probe settings                           | `{ "httpGet": { "path": "/api/health", "port": 3000 } }`|
 | `securityContext`               | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
+| `containerSecurityContext`      | Container securityContext                     | `{}`                                                    |
 | `image.repository`              | Image repository                              | `grafana/grafana`                                       |
 | `image.tag`                     | Image tag. (`Must be >= 5.0.0`)               | `5.3.1`                                                 |
 | `image.pullPolicy`              | Image pull policy                             | `IfNotPresent`                                          |

--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     type: {{ .Values.deploymentStrategy }}
   {{- if ne .Values.deploymentStrategy "RollingUpdate" }}
     rollingUpdate: null
-  {{- end }}    
+  {{- end }}
   template:
     metadata:
       labels:
@@ -54,6 +54,10 @@ spec:
           image: "{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}"
           imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
           command: ["sh", "/etc/grafana/download_dashboards.sh"]
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/download_dashboards.sh"
@@ -87,6 +91,10 @@ spec:
               value: "{{ .Values.sidecar.dashboards.error_throttle_sleep }}"
           resources:
 {{ toYaml .Values.sidecar.resources | indent 12 }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: sc-dashboard-volume
               mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
@@ -104,6 +112,10 @@ spec:
               value: "{{ .Values.sidecar.datasources.error_throttle_sleep }}"
           resources:
 {{ toYaml .Values.sidecar.resources | indent 12 }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: sc-datasources-volume
               mountPath: "/etc/grafana/provisioning/datasources"
@@ -216,6 +228,10 @@ spec:
 {{ toYaml .Values.readinessProbe | indent 12 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -39,6 +39,8 @@ securityContext:
   runAsUser: 472
   fsGroup: 472
 
+containerSecurityContext: {}
+
 downloadDashboardsImage:
   repository: curlimages/curl
   tag: latest

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -51,24 +51,25 @@ spec:
 {{- end }}
 {{- end }}
     spec:
+      {{- $securityContext := dict }}
       {{- if .Values.kubecostFrontend.tls }}
       {{- if .Values.kubecostFrontend.tls.enabled }}
-      securityContext:
-        runAsUser: 0
+      {{- $_ := set $securityContext "runAsUser" 0 -}}
       {{- else }}
-      securityContext:
-        runAsUser: 1001
-        runAsGroup: 1001
-        fsGroup: 1001
+      {{- $_ := set $securityContext "runAsUser" 1001 -}}
+      {{- $_ := set $securityContext "runAsGroup" 1001 -}}
+      {{- $_ := set $securityContext "fsGroup" 1001 -}}
       {{- end }}
       {{- else if lt $nginxPort 1025 }}
-      securityContext:
-        runAsUser: 0
+      {{- $_ := set $securityContext "runAsUser" 0 -}}
       {{- else }}
+      {{- $_ := set $securityContext "runAsUser" 1001 -}}
+      {{- $_ := set $securityContext "runAsGroup" 1001 -}}
+      {{- $_ := set $securityContext "fsGroup" 1001 -}}
+      {{- end }}
+      {{- with (merge .Values.global.securityContext $securityContext) }}
       securityContext:
-        runAsUser: 1001
-        runAsGroup: 1001
-        fsGroup: 1001
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Always
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -217,6 +217,8 @@ global:
     # iam.amazonaws.com/role: role-arn
   additionalLabels: {}
 
+  securityContext: {}
+    # seccompProfile: {type: RuntimeDefault}
   containerSecuritycontext: {}
     # readOnlyRootFilesystem: true
 
@@ -863,9 +865,9 @@ kubecostDeployment:
   # Ref: https://docs.kubecost.com/install-and-configure/advanced-configuration/query-service-replicas
   queryServiceReplicas: 0
   queryService:
-    resources: 
-      requests: 
-        # You can use the Kubecost savings report for 'Right-size your container requests' to determine the recommended resource requests once the pod has run for 24 hours. 
+    resources:
+      requests:
+        # You can use the Kubecost savings report for 'Right-size your container requests' to determine the recommended resource requests once the pod has run for 24 hours.
         cpu: 1000m
         memory: 500Mi
     # default storage class


### PR DESCRIPTION
## What does this PR change?

- This PR adds missing `containerSecurityContext` to Grafana 
- It also the ability to overrides properties of the default `securityContext` for the `cost-analyzer`

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Add ability to set `containerSecurityContext` for Grafana and override `securityContext` for the `cost-analyzer`

## How was this PR tested?

```
$ helm template --set 'grafana.containerSecurityContext.allowPrivilegeEscalation=false' cost-analyzer --show-only charts/grafana/templates/deployment.yaml | yq '.spec.template.spec.containers.[].securityContext'
allowPrivilegeEscalation: false
allowPrivilegeEscalation: false
```

```
$ helm template cost-analyzer --show-only charts/grafana/templates/deployment.yaml | yq '.spec.template.spec.containers.[].securityContext'
null
null
```

```
$ helm template cost-analyzer --show-only templates/cost-analyzer-deployment-template.yaml | yq '.spec.template.spec.securityContext'

fsGroup: 1001
runAsGroup: 1001
runAsUser: 1001
```

```
$ helm template --set 'global.securityContext.runAsNonRoot=true' cost-analyzer --show-only templates/cost-analyzer-deployment-template.yaml | yq '.spec.template.spec.securityContext'

fsGroup: 1001
runAsGroup: 1001
runAsNonRoot: true
runAsUser: 1001
```

```
$ helm template --set 'global.securityContext.runAsUser=2001' cost-analyzer --show-only templates/cost-analyzer-deployment-template.yaml | yq '.spec.template.spec.securityContext'

fsGroup: 1001
runAsGroup: 1001
runAsUser: 2001
```

## Have you made an update to documentation?

Yes!
