### PR TITLE
updated grafana dashboard to match queries used by kubecost

### DIFF
--- a/cost-analyzer/attached-disks.json
+++ b/cost-analyzer/attached-disks.json
@@ -112,7 +112,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(container_fs_limit_bytes{instance=~'$disk', device!=\"tmpfs\", id=\"/\", cluster_id=~'$cluster'}) by (cluster_id, instance)",
+          "expr": "max(container_fs_limit_bytes{instance=~'$disk', device!=\"tmpfs\", id=\"/\", cluster_id=~'$cluster'}) by (cluster_id, instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -209,7 +209,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(container_fs_usage_bytes{instance=~'$disk',id=\"/\", cluster_id=~'$cluster'}) by (cluster_id, instance) / sum(container_fs_limit_bytes{instance=~'$disk',device!=\"tmpfs\", id=\"/\", cluster_id=~'$cluster'}) by (cluster_id,instance)",
+          "expr": "sum(container_fs_usage_bytes{instance=~'$disk',id=\"/\", cluster_id=~'$cluster'}) by (cluster_id, instance) / max(container_fs_limit_bytes{instance=~'$disk',device!=\"tmpfs\", id=\"/\", cluster_id=~'$cluster'}) by (cluster_id,instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
## What does this PR change?
Updates grafana dashboard linked to from local disks savings page to more accurately reflect the queries used by ETL specifically for disk utilization

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users should see a more accurate disk utilization graph in grafana

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
https://kubecost.atlassian.net/browse/GTM-86


## What risks are associated with merging this PR? What is required to fully test this PR?
Should be very low risk, if any. We would want to verify that the disk utilization graph in grafana uses the updated values

## How was this PR tested?
Verified that our grafana dashboard for disk utilization uses the correct math that we use with ETL. Tested on aws-test cluster

## Have you made an update to documentation? If so, please provide the corresponding PR.

