### PR TITLE
add /savings/abandonedWorkloads proxy route for front end in waterfowl 

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -480,6 +480,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/savings/abandonedWorkloads {
+            proxy_read_timeout          300;
+            proxy_pass http://waterfowl/savings/abandonedWorkloads;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
     {{- end }}
     {{- if .Values.waterfowl.cloudCost.enabled }}
         location = /model/cloudCost/status {


### PR DESCRIPTION
## What does this PR change?
Adds the end point proxy route for waterfowl in front end config map

## Does this PR rely on any other PRs?
[1785](https://github.com/kubecost/kubecost-cost-model/pull/1785)

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Get the end point details from waterfowl DB

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
-

## How was this PR tested?
-

## Have you made an update to documentation? If so, please provide the corresponding PR.
-
