### PR TITLE
Bump kiwigrid/k8s-sidecar v1.23.1 -> v1.25.0

### DIFF
--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -258,7 +258,7 @@ smtp:
 sidecar:
   image:
     repository: kiwigrid/k8s-sidecar
-    tag: 1.23.1
+    tag: 1.25.0
     pullPolicy: IfNotPresent
   resources:
 #   limits:


### PR DESCRIPTION
## What does this PR change?

Upgrades Grafana sidecar image version from 1.23.1 -> 1.25.0.

Images of `kiwigrid/k8s-sidecar` listed [here on DockerHub](https://hub.docker.com/r/kiwigrid/k8s-sidecar/tags). Upstream Grafana Helm Chart is currently on `kiwigrid/k8s-sidecar:1.24.6` as shown [here](https://github.com/grafana/helm-charts/blob/c539d6a92953ee751f6ffe63640fd738c371074e/charts/grafana/values.yaml#L794-L798).

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

No Impact

## Links to Issues or ZD tickets this PR addresses or fixes

Reports that the `kiwigrid/k8s-sidecar:1.23.1` was affected by CVEs

## How was this PR tested?

Deployed to my cluster without any errors. Grafana's logs look healthy. I don't anticipate any compatibility issues by upgrading this sidecar since it's only responsible for watching configmaps in the cluster. I will continue to monitor my deployment.

## Have you made an update to documentation?

No
