### PR TITLE
skip online validation helm value

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -925,8 +925,8 @@ spec:
             {{- if .Values.oidc.enabled }}
             - name: OIDC_ENABLED
               value: "true"
-            - name: OIDC_SKIP_TOKEN_VALIDATION
-              value: {{ .Values.oidc.skipOnlineTokenValidation }}
+            - name: OIDC_SKIP_ONLINE_VALIDATION
+              value: {{ (quote .Values.oidc.skipOnlineTokenValidation) | default (quote false) }}
             {{- end}}
             {{- if .Values.saml }}
             {{- if .Values.saml.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -925,6 +925,8 @@ spec:
             {{- if .Values.oidc.enabled }}
             - name: OIDC_ENABLED
               value: "true"
+            - name: OIDC_SKIP_TOKEN_VALIDATION
+              value: {{ .Values.oidc.skipOnlineTokenValidation }}
             {{- end}}
             {{- if .Values.saml }}
             {{- if .Values.saml.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -19,7 +19,7 @@ data:
         "loginRedirectURL" : "{{ .Values.oidc.loginRedirectURL }}",
         "discoveryURL" : "{{ .Values.oidc.discoveryURL }}",
         "hostedDomain" : "{{ .Values.oidc.hostedDomain }}",
-        "skipOnlineTokenValidation" : "{{ .Values.oidc.skipOnlineTokenValidation }}",
+        "skipOnlineTokenValidation" : "{{ .Values.oidc.skipOnlineTokenValidation | default "false" }}",
         "rbac" : {
           "enabled" : {{ .Values.oidc.rbac.enabled }},
           "groups" : [

--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -19,6 +19,7 @@ data:
         "loginRedirectURL" : "{{ .Values.oidc.loginRedirectURL }}",
         "discoveryURL" : "{{ .Values.oidc.discoveryURL }}",
         "hostedDomain" : "{{ .Values.oidc.hostedDomain }}",
+        "skipOnlineTokenValidation" : "{{ .Values.oidc.skipOnlineTokenValidation }}",
         "rbac" : {
           "enabled" : {{ .Values.oidc.rbac.enabled }},
           "groups" : [

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -289,7 +289,7 @@ oidc:
   authURL: "https://my.auth.server/authorize" # endpoint for login to auth server
   loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
   discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
-  skipOnlineTokenValidation: false # allows oidc to validate the token offline
+  skipOnlineTokenValidation: false # if true, will skip accessing OIDC introspection endpoint for online token verification, and instead try to locally validate JWT claims
 #  hostedDomain: "example.com" # optional, blocks access to the auth domain specified in the hd claim of the provider ID token
   rbac:
     enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -289,6 +289,7 @@ oidc:
   authURL: "https://my.auth.server/authorize" # endpoint for login to auth server
   loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
   discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
+  skipOnlineTokenValidation: false # allows oidc to validate the token offline
 #  hostedDomain: "example.com" # optional, blocks access to the auth domain specified in the hd claim of the provider ID token
   rbac:
     enabled: false


### PR DESCRIPTION
## What does this PR change?
Adds helm value to skip online OIDC token validation

## Does this PR rely on any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/1786

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can pass in an environment variable that will allow OIDC tokens to skip online validation steps. These tokens will still be verified for authenticity.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
* https://kubecost.atlassian.net/browse/SELFHOST-304


## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Tested on `aws-test`, confirmed that the env vars go through and affect the expected functions in KCM.

## Have you made an update to documentation? If so, please provide the corresponding PR.
https://github.com/kubecost/docs/pull/740
