### PR TITLE
securityContexts for sigv4 container

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -350,6 +350,10 @@ spec:
           {{- else }}
           imagePullPolicy: Always
           {{- end }}
+        {{- if .Values.global.containerSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 -}}
+        {{- end }}
           args:
           - --name
           - {{ .Values.sigV4Proxy.name }}


### PR DESCRIPTION
## What does this PR change?

add contianerSecurityContexts for sigv4 proxy, 

which was missed here: https://github.com/kubecost/cost-analyzer-helm-chart/pull/2493
