### PR TITLE
Federator pod volume var config

### DIFF
--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -52,6 +52,8 @@ spec:
               containerPort: 9001
               protocol: TCP
           volumeMounts:
+            - name: persistent-configs
+              mountPath: /var/configs
             - name: federator-config
               mountPath: /var/configs/federator
             - name: federated-storage-config
@@ -76,7 +78,7 @@ spec:
               value: /var/db/
             {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
             - name: FEDERATED_STORE_CONFIG
-              value: "/var/configs/etl/federated/federated-store.yaml"
+              value: /var/configs/etl/federated/federated-store.yaml
             {{- end }}
             {{- if .Values.federatedETL.federator.extraEnv }}
             {{- toYaml .Values.federatedETL.federator.extraEnv | nindent 12 }}
@@ -84,18 +86,25 @@ spec:
       restartPolicy: Always
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       volumes:
-        - name: federator-config
-          configMap:
-            name: {{ template "cost-analyzer.fullname" . }}-federator
-        {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
-        - name: federated-storage-config
-          secret:
-            defaultMode: 420
-            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
-        {{- end }}
-        {{- if .Values.federatedETL.federator.extraVolumes }}
-        {{- toYaml .Values.federatedETL.federator.extraVolumes | nindent 8 }}
-        {{- end }}
+      - name: persistent-configs
+      {{- if .Values.persistentVolume.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "federator.fullname" . }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      - name: federator-config
+        configMap:
+          name: {{ template "cost-analyzer.fullname" . }}-federator
+      {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+      - name: federated-storage-config
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
+      {{- end }}
+      {{- if .Values.federatedETL.federator.extraVolumes }}
+      {{- toYaml .Values.federatedETL.federator.extraVolumes | nindent 8 }}
+      {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}

--- a/cost-analyzer/templates/federator-pvc-template.yaml
+++ b/cost-analyzer/templates/federator-pvc-template.yaml
@@ -1,0 +1,33 @@
+{{- if and (.Values.federatedETL.federator) (.Values.federatedETL.federator.enabled) }}
+{{- if .Values.persistentVolume -}}
+{{- if .Values.persistentVolume.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "federator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- with .Values.persistentVolume.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.persistentVolume.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistentVolume.storageClass }}
+  storageClassName: {{ .Values.persistentVolume.storageClass }}
+  {{ end }}
+  resources:
+    requests:
+    {{- if .Values.persistentVolume }}
+      storage: {{ .Values.persistentVolume.size }}
+    {{- else }}
+      storage: 32.0Gi
+    {{ end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## What does this PR change?
adds PVC to federator pod

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Create a PV for federator pod to reduce the likelihood of needing to pull 90d of data from s3 if the pod is rescheduled on a different node.

## What risks are associated with merging this PR? What is required to fully test this PR?
None that I can think of. This change follows the same deployment standard as cost-analyzer pod.

## How was this PR tested?
Helm installs with and without `--set persistentVolume.enabled=false`

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA, follows same model as cost-analyzer
