### PR TITLE
[cherry-pick] Bump to `kubecost-network-costs:v0.16.8` (#2558)

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -716,7 +716,7 @@ networkCosts:
   enabled: false
   podSecurityPolicy:
     enabled: false
-  image: gcr.io/kubecost1/kubecost-network-costs:v0.16.7
+  image: gcr.io/kubecost1/kubecost-network-costs:v0.16.8
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
Cherry-pick of PR https://github.com/kubecost/cost-analyzer-helm-chart/pull/2558