### PR TITLE
Allow disabling the kubecost frontend

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -76,25 +76,27 @@ spec:
       restartPolicy: Always
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       volumes:
-      {{- if .Values.global.gcpstore.enabled }}
+        {{- if .Values.global.gcpstore.enabled }}
         - name: ubbagent-config
           configMap:
             name: ubbagent-config
-      {{- end }}
-      {{- if .Values.hosted }}
+        {{- end }}
+        {{- if .Values.hosted }}
         - name: config-store
           secret:
             defaultMode: 420
             secretName: kubecost-thanos
-      {{- end }}
+        {{- end }}
         - name: tmp
           emptyDir: {}
+        {{- if .Values.kubecostFrontend.enabled }}
         - name: nginx-conf
           configMap:
             name: nginx-conf
             items:
               - key: nginx.conf
                 path: default.conf
+        {{- end }}
         {{- if .Values.global.containerSecuritycontext }}
         - name: var-run
           emptyDir: { }
@@ -1043,6 +1045,7 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: kubecost-token
+        {{- if .Values.kubecostFrontend.enabled }}
         {{- if .Values.kubecostFrontend }}
         {{- if .Values.kubecostFrontend.fullImageName }}
         - image: {{ .Values.kubecostFrontend.fullImageName }}
@@ -1119,6 +1122,7 @@ spec:
           securityContext:
           {{- toYaml .Values.global.containerSecuritycontext | nindent 12 }}
           {{- end }}
+        {{ end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubecostFrontend.enabled }}
 {{- if and (not .Values.agent) (not .Values.cloudAgent) }}
 {{- $serviceName := include "cost-analyzer.serviceName" . -}}
 {{- $nginxPort := .Values.service.targetPort | default 9090 -}}
@@ -332,4 +333,5 @@ data:
         }
         {{ end }}
     }
+{{- end }}
 {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -322,6 +322,7 @@ systemProxy:
 # - name: "image-pull-secret"
 
 kubecostFrontend:
+  enabled: true
   image: "gcr.io/kubecost1/frontend"
   imagePullPolicy: Always
   # extraEnv:
@@ -1179,5 +1180,3 @@ extraObjects: []
 #             host: kubecost.kubecost.svc.cluster.local
 #             port:
 #               number: 80
-
-


### PR DESCRIPTION
A frontend is not necessary in remote Kubecosts, so disabling allows us to cut some resources. In our setup we have a central Kubecost receiving data from all the remote Kubecost instances.

## What does this PR change?
Add an additional `kubecostFrontend.enabled` value that allows disabling the Kubecost frontend.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No, the change is fully backwards compatible. By default the component is enabled.

## Links to Issues or tickets this PR addresses or fixes
None
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
Rendering the helm chart with the default `values.yaml` should return the same result before and after this PR.
Disabling `kubecostFrontend.enabled` must allow the Kubecost instance to work seamlessly but with one fewer container.

## How was this PR tested?
Disabled the frontend and applied it in Kubernetes.

## Have you made an update to documentation? If so, please provide the corresponding PR.
I didn't find a relevant place where the documentation needs to be updated.
