### PR TITLE
add ingress for model access

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Parameter | Description | Default
 `ingress.paths` | Ingress paths | `["/"]`
 `ingress.hosts` | Ingress hostnames | `[cost-analyzer.local]`
 `ingress.tls` | Ingress TLS configuration (YAML) | `[]`
+`kubecostModel.ingress.*` | Same as ingress.*, but will create an ingress directly to the model | `{ enabled: false }`
 `networkPolicy.enabled` | If true, create a NetworkPolicy to deny egress  | `false`
 `networkCosts.enabled` | If true, collect network allocation metrics [More info](http://docs.kubecost.com/network-allocation) | `false`
 `networkCosts.podMonitor.enabled` | If true, a [PodMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#podmonitor) for the network-cost daemonset is created | `false`

--- a/cost-analyzer/templates/model-ingress-template.yaml
+++ b/cost-analyzer/templates/model-ingress-template.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.kubecostModel.ingress -}}
+{{- if .Values.kubecostModel.ingress.enabled -}}
+{{- $fullName := include "cost-analyzer.fullname" . -}}
+{{- $serviceName := include "cost-analyzer.serviceName" . -}}
+{{- $ingressPaths := .Values.kubecostModel.ingress.paths -}}
+{{- $ingressPathType := .Values.kubecostModel.ingress.pathType -}}
+{{- $apiV1 := false -}}
+{{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare "^1.19-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-model
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+  {{- with .Values.kubecostModel.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.kubecostModel.ingress.className }}
+  ingressClassName: {{ .Values.kubecostModel.ingress.className }}
+{{- end }}
+{{- if .Values.kubecostModel.ingress.tls }}
+  tls:
+  {{- range .Values.kubecostModel.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.kubecostModel.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+        {{- range $ingressPaths }}
+          {{- if $apiV1 }}
+          - path: {{ . }}
+            pathType: {{ $ingressPathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  name: tcp-model
+          {{- else }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: tcp-model
+          {{- end }}
+        {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/model-ingress-template.yaml
+++ b/cost-analyzer/templates/model-ingress-template.yaml
@@ -19,6 +19,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- with .Values.kubecostModel.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.kubecostModel.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -534,21 +534,6 @@ ingress:
   #    hosts:
   #      - cost-analyzer.local
 
-apiIngress:
-  enabled: false
-  # className: nginx
-  annotations:
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  paths: ["/"] # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing
-  pathType: ImplementationSpecific
-  hosts:
-    - cost-analyzer.local
-  tls: []
-  #  - secretName: cost-analyzer-tls
-  #    hosts:
-  #      - cost-analyzer.local
-
 nodeSelector: {}
 
 tolerations: []

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -498,6 +498,22 @@ kubecostModel:
     failureThreshold: 200
   extraArgs: []
 
+  ingress:
+    enabled: false
+    # className: nginx
+    annotations:
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    paths: ["/"]
+    pathType: ImplementationSpecific
+    hosts:
+      - cost-analyzer-model.local
+    tls: []
+    #  - secretName: cost-analyzer-model-tls
+    #    hosts:
+    #      - cost-analyzer-model.local
+
+
 # Basic Kubecost ingress, more examples available at https://github.com/kubecost/docs/blob/main/ingress-examples.md
 ingress:
   enabled: false
@@ -505,6 +521,21 @@ ingress:
   labels:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  paths: ["/"] # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing
+  pathType: ImplementationSpecific
+  hosts:
+    - cost-analyzer.local
+  tls: []
+  #  - secretName: cost-analyzer-tls
+  #    hosts:
+  #      - cost-analyzer.local
+
+apiIngress:
+  enabled: false
+  # className: nginx
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -498,6 +498,7 @@ kubecostModel:
     failureThreshold: 200
   extraArgs: []
 
+  # creates an ingress directly to the model container, for API access
   ingress:
     enabled: false
     # className: nginx

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -502,6 +502,9 @@ kubecostModel:
   ingress:
     enabled: false
     # className: nginx
+    labels:
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
     annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
## What does this PR change?

This adds an optional kubecostModel.ingress option so that it can be configured separately from the frontend. This comes from a need in my company to expose the model through a basic auth ingress so that it can be accessed programatically, while the frontend is handled differently.

## Does this PR rely on any other PRs?

No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Adds an additional option (defaulting off) to have an ingress that points directly to the model container.

## Links to Issues or tickets this PR addresses or fixes

I haven't created any issues for this, should I create one?

## What risks are associated with merging this PR? What is required to fully test this PR?

Should be a pretty simple change; one deployment with it enabled and disabled should be enough IMO.

## How was this PR tested?

Tested locally and backported with no changes o the version currently in use by my company (1.102.2), which is deployed in my company's test cluster.

## Have you made an update to documentation? If so, please provide the corresponding PR.

Added `kubecostModel.ingress` to the README



This is my first contribution to the project, if there's any additional information or changes needed, do comment!