### PR TITLE
CI updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    rebase-strategy: disabled

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -42,25 +42,62 @@ jobs:
 
       # Setup a short sha to use for cluster naming to ensure we create and cleanup unique clusters and set the k8s version for
       # both kubectl and k3s
-      - name: Setup env
-        run: |
-          echo "short_sha=${GITHUB_SHA::10}" >> $GITHUB_ENV
-          echo "k8s_version=v1.23.7" >> $GITHUB_ENV
+      # - name: Setup env
+      #   run: |
+      #     echo "short_sha=${GITHUB_SHA::10}" >> $GITHUB_ENV
+      #     echo "k8s_version=v1.23.7" >> $GITHUB_ENV
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v3
         with:
           version: ${{ env.k8s_version }}
 
-      - name: Create k3d cluster
-        uses: AbsaOSS/k3d-action@v2
+      # - name: Create k3d cluster
+      #   uses: AbsaOSS/k3d-action@v2
+      #   with:
+      #     cluster-name: ${{ env.short_sha }}
+      #     args: >-
+      #       --agents 1
+      #       --no-lb
+      #       --image docker.io/rancher/k3s:${{ env.k8s_version }}-k3s1
+      #       --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+
+      # - name: Install Kubecost
+      #   working-directory: ./cost-analyzer
+      #   run: |
+      #     kubectl create ns kubecost
+      #     helm install kubecost . --namespace kubecost --set global.prometheus.enabled=false --set global.grafana.enabled=false
+
+  # Installs the chart across a matrix of modern Kubernetes versions
+  deploy-chart:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version:
+          - name: v1.23
+            version: v1.23.17
+          - name: v1.24
+            version: v1.24.16
+          - name: v1.25
+            version: v1.25.12
+          - name: v1.26
+            version: v1.26.7
+          - name: v1.27
+            version: v1.27.4
+          - name: v1.28
+            version: v1.28.0
+    needs: build-with-cost-model-develop
+    name: ${{ matrix.k8s-version.name }} test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create KinD Cluster
+        uses: helm/kind-action@v1
         with:
-          cluster-name: ${{ env.short_sha }}
-          args: >-
-            --agents 1
-            --no-lb
-            --image docker.io/rancher/k3s:${{ env.k8s_version }}-k3s1
-            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+          node_image: ${{ matrix.k8s-version.version }}
+          kubectl_version: ${{ matrix.k8s-version.version }}
 
       - name: Install Kubecost
         working-directory: ./cost-analyzer

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -75,4 +75,4 @@ jobs:
         working-directory: ./cost-analyzer
         run: |
           kubectl create ns kubecost
-          helm install kubecost . --namespace kubecost --set global.prometheus.enabled=false --set global.grafana.enabled=false
+          helm install --wait --wait-for-jobs kubecost . --namespace kubecost --set global.prometheus.enabled=false --set global.grafana.enabled=false

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.3
+      # - name: Set up Helm
+      #   uses: azure/setup-helm@v3
+      #   with:
+      #     version: v3.12.3
 
       - name: Run helm lint
         working-directory: ./cost-analyzer

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -78,13 +78,13 @@ jobs:
           - name: v1.23
             version: v1.23.17
           - name: v1.24
-            version: v1.24.16
+            version: v1.24.15
           - name: v1.25
-            version: v1.25.12
+            version: v1.25.11
           - name: v1.26
-            version: v1.26.7
+            version: v1.26.6
           - name: v1.27
-            version: v1.27.4
+            version: v1.27.3
           - name: v1.28
             version: v1.28.0
     needs: build-with-cost-model-develop

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Print tool versions
         run: |
-          kubectl version
+          kubectl version --short
           helm version
   
       - name: Install Kubecost Helm chart

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -64,5 +64,4 @@ jobs:
       - name: Install Kubecost chart
         working-directory: ./cost-analyzer
         run: |
-          kubectl create ns kubecost
-          helm install --wait --wait-for-jobs kubecost . --namespace kubecost --set global.prometheus.enabled=false --set global.grafana.enabled=false
+          helm install --wait --wait-for-jobs kubecost . --namespace kubecost --create-namespace --set global.prometheus.enabled=false --set global.grafana.enabled=false

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Helm lint
         working-directory: ./cost-analyzer
@@ -52,10 +52,10 @@ jobs:
     name: ${{ matrix.k8s-version.name }} test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Create KinD cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
         with:
           version: v0.20.0
           node_image: kindest/node:${{ matrix.k8s-version.version }}

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -14,11 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # - name: Set up Helm
-      #   uses: azure/setup-helm@v3
-      #   with:
-      #     version: v3.12.3
-
       - name: Run helm lint
         working-directory: ./cost-analyzer
         run: helm lint
@@ -30,7 +25,7 @@ jobs:
       - name: Kubeconform test
         uses: docker://ghcr.io/yannh/kubeconform:latest
         with:
-          entrypoint: '/kubeconform'
+          entrypoint: /kubeconform
           args: "-summary -output text ./cost-analyzer/full.yaml"
 
 
@@ -65,11 +60,6 @@ jobs:
           version: v0.20.0
           node_image: kindest/node:${{ matrix.k8s-version.version }}
           kubectl_version: ${{ matrix.k8s-version.version }}
-
-      - name: Print tool versions
-        run: |
-          kubectl version --short
-          helm version
   
       - name: Install Kubecost Helm chart
         working-directory: ./cost-analyzer

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -28,11 +28,11 @@ jobs:
         # Template the chart out for kubeval usage and also validates that it can 'build'
         run: helm template . --set global.prometheus.enabled=false --set global.grafana.enabled=false > full.yaml
 
-      - name: Kubeval test
-        uses: instrumenta/kubeval-action@master
-        with:
-          files: ./cost-analyzer/full.yaml
-          ignore_missing_schemas: false
+      # - name: Kubeval test
+      #   uses: instrumenta/kubeval-action@master
+      #   with:
+      #     files: ./cost-analyzer/full.yaml
+      #     ignore_missing_schemas: false
 
       - name: Kubeconform test
         uses: docker://ghcr.io/yannh/kubeconform:latest

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -1,6 +1,7 @@
 name: Chart build
 
 on:
+  workflow_dispatch: {}
   pull_request:
     branches:
       - develop
@@ -10,12 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.8.2
+          version: v3.12.13
 
       - name: Run helm lint
         working-directory: ./cost-analyzer
@@ -39,12 +41,13 @@ jobs:
           echo "short_sha=${GITHUB_SHA::10}" >> $GITHUB_ENV
           echo "k8s_version=v1.23.7" >> $GITHUB_ENV
 
-      - uses: azure/setup-kubectl@v3.0
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
         with:
           version: ${{ env.k8s_version }}
 
-      - uses: AbsaOSS/k3d-action@v2
-        name: "Create Single Cluster"
+      - name: Create k3d cluster
+        uses: AbsaOSS/k3d-action@v2
         with:
           cluster-name: ${{ env.short_sha }}
           args: >-

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -68,8 +68,8 @@ jobs:
 
       - name: Print tool versions
         run: |
-          kubectl --version
-          helm --version
+          kubectl version
+          helm version
   
       - name: Install Kubecost Helm chart
         working-directory: ./cost-analyzer

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -94,9 +94,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Create KinD Cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@v1.8.0
         with:
-          node_image: ${{ matrix.k8s-version.version }}
+          version: v0.20.0
+          node_image: kindest/node:${{ matrix.k8s-version.version }}
           kubectl_version: ${{ matrix.k8s-version.version }}
 
       - name: Install Kubecost

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -58,8 +58,3 @@ jobs:
         run: |
           kubectl create ns kubecost
           helm install kubecost . --namespace kubecost --set global.prometheus.enabled=false --set global.grafana.enabled=false
-
-      - name: Cleanup k3s
-        if: always()
-        run: |
-          k3d cluster delete ${{ env.short_sha }}

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.12.13
+          version: v3.12.3
 
       - name: Run helm lint
         working-directory: ./cost-analyzer

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -7,7 +7,7 @@ on:
       - develop
 
 jobs:
-  build-with-cost-model-develop:
+  test-chart:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,14 +25,7 @@ jobs:
 
       - name: Run helm template
         working-directory: ./cost-analyzer
-        # Template the chart out for kubeval usage and also validates that it can 'build'
         run: helm template . --set global.prometheus.enabled=false --set global.grafana.enabled=false > full.yaml
-
-      # - name: Kubeval test
-      #   uses: instrumenta/kubeval-action@master
-      #   with:
-      #     files: ./cost-analyzer/full.yaml
-      #     ignore_missing_schemas: false
 
       - name: Kubeconform test
         uses: docker://ghcr.io/yannh/kubeconform:latest
@@ -40,33 +33,6 @@ jobs:
           entrypoint: '/kubeconform'
           args: "-summary -output text ./cost-analyzer/full.yaml"
 
-      # Setup a short sha to use for cluster naming to ensure we create and cleanup unique clusters and set the k8s version for
-      # both kubectl and k3s
-      # - name: Setup env
-      #   run: |
-      #     echo "short_sha=${GITHUB_SHA::10}" >> $GITHUB_ENV
-      #     echo "k8s_version=v1.23.7" >> $GITHUB_ENV
-
-      # - name: Install kubectl
-      #   uses: azure/setup-kubectl@v3
-      #   with:
-      #     version: ${{ env.k8s_version }}
-
-      # - name: Create k3d cluster
-      #   uses: AbsaOSS/k3d-action@v2
-      #   with:
-      #     cluster-name: ${{ env.short_sha }}
-      #     args: >-
-      #       --agents 1
-      #       --no-lb
-      #       --image docker.io/rancher/k3s:${{ env.k8s_version }}-k3s1
-      #       --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
-
-      # - name: Install Kubecost
-      #   working-directory: ./cost-analyzer
-      #   run: |
-      #     kubectl create ns kubecost
-      #     helm install kubecost . --namespace kubecost --set global.prometheus.enabled=false --set global.grafana.enabled=false
 
   # Installs the chart across a matrix of modern Kubernetes versions
   deploy-chart:
@@ -87,7 +53,7 @@ jobs:
             version: v1.27.3
           - name: v1.28
             version: v1.28.0
-    needs: build-with-cost-model-develop
+    needs: test-chart
     name: ${{ matrix.k8s-version.name }} test
     steps:
       - name: Checkout repository
@@ -100,7 +66,12 @@ jobs:
           node_image: kindest/node:${{ matrix.k8s-version.version }}
           kubectl_version: ${{ matrix.k8s-version.version }}
 
-      - name: Install Kubecost
+      - name: Print tool versions
+        run: |
+          kubectl --version
+          helm --version
+  
+      - name: Install Kubecost Helm chart
         working-directory: ./cost-analyzer
         run: |
           kubectl create ns kubecost

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -28,11 +28,17 @@ jobs:
         # Template the chart out for kubeval usage and also validates that it can 'build'
         run: helm template . --set global.prometheus.enabled=false --set global.grafana.enabled=false > full.yaml
 
-      - name: Kubeval
+      - name: Kubeval test
         uses: instrumenta/kubeval-action@master
         with:
           files: ./cost-analyzer/full.yaml
           ignore_missing_schemas: false
+
+      - name: Kubeconform test
+        uses: docker://ghcr.io/yannh/kubeconform:latest
+        with:
+          entrypoint: '/kubeconform'
+          args: "-summary -output text ./cost-analyzer/full.yaml"
 
       # Setup a short sha to use for cluster naming to ensure we create and cleanup unique clusters and set the k8s version for
       # both kubectl and k3s

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -47,10 +47,10 @@ jobs:
       #     echo "short_sha=${GITHUB_SHA::10}" >> $GITHUB_ENV
       #     echo "k8s_version=v1.23.7" >> $GITHUB_ENV
 
-      - name: Install kubectl
-        uses: azure/setup-kubectl@v3
-        with:
-          version: ${{ env.k8s_version }}
+      # - name: Install kubectl
+      #   uses: azure/setup-kubectl@v3
+      #   with:
+      #     version: ${{ env.k8s_version }}
 
       # - name: Create k3d cluster
       #   uses: AbsaOSS/k3d-action@v2

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Run helm lint
+      - name: Helm lint
         working-directory: ./cost-analyzer
         run: helm lint
 
-      - name: Run helm template
+      - name: Helm template
         working-directory: ./cost-analyzer
         run: helm template . --set global.prometheus.enabled=false --set global.grafana.enabled=false > full.yaml
 
-      - name: Kubeconform test
+      - name: Kubeconform
         uses: docker://ghcr.io/yannh/kubeconform:latest
         with:
           entrypoint: /kubeconform
@@ -51,17 +51,17 @@ jobs:
     needs: test-chart
     name: ${{ matrix.k8s-version.name }} test
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Create KinD Cluster
+      - name: Create KinD cluster
         uses: helm/kind-action@v1.8.0
         with:
           version: v0.20.0
           node_image: kindest/node:${{ matrix.k8s-version.version }}
           kubectl_version: ${{ matrix.k8s-version.version }}
   
-      - name: Install Kubecost Helm chart
+      - name: Install Kubecost chart
         working-directory: ./cost-analyzer
         run: |
           kubectl create ns kubecost


### PR DESCRIPTION
Closes #2503 
Closes #2513
Closes #2514  

## What does this PR change?

* Updates the Helm CI action to bump dependencies, fix and improve logic
* Enables on-demand testing
* Uses more recent version of actions for linting/testing
* Reworks the action to introduce parallelized testing across a spread of Kubernetes versions
* Introduces a dependabot file to track deps listed in GitHub Actions

See latest run [here](https://github.com/kubecost/cost-analyzer-helm-chart/actions/runs/5914118961) for proof.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

This is an internal-only change.

## Links to Issues or ZD tickets this PR addresses or fixes

N/A


## What risks are associated with merging this PR? What is required to fully test this PR?

Future PRs to this repo could fail due to faulty changes.

## How was this PR tested?

Tested locally from fork and observing results of Action execution in this repo.

## Have you made an update to documentation?

N/A
