### PR TITLE
[cherry-pick] `ETL_CLOUD_USAGE_ENABLED` disabled by default

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -787,7 +787,7 @@ spec:
             {{- else if kindIs "bool" .Values.kubecostModel.etlCloudAsset }}
               value: {{ (quote .Values.kubecostModel.etlCloudAsset) }}
             {{- else }}
-              value: "true"
+              value: "false"
             {{- end }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}


### PR DESCRIPTION
This is a cherry-pick of PR https://github.com/kubecost/cost-analyzer-helm-chart/pull/2532 into the v1.106 branch.