### PR TITLE
[cherry-pick] Ability to add extra configs to Nginx's `location /model/ {}`

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -192,6 +192,9 @@ data:
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+            {{- if .Values.kubecostFrontend.extraModelConfigs }}
+            {{- .Values.kubecostFrontend.extraModelConfigs | toString | nindent 12 -}}
+            {{- end }}
         }
 
         location ~ ^/(turndown|cluster)/ {


### PR DESCRIPTION
This is a cherry-pick of https://github.com/kubecost/cost-analyzer-helm-chart/pull/2472 into v1.106