### PR TITLE
allow adding default datasource

### DIFF
--- a/cost-analyzer/charts/grafana/templates/configmap.yaml
+++ b/cost-analyzer/charts/grafana/templates/configmap.yaml
@@ -31,7 +31,6 @@ data:
   datasources.yaml: |
     apiVersion: 1
     datasources:
-{{- end }}
 {{- if .Values.global.thanos.enabled }}
     - access: proxy
       isDefault: true
@@ -66,7 +65,8 @@ data:
         prometheusVersion: 2.35.0
         timeInterval: 1m
 {{- end -}}
-
+# end of if not .Values.datasources:
+{{- end }}
 {{- if .Values.dashboardProviders }}
   {{- range $key, $value := .Values.dashboardProviders }}
   {{ $key }}: |


### PR DESCRIPTION
## What does this PR change?

Allow adding default Grafana data source
until now, kubecost forced the default to be one of our select few. This should now work for all use cases.

example:
```yaml
grafana:
  datasources:
    datasources.yaml:
      apiVersion: 1
      datasources:
      - access: proxy
        isDefault: true
        name: Prometheus
        type: prometheus
        url:  http://thanos-query-frontend.thanos:9090
        jsonData:
          timeInterval: 1m
          prometheusType: Thanos
          prometheusVersion: 0.29.0
          httpMethod: POST
      - access: proxy
        isDefault: false
        name: Prometheus-local
        type: prometheus
        url: http://kubecost-prometheus-server:80
        jsonData:
          httpMethod: POST
          prometheusType: Prometheus
          prometheusVersion: 2.35.0
          timeInterval: 1m
```

## Does this PR rely on any other PRs?

no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Change default Grafana datasource to thanos if enabled and allow user to set default data source
Update Grafana datasource for Prometheus to allow for Grafana interval variables to work properly

## How was this PR tested?

with and without custom datasource

## Have you made an update to documentation?

not required.