### PR TITLE
Federator and QueryService `extraEnv`, `extraVolumes`, and `extraVolumeMounts` config options

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -92,17 +92,17 @@ spec:
             items:
               - key: nginx.conf
                 path: default.conf
-        {{- /*
-          If Thanos is enabled, then enable ETL backups by default.
-          To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret=""
-        */}}
-        {{- $etlBackupBucketSecret := "" }}
         {{- if .Values.global.containerSecuritycontext }}
         - name: var-run
           emptyDir: { }
         - name: cache
           emptyDir: { }
         {{- end }}
+        {{- /*
+          If Thanos is enabled, then enable ETL backups by default.
+          To opt out of ETL backups, set .Values.kubecostModel.etlBucketConfigSecret=""
+        */}}
+        {{- $etlBackupBucketSecret := "" }}
         {{- if .Values.kubecostModel.etlBucketConfigSecret }}
             {{- $etlBackupBucketSecret = .Values.kubecostModel.etlBucketConfigSecret }}
         {{- else if and .Values.global.thanos.enabled (ne (typeOf .Values.kubecostModel.etlBucketConfigSecret) "string") }}

--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -45,6 +45,9 @@ spec:
             - name: federated-storage-config
               mountPath: /var/configs/etl/federated
               readOnly: true
+            {{- if .Values.federatedETL.federator.extraVolumeMounts }}
+            {{- toYaml .Values.federatedETL.federator.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz
@@ -53,7 +56,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 200
           resources:
-{{ toYaml .Values.federatedETL.federator.resources | indent 12}} 
+            {{- toYaml .Values.federatedETL.federator.resources | nindent 12 }}
           env:
             - name: CONFIG_PATH
               value: /var/configs/
@@ -62,6 +65,9 @@ spec:
             {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
             - name: FEDERATED_STORE_CONFIG
               value: "/var/configs/etl/federated/federated-store.yaml"
+            {{- end }}
+            {{- if .Values.federatedETL.federator.extraEnv }}
+            {{- toYaml .Values.federatedETL.federator.extraEnv | nindent 12 }}
             {{- end }}
       restartPolicy: Always
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
@@ -74,5 +80,8 @@ spec:
           secret:
             defaultMode: 420
             secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
+        {{- end }}
+        {{- if .Values.federatedETL.federator.extraVolumes }}
+        {{- toYaml .Values.federatedETL.federator.extraVolumes | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -59,6 +59,9 @@ spec:
            defaultMode: 420
            secretName: {{ $etlBackupBucketSecret }}
         {{- end }}
+        {{- if .Values.kubecostDeployment.queryService.extraVolumes }}
+        {{- toYaml .Values.kubecostDeployment.queryService.extraVolumes | nindent 8 }}
+        {{- end }}
       initContainers:
         - name: config-db-perms-fix
           image: busybox
@@ -99,7 +102,7 @@ spec:
               containerPort: 9003
               protocol: TCP
           resources:
-{{ toYaml .Values.kubecostDeployment.queryService.resources | indent 12 }}
+            {{- toYaml .Values.kubecostDeployment.queryService.resources | nindent 12 }}
           volumeMounts:
             - name: persistent-configs
               mountPath: /var/configs
@@ -107,6 +110,9 @@ spec:
               mountPath: /var/configs/etl
             - name: database-storage
               mountPath: /var/db
+            {{- if .Values.kubecostDeployment.queryService.extraVolumeMounts }}
+            {{- toYaml .Values.kubecostDeployment.queryService.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           env:
             - name: CONFIG_PATH
               value: /var/configs/
@@ -136,6 +142,9 @@ spec:
               value: "/var/db"
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API key.This GCP api key is expected to be here and is limited to accessing google's billing API.'
+            {{- if .Values.kubecostDeployment.queryService.extraEnv }}
+            {{- toYaml .Values.kubecostDeployment.queryService.extraEnv | nindent 12 }}
+            {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}


### PR DESCRIPTION
## What does this PR change?

Adds `extraEnv`, `extraVolumes`, and `extraVolumeMounts` config options for the Federator deployment and QueryService statefulset.

## Does this PR rely on any other PRs?

- 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Some users will need to pass these extra config options so that the pods have proper IAM permissions

## Links to Issues or ZD tickets this PR addresses or fixes

- [KC-41](https://kubecost.atlassian.net/jira/polaris/projects/KC/ideas/view/2936873?selectedIssue=KC-41&issueViewSection=comments)

## How was this PR tested?

```yaml
# values.yaml
federatedETL:
  federator:
    enabled: true
    extraEnv:
    - name: AWS_ROLE_ARN
      value: "<IAM_ROLE_ARN>"
    - name: AWS_WEB_IDENTITY_TOKEN_FILE
      value: /var/run/secrets/aws-iam-token/serviceaccount/token
    extraVolumes:
    - name: aws-iam-token
      projected:
        defaultMode: 420
        sources:
        - serviceAccountToken:
            audience: sts.amazonaws.com
            expirationSeconds: 86400
            path: token 
    extraVolumeMounts:
    - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
      name: aws-iam-token
      readOnly: true

kubecostDeployment:
  queryServiceReplicas: 1
  queryService:
    extraEnv: 
    - name: AWS_ROLE_ARN
      value: "<IAM_ROLE_ARN>"
    - name: AWS_WEB_IDENTITY_TOKEN_FILE
      value: /var/run/secrets/aws-iam-token/serviceaccount/token
    extraVolumes:
    - name: aws-iam-token
      projected:
        defaultMode: 420
        sources:
        - serviceAccountToken:
            audience: sts.amazonaws.com
            expirationSeconds: 86400
            path: token 
    extraVolumeMounts:
    - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
      name: aws-iam-token
      readOnly: true
```

```sh
# Review that we are correctly rendering for the following files
# Source: cost-analyzer/templates/federator-deployment-template.yaml
# Source: cost-analyzer/templates/query-service-deployment-template.yaml
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer/ -f values.yaml > output.txt
```

[output.txt](https://github.com/kubecost/cost-analyzer-helm-chart/files/12294589/output.txt)

```sh
# Successful rendering when default values are used
$ helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer/ > output.txt
```

[output.txt](https://github.com/kubecost/cost-analyzer-helm-chart/files/12294590/output.txt)

## Have you made an update to documentation?

- No


[KC-41]: https://kubecost.atlassian.net/browse/KC-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ