### PR TITLE
Federator: Add imagePullSecret and pod scheduling values

### DIFF
--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -84,4 +84,29 @@ spec:
         {{- if .Values.federatedETL.federator.extraVolumes }}
         {{- toYaml .Values.federatedETL.federator.extraVolumes | nindent 8 }}
         {{- end }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }}
+      {{- if .Values.federatedETL.federator.priority }}
+      {{- if .Values.federatedETL.federator.priority.enabled }}
+      {{- if .Values.federatedETL.federator.priority.name }}
+      priorityClassName: {{ .Values.federatedETL.federator.priority.name }}
+      {{- else }}
+      priorityClassName: {{ template "federator.fullname" . }}-priority
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.federatedETL.federator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.federatedETL.federator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.federatedETL.federator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
Adds the ability to set the following values for the Federator pod.
`.Values.imagePullSecrets`
`.Values.federatedETL.federator.priority`
`.Values.federatedETL.federator.priority.enabled`
`.Values.federatedETL.federator.priority.name`
`.Values.federatedETL.federator.nodeSelector`
`.Values.federatedETL.federator.tolerations`
`.Values.federatedETL.federator.affinity`

## Does this PR rely on any other PRs?
Nope!

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds the ability to define an image pull secret as well as standard pod scheduling concepts to the Federator deployment

## Links to Issues or ZD tickets this PR addresses or fixes
n/a

## What risks are associated with merging this PR? What is required to fully test this PR?
Not sure.

## How was this PR tested?

``` shell
helm template kubecost --repo https://kubecost.github.io/cost-analyzer/ cost-analyzer -f pr2511_values.yaml > pr2511_output.yaml
```

pr2511_values.yaml
```yaml
imagePullSecrets:
  - name: image-secret
federatedETL:
  federator:
    enabled: true
    priority:
      enabled: true
    nodeSelector: 
      kubernetes.io/os: linux
    tolerations:
    - key: "node.kubernetes.io/unreachable"
      operator: "Exists"
      effect: "NoExecute"
      tolerationSeconds: 6000
    affinity: 
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: kubernetes.io/os
              operator: In
              values:
              - linux
```

pr2511_output.yaml
```yaml
...
---
# Source: cost-analyzer/templates/federator-deployment-template.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: kubecost-federator
  namespace: kubecost
  labels:
    app.kubernetes.io/name: federator
    helm.sh/chart: cost-analyzer-1.106.0-rc.4
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app: federator
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: federator
      app.kubernetes.io/instance: kubecost
      app: federator
  template:
    metadata:
      labels:
        app.kubernetes.io/name: federator
        app.kubernetes.io/instance: kubecost
        app: federator
    spec:
...
      restartPolicy: Always
      serviceAccountName: kubecost-cost-analyzer
      imagePullSecrets:
        - name: image-secret
      priorityClassName: kubecost-federator-priority
      nodeSelector:
        kubernetes.io/os: linux
      tolerations:
        - effect: NoExecute
          key: node.kubernetes.io/unreachable
          operator: Exists
          tolerationSeconds: 6000
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: kubernetes.io/os
                operator: In
                values:
                - linux
```


## Have you made an update to documentation?
Not needed
