### PR TITLE
mimir proxy basic auth

### DIFF
--- a/cost-analyzer/templates/mimir-proxy-configmap-template.yaml
+++ b/cost-analyzer/templates/mimir-proxy-configmap-template.yaml
@@ -12,6 +12,9 @@ data:
         location / {
           proxy_pass  {{ .Values.global.mimirProxy.mimirEndpoint }};
           proxy_set_header  X-Scope-OrgID "{{ .Values.global.mimirProxy.orgIdentifier }}";
+          {{- if .Values.global.mimirProxy.basicAuth }}
+          proxy_set_header  Authorization "Basic {{ (printf "%s:%s" .Values.global.mimirProxy.basicAuth.username .Values.global.mimirProxy.basicAuth.password) | b64enc }}";
+          {{- end }}
         }
     }
 {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -67,7 +67,9 @@ global:
     port: 8085
     mimirEndpoint: $mimir_endpoint #Your Mimir query endpoint. If your Mimir query endpoint is http://example.com/prometheus, replace $mimir_endpoint with http://example.com/
     orgIdentifier: $your_tenant_ID #Your Grafana Mimir tenant ID
-
+    # basicAuth:
+      # username: user
+      # password: pwd
 
   notifications:
     # Kubecost alerting configuration


### PR DESCRIPTION
## What does this PR change?
Allows mimir proxy to add basic auth header


## Does this PR rely on any other PRs?
no


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
-

## Links to Issues or ZD tickets this PR addresses or fixes
-

## How was this PR tested?
Tested on my clusters


## Have you made an update to documentation?
Example added to values.yaml
