### PR TITLE
Grafana request sizing update

### DIFF
--- a/cost-analyzer/pod-utilization.json
+++ b/cost-analyzer/pod-utilization.json
@@ -271,7 +271,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Traffic in and out of this pod, as a sum of its containers",
+      "description": "Network traffic by pod",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -355,7 +355,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "max (irate (container_network_receive_bytes_total\n  {namespace=~\"$namespace\",pod=~\"$pod\"}\n  [$__rate_interval])) \nby (cluster_id, namespace, pod)",
+          "expr": "sum (irate (container_network_receive_bytes_total\n  {namespace=~\"$namespace\",pod=~\"$pod\",container=\"POD\"}\n  [$__rate_interval])) \nby (cluster_id, namespace, pod)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -371,7 +371,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "- max (irate (container_network_transmit_bytes_total\n  {namespace=~\"$namespace\",pod_name=~\"$pod\"}\n  [$__rate_interval])) \nby (cluster_id, namespace, pod)",
+          "expr": "- sum (irate (container_network_transmit_bytes_total\n  {namespace=~\"$namespace\",pod=~\"$pod\",container=\"POD\"}\n  [$__rate_interval])) \nby (cluster_id, namespace, pod)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -416,8 +416,8 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
-            "spanNulls": true,
+            "showPoints": "auto",
+            "spanNulls": 3600000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -456,7 +456,7 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull"
+            "max"
           ],
           "displayMode": "list",
           "placement": "bottom",
@@ -474,7 +474,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "max (irate (container_fs_writes_bytes_total\r\n    {namespace=~\"$namespace\",pod=~\"$pod\", container=~\"$container\", container!=\"POD\",container!=\"\"}\r\n    [$__rate_interval])) \r\n    by (cluster_id, namespace, pod, container)",
+          "expr": "sum(irate (container_fs_writes_bytes_total\r\n    {container!=\"POD\",pod!=\"\",pod=~\"$pod\",container=~\"$container\"}\r\n     [$__rate_interval])) \r\nby (cluster_id,namespace,pod,container)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -490,7 +490,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "- max (irate (container_fs_reads_bytes_total\r\n    {cnamespace=~\"$namespace\",pod=~\"$pod\", container=~\"$container\", container!=\"POD\",container!=\"\"}\r\n    [$__rate_interval])) \r\n    by (cluster_id, namespace, pod, container)",
+          "expr": "- sum(irate(container_fs_reads_bytes_total\r\n     {container!=\"POD\",pod!=\"\",pod=~\"$pod\",container=~\"$container\"}\r\n     [$__rate_interval])) \r\nby (cluster_id,namespace,pod,container)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -636,7 +636,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "kubecost",
           "value": "kubecost"
         },
@@ -721,7 +721,7 @@
     ]
   },
   "time": {
-    "from": "now-1d",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {

--- a/cost-analyzer/pod-utilization.json
+++ b/cost-analyzer/pod-utilization.json
@@ -336,8 +336,7 @@
       "options": {
         "legend": {
           "calcs": [
-            "mean",
-            "max"
+            "mean"
           ],
           "displayMode": "list",
           "placement": "bottom",
@@ -455,8 +454,7 @@
       "options": {
         "legend": {
           "calcs": [
-            "mean",
-            "max"
+            "mean"
           ],
           "displayMode": "list",
           "placement": "bottom",
@@ -574,7 +572,9 @@
       "links": [],
       "options": {
         "legend": {
-          "calcs": [],
+          "calcs": [
+            "mean"
+          ],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true

--- a/cost-analyzer/pod-utilization.json
+++ b/cost-analyzer/pod-utilization.json
@@ -354,7 +354,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum (irate (container_network_receive_bytes_total\n  {namespace=~\"$namespace\",pod=~\"$pod\",container=\"POD\"}\n  [$__rate_interval])) \nby (cluster_id, namespace, pod)",
+          "expr": "sum (irate (container_network_receive_bytes_total\n  {namespace=~\"$namespace\",pod=~\"$pod\"}\n  [$__rate_interval])) \nby (cluster_id, namespace, pod)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -370,7 +370,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "- sum (irate (container_network_transmit_bytes_total\n  {namespace=~\"$namespace\",pod=~\"$pod\",container=\"POD\"}\n  [$__rate_interval])) \nby (cluster_id, namespace, pod)",
+          "expr": "- sum (irate (container_network_transmit_bytes_total\n  {namespace=~\"$namespace\",pod=~\"$pod\"}\n  [$__rate_interval])) \nby (cluster_id, namespace, pod)",
           "format": "time_series",
           "hide": false,
           "instant": false,


### PR DESCRIPTION
## What does this PR change?

minor edits to https://github.com/kubecost/cost-analyzer-helm-chart/pull/2475:
1. fix queries that should have been using sum, not avg or max.
2. change default range to 2d to match Kubecost request-sizing UI default of 2d


## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Update the request-sizing target grafana dashboard to use max usage for cpu and memory to match defaults


## How was this PR tested?

nightly and qa environments 

## Have you made an update to documentation?

NA