### PR TITLE
fix(cost-analyzer): Set remoreWrite env variables only when enabled

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -656,11 +656,11 @@ spec:
               value: {{ (quote .Values.kubecostProductConfigs.regionOverrides) }}
             {{- end }}
             {{- end }}
-            - name: REMOTE_WRITE_PASSWORD
-              value: {{ .Values.remoteWrite.postgres.auth.password }}
             {{- if .Values.remoteWrite.postgres.enabled }}
             - name: REMOTE_WRITE_ENABLED
               value: "true"
+            - name: REMOTE_WRITE_PASSWORD
+              value: {{ .Values.remoteWrite.postgres.auth.password }}
             {{- end }}
             {{- if .Values.global.thanos.queryServiceBasicAuthSecretName}}
             - name: MC_BASIC_AUTH_USERNAME


### PR DESCRIPTION
## What does this PR change?
`REMOTE_WRITE_PASSWORD` environmental variable will be set only if `remoteWrite.postgres` is enabled.


## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

There will be no impact since setting `REMOTE_WRITE_PASSWORD` is not really used if `remoteWrite.postgres` is 
not enabled.

## Links to Issues or tickets this PR addresses or fixes

https://github.com/kubecost/cost-analyzer-helm-chart/issues/2409

## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Only local rendering was tested.

## Have you made an update to documentation? If so, please provide the corresponding PR.

