### PR TITLE
Re-add the `useMultiClusterDB` helm config

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -790,6 +790,10 @@ spec:
             - name: FEDERATED_REDIRECT_BACKUP
               value: "true"
             {{- end}}
+            {{- if .Values.federatedETL.useMultiClusterDB }}
+            - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
+              value: "true"
+            {{- end }}
             - name: ETL_STORE_READ_ONLY
               value: {{ (quote .Values.kubecostModel.etlStoreReadOnly) | default (quote false) }}
             - name : ETL_CLOUD_USAGE_ENABLED


### PR DESCRIPTION
## What does this PR change?

- Re-add the `.Values.federatedETL.useMultiClusterDB` config to `cost-analyzer-deployment-template.yaml`
- It was first introduced in PR #2340 
- It was incorrectly removed by PR #2438 

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- The config `.Values.federatedETL.useMultiClusterDB` was not available to users in v1.105.x and v1.106.0. This PR fixes that.

## Links to Issues or tickets this PR addresses or fixes

- None.

## What risks are associated with merging this PR? What is required to fully test this PR?

- No risks. However, we should validate that a Federated ETL + centralized Prom architecture remains functional after re-introducing this config.

## How was this PR tested?

```yaml
federatedETL:
  useMultiClusterDB: true
```

```sh
$ helm template ./cost-analyzer -f values.yaml
...
            - name: ETL_ENABLED
              value: "true"
            - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
              value: "true"
            - name: ETL_STORE_READ_ONLY
              value: "false"
...
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

- Not yet. Potentially add more docs about this config here https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl.

