### PR TITLE
Adds/fixes templating of global.podAnnotations

### DIFF
--- a/cost-analyzer/templates/awsstore-deployment-template.yaml
+++ b/cost-analyzer/templates/awsstore-deployment-template.yaml
@@ -20,6 +20,10 @@ spec:
     metadata:
       labels:
         app: awsstore
+      {{- with .Values.global.podAnnotations}}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: awsstore-serviceaccount
       {{- if .Values.awsstore.priorityClassName }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -44,12 +44,10 @@ spec:
         {{- if and .Values.kubecostDeployment .Values.kubecostDeployment.labels }}
         {{- toYaml .Values.kubecostDeployment.labels | nindent 8 }}
         {{- end }}
-{{- if .Values.global.podAnnotations}}
+      {{- with .Values.global.podAnnotations}}
       annotations:
-{{- with .Values.global.podAnnotations }}
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.kubecostFrontend.tls }}
       {{- if .Values.kubecostFrontend.tls.enabled }}

--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -19,6 +19,10 @@ spec:
     metadata:
       labels:
         {{- include "federator.selectorLabels" . | nindent 8 }}
+      {{- with .Values.global.podAnnotations}}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.global.securityContext }}
       securityContext:

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -32,12 +32,10 @@ spec:
 {{- with .Values.kubecostMetrics.exporter.labels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- if .Values.global.podAnnotations }}
+      {{- with .Values.global.podAnnotations}}
       annotations:
-{{- with .Values.global.podAnnotations }}
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.kubecostFrontend.tls }}
       {{- if .Values.kubecostFrontend.tls.enabled }}

--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -38,6 +38,10 @@ spec:
         app.kubernetes.io/name: query-service
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: query-service
+      {{- with .Values.global.podAnnotations}}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: Always
       {{- if .Values.kubecostDeployment.queryService.securityContext }}


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

* Fixes templating instances where `global.podAnnotations` was not being correctly applied when the map had greater than one entry:
  * cost-analyzer/templates/cost-analyzer-deployment-template.yaml
  * cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
* Adds this as a template to several other Deployment templates (yet none in the sub-charts):
  * cost-analyzer/templates/awsstore-deployment-template.yaml
  * cost-analyzer/templates/federator-deployment-template.yaml
  * cost-analyzer/templates/query-service-deployment-template.yaml

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

* Allows users to specify a proper map as the value of `global.podAnnotations` and have that rendered for existing Deployment templates.
* Allows users to have these global annotations applied to more Deployments including Federator, AWS store, Kubecost metrics, and Query Service

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

[KC-100](https://kubecost.atlassian.net/jira/polaris/projects/KC/ideas/view/2936873?selectedIssue=KC-100) (Kubecost internal Jira ticket)

## What risks are associated with merging this PR? What is required to fully test this PR?

Templating may not work if `global.podAnnotations` is specified or with a map with greater than a single entry.

## How was this PR tested?

Tested locally by templating with all the various option flags enabled to ensure a single and a full map is rendered correctly.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A


[KC-100]: https://kubecost.atlassian.net/browse/KC-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ