### PR TITLE
Enables Dependabot to scan all `yaml` files for outdated images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
     rebase-strategy: disabled
+  - package-ecosystem: "docker"
+    directory: "/cost-analyzer"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/cost-analyzer/charts/grafana"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/cost-analyzer/charts/prometheus"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/cost-analyzer/charts/thanos"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-  - package-ecosystem: "docker"
-    directory: "/cost-analyzer"
+      interval: weekly
+    rebase-strategy: disabled
+  - package-ecosystem: docker
+    directory: /cost-analyzer
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/cost-analyzer/charts/grafana"
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /cost-analyzer/charts/grafana
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/cost-analyzer/charts/prometheus"
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /cost-analyzer/charts/prometheus
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/cost-analyzer/charts/thanos"
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /cost-analyzer/charts/thanos
     schedule:
-      interval: "weekly"
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    rebase-strategy: disabled
+    rebase-strategy: "disabled"
   - package-ecosystem: "docker"
     directory: "/cost-analyzer"
     schedule:


### PR DESCRIPTION
## What does this PR change?

- Updates Dependabot configuration to look for outdated container images
- Dependabot will scan all `yaml` files at the described directories
- Example shown in my fork: https://github.com/thomasvn/cost-analyzer-helm-chart/pulls

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- None

## Links to Issues or tickets this PR addresses or fixes

- None

## What risks are associated with merging this PR? What is required to fully test this PR?

- No risks. Dependabot will create PRs to this repo, but all PRs will still be manually tested & merged.

## How was this PR tested?

- Example shown in my fork: https://github.com/thomasvn/cost-analyzer-helm-chart/pulls

## Have you made an update to documentation? If so, please provide the corresponding PR.

- Not needed