### PR TITLE
Add configurability for Deployment Annotations

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -6,19 +6,21 @@ metadata:
   name: {{ template "cost-analyzer.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
-{{- if .Values.kubecostDeployment }}
-{{- with .Values.kubecostDeployment.labels }}
-{{ toYaml . | indent 4 }}
-{{- end }}
-{{- end }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- if and .Values.kubecostDeployment .Values.kubecostDeployment.labels }}
+    {{- toYaml .Values.kubecostDeployment.labels | nindent 4 }}
+    {{- end }}
+  {{- if and .Values.kubecostDeployment .Values.kubecostDeployment.annotations }}
+  annotations:
+    {{- toYaml .Values.kubecostDeployment.annotations | nindent 4 }}
+  {{- end }}
 spec:
 {{- if .Values.kubecostDeployment }}
   replicas: {{ .Values.kubecostDeployment.replicas | default 1 }}
 {{- end }}
   selector:
     matchLabels:
-{{ include "cost-analyzer.selectorLabels" . | nindent 8}}
+      {{- include "cost-analyzer.selectorLabels" . | nindent 8}}
 {{- if .Values.kubecostDeployment }}
 {{- if .Values.kubecostDeployment.deploymentStrategy }}
 {{- with .Values.kubecostDeployment.deploymentStrategy }}
@@ -35,15 +37,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "cost-analyzer.selectorLabels" . | nindent 8 }}
+        {{- include "cost-analyzer.selectorLabels" . | nindent 8 }}
         {{- if .Values.global.additionalLabels }}
         {{ toYaml .Values.global.additionalLabels | nindent 8 }}
         {{- end }}
-{{- if .Values.kubecostDeployment }}
-{{- with .Values.kubecostDeployment.labels }}
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- end }}
+        {{- if and .Values.kubecostDeployment .Values.kubecostDeployment.labels }}
+        {{- toYaml .Values.kubecostDeployment.labels | nindent 8 }}
+        {{- end }}
 {{- if .Values.global.podAnnotations}}
       annotations:
 {{- with .Values.global.podAnnotations }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -847,8 +847,9 @@ networkCosts:
   additionalSecurityContext: {}
     # readOnlyRootFilesystem: true
 
-# Kubecost Deployment Configuration
-# Used for HA mode in Business & Enterprise tier
+## Kubecost Deployment Configuration
+## Used for HA mode in Business & Enterprise tier
+##
 kubecostDeployment:
   replicas: 1
   leaderFollower:
@@ -858,17 +859,20 @@ kubecostDeployment:
   #     maxSurge: 1
   #     maxUnavailable: 1
   #   type: RollingUpdate
+  labels: {}
+  annotations: {}
 
-  # QueryServiceReplicas
-  # Ref: https://docs.kubecost.com/install-and-configure/advanced-configuration/query-service-replicas
+  ## QueryServiceReplicas
+  ## Ref: https://docs.kubecost.com/install-and-configure/advanced-configuration/query-service-replicas
+  ##
   queryServiceReplicas: 0
   queryService:
     resources: 
       requests: 
-        # You can use the Kubecost savings report for 'Right-size your container requests' to determine the recommended resource requests once the pod has run for 24 hours. 
+        ## You can use the Kubecost savings report for 'Right-size your container requests' to determine the recommended resource requests once the pod has run for 24 hours. 
         cpu: 1000m
         memory: 500Mi
-    # default storage class
+    ## default storage class
     storageClass: ""
     databaseVolumeSize: 100Gi
     configVolumeSize: 1Gi


### PR DESCRIPTION
## What does this PR change?

- Add config option for annotations
- Cleanup the templating for labels.

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Users can add annotations to the Kubecost deployment via Helm Chart.

## Links to Issues or ZD tickets this PR addresses or fixes

- N/a

## How was this PR tested?

```yaml
# values.yaml
kubecostDeployment:
  labels:
    environment: "production"
  annotations:
    description: "This deployment monitors & reports kubernetes spend"
```

```sh
# Test the helm chart's new configuration. Review the following files:
# Source: cost-analyzer/templates/cost-analyzer-deployment-template.yaml
helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer/ -f values.yaml > output.txt
```

[output.txt](https://github.com/kubecost/cost-analyzer-helm-chart/files/12295734/output.txt)

```sh
# Test the helm chart's default configuration still renders properly
helm template ~/kubecost/cost-analyzer-helm-chart/cost-analyzer/ > output.txt
```

[output.txt](https://github.com/kubecost/cost-analyzer-helm-chart/files/12295735/output.txt)

## Have you made an update to documentation?

- No
