### PR TITLE
[Hold for 1.107] create global security contexts for nonRoot

### DIFF
--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -41,9 +41,12 @@ spec:
 {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
-{{- if .Values.securityContext }}
+{{- if .Values.global.securityContext }}
       securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
+{{- toYaml .Values.global.securityContext | nindent 8 }}
+{{- else if .Values.securityContext }}
+      securityContext:
+{{- toYaml .Values.securityContext | nindent 8 }}
 {{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -54,6 +57,10 @@ spec:
           image: "{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}"
           imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
           command: ["sh", "/etc/grafana/download_dashboards.sh"]
+          {{- with .Values.global.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/download_dashboards.sh"
@@ -78,6 +85,10 @@ spec:
         - name: {{ template "grafana.name" . }}-sc-dashboard
           image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
           imagePullPolicy: {{ .Values.sidecar.image.pullPolicy }}
+          {{- if .Values.global.containerSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 -}}
+          {{- end }}
           env:
             - name: LABEL
               value: "{{ .Values.sidecar.dashboards.label }}"
@@ -95,6 +106,10 @@ spec:
         - name: {{ template "grafana.name" . }}-sc-datasources
           image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
           imagePullPolicy: {{ .Values.sidecar.image.pullPolicy }}
+          {{- with .Values.global.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: LABEL
               value: "{{ .Values.sidecar.datasources.label }}"
@@ -111,6 +126,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.global.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"

--- a/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
@@ -59,10 +59,15 @@ spec:
             - --volume-dir={{ . }}
           {{- end }}
           resources:
-{{ toYaml .Values.configmapReload.prometheus.resources | indent 12 }}
-          {{- with .Values.configmapReload.prometheus.containerSecurityContext }}
+          {{- toYaml .Values.configmapReload.prometheus.resources | nindent 12 }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.global.containerSecurityContext }}
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          {{- else if .Values.global.containerSecurityContext }}
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          {{- else }}
+          securityContext:
+            {{- toYaml .Values.configmapReload.prometheus.containerSecurityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.selfsignedCertConfigMapName }}
@@ -129,10 +134,12 @@ spec:
             failureThreshold: {{ .Values.server.livenessProbeFailureThreshold }}
             successThreshold: {{ .Values.server.livenessProbeSuccessThreshold }}
           resources:
-{{ toYaml .Values.server.resources | indent 12 }}
-          {{- with .Values.server.containerSecurityContext }}
+          {{- toYaml .Values.server.resources | nindent 12 }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.global.containerSecurityContext }}
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          {{- else }}
+            {{- toYaml .Values.server.prometheus.containerSecurityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: config-volume
@@ -170,11 +177,14 @@ spec:
     {{- end }}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.server.nodeSelector | indent 8 }}
+      {{- toYaml .Values.server.nodeSelector | nindent 8 }}
     {{- end }}
-    {{- if .Values.server.securityContext }}
+    {{- if .Values.global.securityContext }}
       securityContext:
-{{ toYaml .Values.server.securityContext | indent 8 }}
+    {{- toYaml .Values.global.securityContext | nindent 8 }}
+    {{- else if .Values.server.securityContext }}
+      securityContext2:
+    {{- toYaml .Values.server.securityContext | nindent 8 }}
     {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -64,6 +64,9 @@ spec:
       {{- else if lt $nginxPort 1025 }}
       securityContext:
         runAsUser: 0
+      {{- else if .Values.global.securityContext }}
+      securityContext:
+        {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- else }}
       securityContext:
         runAsUser: 1001
@@ -408,10 +411,12 @@ spec:
           args:
           {{- toYaml .Values.kubecostModel.extraArgs | nindent 12 }}
         {{- end }}
-        {{- if .Values.kubecostModel.securityContext }}
           securityContext:
+        {{- if .Values.kubecostModel.securityContext }}
             {{- toYaml .Values.kubecostModel.securityContext | nindent 12 -}}
-        {{ end }}
+        {{- else if .Values.global.containerSecurityContext }}
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 -}}
+        {{- end }}
         {{- if .Values.kubecostModel.imagePullPolicy }}
           imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}
         {{- else }}
@@ -1066,7 +1071,10 @@ spec:
         {{- if .Values.kubecostFrontend.securityContext }}
           securityContext:
             {{- toYaml .Values.kubecostFrontend.securityContext | nindent 12 }}
-        {{ end }}
+          {{- else if .Values.global.containerSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         {{- include "federator.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.global.securityContext }}
+      securityContext:
+      {{- toYaml .Values.global.securityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: federator
           {{- if .Values.kubecostModel }}
@@ -34,6 +38,10 @@ spec:
           image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
           {{- end }}
           imagePullPolicy: Always
+          {{- if .Values.global.containerSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 -}}
+          {{- end }}
           args: ["federator"]
           ports:
             - name: tcp-model

--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "query-service.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "query-service.commonLabels" . | nindent 4 }}
+    {{- include "query-service.commonLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.kubecostDeployment.queryServiceReplicas }}
   serviceName: "query-service"
@@ -40,7 +40,13 @@ spec:
         app: query-service
     spec:
       restartPolicy: Always
-
+      {{- if .Values.kubecostDeployment.queryService.securityContext }}
+      securityContext:
+        {{- toYaml .Values.kubecostDeployment.queryService.securityContext | nindent 8 }}
+      {{- else if .Values.global.securityContext }}
+      securityContext:
+        {{- toYaml .Values.global.securityContext | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "query-service.serviceAccountName" . }}
       volumes:
         {{- $etlBackupBucketSecret := "" }}
@@ -96,6 +102,12 @@ spec:
             periodSeconds: 10
             failureThreshold: 200
           imagePullPolicy: Always
+          securityContext:
+          {{- if .Values.kubecostDeployment.queryService.containerSecurityContext }}
+            {{- toYaml .Values.kubecostDeployment.queryService.containerSecurityContext | nindent 12 -}}
+          {{- else if .Values.global.containerSecurityContext }}
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 -}}
+          {{- end }}
           args: ["query-service"]
           ports:
             - name: tcp-model

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -7,7 +7,7 @@ global:
 # will greatly assist in reduction memory bloat in query.
 kubecostModel:
   maxQueryConcurrency: 5
-  # This configuration is applied to thanos only. Expresses the resolution to 
+  # This configuration is applied to thanos only. Expresses the resolution to
   # use for longer query ranges. Options: raw, 5m, 1h - Default: raw
   maxSourceResolution: 5m
 
@@ -30,8 +30,11 @@ prometheus:
     - name: thanos-sidecar
       image: thanosio/thanos:v0.29.0
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1001
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+          - ALL
       args:
       - sidecar
       - --log.level=debug
@@ -62,7 +65,7 @@ prometheus:
         subPath: ""
       - name: object-store-volume
         mountPath: /etc/config
-    
+
 thanos:
   store:
     enabled: true
@@ -73,10 +76,10 @@ thanos:
         value: "100"
       - name: GODEBUG
         value: "madvdontneed=1"
-    resources: 
+    resources:
       requests:
         memory: "2.5Gi"
-  query: 
+  query:
     enabled: true
     timeout: 3m
     # Maximum number of queries processed concurrently by query node.
@@ -99,7 +102,7 @@ thanos:
     compressResponses: true
     # Downstream Tripper Configuration
     downstreamTripper:
-      enabled: true 
+      enabled: true
       idleConnectionTimeout: 90s
       responseHeaderTimeout: 2m
       tlsHandshakeTimeout: 10s
@@ -108,10 +111,10 @@ thanos:
       maxIdleConnectionsPerHost: 100
       maxConnectionsPerHost: 0
     # Response Cache Configuration
-    # Configure either a max size constraint or max items. 
+    # Configure either a max size constraint or max items.
     responseCache:
       enabled: true
-      # Maximum memory size of the cache in bytes. A unit suffix (KB, MB, GB) may be applied.      
+      # Maximum memory size of the cache in bytes. A unit suffix (KB, MB, GB) may be applied.
       maxSize: 1.25GB
       # Maximum number of entries in the cache.
       maxSizeItems: 0
@@ -128,7 +131,7 @@ thanos:
 
   # Thanos Sidecar Service Discovery
   # Disabling removes the prometheus sidecar from querier store discovery. This ensures
-  # that all clusters read from the same data in remote store. 
+  # that all clusters read from the same data in remote store.
   sidecar:
     enabled: true
   bucket:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -226,6 +226,7 @@ global:
     runAsUser: 65534
   containerSecurityContext:
     allowPrivilegeEscalation: false
+    privileged: false
     readOnlyRootFilesystem: true
     capabilities:
       drop:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -217,8 +217,19 @@ global:
     # iam.amazonaws.com/role: role-arn
   additionalLabels: {}
 
-  containerSecuritycontext: {}
-    # readOnlyRootFilesystem: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    fsGroup: 65534
+    runAsGroup: 65534
+    runAsUser: 65534
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+      - ALL
 
 # generated at http://kubecost.com/install, used for alerts tracking and free trials
 kubecostToken: # ""
@@ -867,10 +878,23 @@ kubecostDeployment:
   ##
   queryServiceReplicas: 0
   queryService:
-    resources: 
-      requests: 
-        ## You can use the Kubecost savings report for 'Right-size your 
-        ## container requests' to determine the recommended resource requests 
+    securityContext:
+      fsGroup: 65534
+      runAsGroup: 65534
+      runAsUser: 65534
+      runAsNonRoot: false
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      allowPrivilegeEscalation: true
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop:
+        - ALL
+    resources:
+      requests:
+        ## You can use the Kubecost savings report for 'Right-size your
+        ## container requests' to determine the recommended resource requests
         ## once the pod has run for 24 hours.
         cpu: 1000m
         memory: 500Mi


### PR DESCRIPTION
## What does this PR change?

Change global setting to run all pods as nonRoot and adds ability to make global changes to securityContexts.

Exceptions:
1. networkCosts requires root, is optional and not enabled by default
2. queryService initContainer requires root, is optional and not enabled by default
3. NodeExporter requires hostNetwork, is optional and is enabled by default
4. KSM should be disabled

New defaults (exceptions above):
```yaml
global:
  securityContext:
    runAsNonRoot: true
    seccompProfile:
      type: RuntimeDefault
    fsGroup: 65534
    runAsGroup: 65534
    runAsUser: 65534
  containerSecurityContext:
    allowPrivilegeEscalation: false
    readOnlyRootFilesystem: true
    capabilities:
      drop:
      - ALL
```

## Does this PR rely on any other PRs?

no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

change global setting to run all pods as nonRoot and adds ability to make global changes to securityContexts:

## Links to Issues or ZD tickets this PR addresses or fixes

https://kubecost.atlassian.net/browse/CORE-274

## How was this PR tested?

test cluster with QSR and federator enabled

## Have you made an update to documentation?

will be in values, but could use an official doc. 