### PR TITLE
Bump to `kubecost-network-costs:v0.16.8`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
     rebase-strategy: disabled
+  - package-ecosystem: "docker"
+    directory: "/cost-analyzer"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/cost-analyzer/charts/grafana"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/cost-analyzer/charts/prometheus"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/cost-analyzer/charts/thanos"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-  - package-ecosystem: "docker"
-    directory: "/cost-analyzer"
+      interval: weekly
+    rebase-strategy: disabled
+  - package-ecosystem: docker
+    directory: /cost-analyzer
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/cost-analyzer/charts/grafana"
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /cost-analyzer/charts/grafana
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/cost-analyzer/charts/prometheus"
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /cost-analyzer/charts/prometheus
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/cost-analyzer/charts/thanos"
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /cost-analyzer/charts/thanos
     schedule:
-      interval: "weekly"
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    rebase-strategy: disabled
+    rebase-strategy: "disabled"
   - package-ecosystem: "docker"
     directory: "/cost-analyzer"
     schedule:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -730,7 +730,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v0.16.7
+  image: gcr.io/kubecost1/kubecost-network-costs:v0.16.8
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
## What does this PR change?

- Bump image version for kubecost-network-costs
- New image version was published to mitigate CVEs found in vulnerability scans

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Users who have network costs enabled will be downloading this new image

## Links to Issues or tickets this PR addresses or fixes

- Closes https://kubecost.atlassian.net/browse/GTM-70
- Related to https://github.com/kubecost/kubecost-network-costs/pull/35

## What risks are associated with merging this PR? What is required to fully test this PR?

- Few risks. The new image only updates a few dependencies.

## How was this PR tested?

- `docker pull gcr.io/kubecost1/kubecost-network-costs:v0.16.8` to ensure this image was available for use
- No further testing performed. Let me know if you believe we should though.

## Have you made an update to documentation? If so, please provide the corresponding PR.

- Not needed.