### PR TITLE
Ability to add extra configs to Nginx's `location /model/ {}`

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -192,6 +192,9 @@ data:
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+            {{- if .Values.kubecostFrontend.extraModelConfigs }}
+            {{- .Values.kubecostFrontend.extraModelConfigs | toString | nindent 12 -}}
+            {{- end }}
         }
 
         location ~ ^/(turndown|cluster)/ {


### PR DESCRIPTION
## What does this PR change?

Ability to add extra configs to Nginx's `location /model/ {}`

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- For some users, adding additional configurations to this endpoint helped mitigate timeouts & 502s

## Links to Issues or ZD tickets this PR addresses or fixes

- [KC-36](https://kubecost.atlassian.net/jira/polaris/projects/KC/ideas/view/2936873?selectedIssue=KC-36&issueViewSection=comments)

## How was this PR tested?

```yaml
# values.yaml
kubecostFrontend:
  extraModelConfigs: |
    proxy_buffers y;
    proxy_buffer_size y;
    proxy_busy_buffers_size y;
```

```sh
# Review the following rendered templates:
# Source: cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer/ -f values.yaml > output.txt
...
        location /model/ {
            proxy_connect_timeout       600;
            proxy_send_timeout          600;
            proxy_read_timeout          600;
            proxy_pass http://model/;
            proxy_redirect off;
            proxy_http_version 1.1;
            proxy_set_header Connection "";
            proxy_set_header  X-Real-IP  $remote_addr;
            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_buffers y;
            proxy_buffer_size y;
            proxy_busy_buffers_size y;

        }
...
```

[output.txt](https://github.com/kubecost/cost-analyzer-helm-chart/files/12295644/output.txt)

```sh
# Default install of Kubecost still renders correctly
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer/ > output.txt
```

[output.txt](https://github.com/kubecost/cost-analyzer-helm-chart/files/12295641/output.txt)

## Have you made an update to documentation?

- No

[KC-36]: https://kubecost.atlassian.net/browse/KC-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ