### PR TITLE
Fix issue template about length

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,5 @@
 name: "Feature Request"
-description: Suggest a new feature for the Kubecost chart. If you've found a reproducible bug please reach out to our technical support team via email at support@kubecost.com or Slack at https://kubecost.com/join-slack. There, we will triage the issue and work to resolve it.
+description: Suggest a new feature for the Kubecost chart.
 title: "[Feature] "
 labels: ["enhancement", "needs-triage"]
 body:
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Problem Statement
       description: Describe the problem.
-      placeholder: A clear and concise description of the problem statement.
+      placeholder: A clear and concise description of the problem statement. If you've found a reproducible bug please reach out to our technical support team via email at support@kubecost.com or Slack at https://kubecost.com/join-slack. There, we will triage the issue and work to resolve it.
       # value: "asdf"
     validations:
       required: true


### PR DESCRIPTION
## What does this PR change?

* Fixes the About length problem by moving into a field box. Follow-on fix from #2521.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows them to open feature requests with GitHub forms.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

Feature requests continue to be unavailable.

## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

