### PR TITLE
Update AMP endpoint's path in config

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -46,7 +46,7 @@ global:
   # Amazon Managed Service for Prometheus
   amp:
     enabled: false # If true, kubecost will be configured to remote_write and query from Amazon Managed Service for Prometheus.
-    prometheusServerEndpoint: https://localhost:8085/<workspaceId>/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the SigV4Proxy side car to the AMP workspace.
+    prometheusServerEndpoint: https://localhost:8085/workspaces/<workspaceId>/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the SigV4Proxy side car to the AMP workspace.
     remoteWriteService: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspaceId>/api/v1/remote_write # The remote_write endpoint for the AMP workspace.
     sigv4:
       region: us-west-2


### PR DESCRIPTION
## What does this PR change?

Updates the path for `.Values.global.amp.prometheusServerEndpoint` to match the configuration described in our docs

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Added clarity

## Links to Issues or tickets this PR addresses or fixes

Closes https://kubecost.atlassian.net/browse/GTM-96

## What risks are associated with merging this PR? What is required to fully test this PR?

None

## How was this PR tested?

None

## Have you made an update to documentation? If so, please provide the corresponding PR.

This PR brings the `values.yaml` file in accordance with the existing doc https://docs.kubecost.com/install-and-configure/install/custom-prom/aws-amp-integration