### PR TITLE
Default disable KSM

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -671,11 +671,14 @@ prometheus:
   # node-export must be disabled if there is an existing daemonset: https://guide.kubecost.com/hc/en-us/articles/4407601830679-Troubleshoot-Install#a-name-node-exporter-a-issue-failedscheduling-kubecost-prometheus-node-exporter
   nodeExporter:
     enabled: true
-  # kubecost emits pre-2.0 KSM metrics, KSM is enabled by default here for backwards compatibility, but can be disabled to save resources without concern to kubecost metrics
+
+  ## Default disabled since Kubecost already emits KSMv1 metrics.
+  ## Ref: https://docs.kubecost.com/architecture/ksm-metrics
   kubeStateMetrics:
-    enabled: true
+    enabled: false
   kube-state-metrics:
-    disabled: false
+    disabled: true
+
   pushgateway:
     enabled: false
     persistentVolume:


### PR DESCRIPTION
## What does this PR change?

Proposal to default disable kube-state-metrics (KSM) for all users moving forward. Users still have the option to enable the bundled KSM if they choose.

This has the advantage of simplifying the user's install process, and reducing likelihood they would need to troubleshoot Prometheus metrics during install. Especially in cases where users already have KSM running in their environment. And especially in cases where users are bringing their own Prometheus which already houses some KSMv2 metrics.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Kubecost's bundled kube-state-metrics deployment is now disabled by default.

## Links to Issues or tickets this PR addresses or fixes

None

## What risks are associated with merging this PR? What is required to fully test this PR?

Low risk. We do not lose anything significant when KSM is disabled. Users are able to re-enable Kubecost's bundled KSM if they wish.

Note, that this change impacts users who are intentionally running Kubecost's bundled KSM for the purposes of higher availability metrics. I suggest we widely announce the default disabling of KSM in release notes.

## How was this PR tested?

Running Kubecost without KSM has been common practice and tested for many releases now. It is also what is recommended in the [poc-common-configurations repo](https://github.com/kubecost/poc-common-configurations/blob/f20fc36ea1dea1dae782aefa64ff7f62cb2eec07/etl-federation/primary-federator.yaml#L29-L35).

## Have you made an update to documentation? If so, please provide the corresponding PR.

https://github.com/kubecost/docs/pull/752
