### PR TITLE
fix: Use container_memory_working_set_bytes for memory utilization. T…

### DIFF
--- a/cost-analyzer/cluster-utilization.json
+++ b/cost-analyzer/cluster-utilization.json
@@ -613,7 +613,7 @@
         "pluginVersion": "8.3.2",
         "targets": [
           {
-            "expr": "SUM(container_memory_usage_bytes{namespace!=\"\"}) / SUM(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"}) * 100",
+            "expr": "SUM(container_memory_working_set_bytes{name!=\"POD\", container!=\"\", namespace!=\"\"}) / SUM(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"}) * 100",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,


### PR DESCRIPTION
Hi all, 

I'm no expert with your tool, just trying to give back to the community. 
Please close this if I'm missing something or if it is not applicable for any reason.

## What does this PR change?
It replaces the ```container_memory_usage_bytes``` by ```container_memory_working_set_bytes```. 
This gives a more accurate view of the memory utilization when compared to the average of ```kubectl top nodes``` for memory consumption.
It also takes into consideration that file cache could be evicted under pressure.

BEFORE: The dashboard shows 259% of RAM Utilization. 
AFTER:  RAM Utilization shows 55% which matches the number from kubectl.

## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
They will see memory consumption that actually matches the same as if they gather the info from ```kubectl top nodes```.

## Links to Issues or ZD tickets this PR addresses or fixes
n/a

## How was this PR tested?
By checking the effect on our dashboard and comparing it to an quickly calculated average of the values delivered by ```kubectl top nodes```

## Have you made an update to documentation?
n/a
