### PR TITLE
feat: working oidc custom secret

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -248,15 +248,15 @@ spec:
         - name: oidc-config
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-oidc
-        {{- if and (not .Values.oidc.customSecret.enabled) .Values.oidc.secretName }}
+        {{- if and (not .Values.oidc.existingCustomSecret.enabled) .Values.oidc.secretName }}
         - name: oidc-client-secret
           secret:
             secretName: {{ .Values.oidc.secretName }}
         {{- end }}
-        {{- if .Values.oidc.customSecret.enabled }}
+        {{- if .Values.oidc.existingCustomSecret.enabled }}
         - name: oidc-client-secret
           secret:
-            secretName: {{ .Values.oidc.customSecret.name }}
+            secretName: {{ .Values.oidc.existingCustomSecret.name }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -248,10 +248,15 @@ spec:
         - name: oidc-config
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-oidc
-        {{- if .Values.oidc.secretName }}
+        {{- if and (not .Values.oidc.customSecret.enabled) .Values.oidc.secretName }}
         - name: oidc-client-secret
           secret:
             secretName: {{ .Values.oidc.secretName }}
+        {{- end }}
+        {{- if .Values.oidc.customSecret.enabled }}
+        - name: oidc-client-secret
+          secret:
+            secretName: {{ .Values.oidc.customSecret.name }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -14,8 +14,8 @@ data:
         "enabled" : {{ .Values.oidc.enabled }},
         "useIDToken" : {{ .Values.oidc.useIDToken | default "false" }},
         "clientID" : "{{ .Values.oidc.clientID }}",
-        {{- if .Values.oidc.customSecret.enabled }}
-        "secretName" : "{{ .Values.oidc.customSecret.name }}",
+        {{- if .Values.oidc.existingCustomSecret.enabled }}
+        "secretName" : "{{ .Values.oidc.existingCustomSecret.name }}",
         {{- else }}
         "secretName" : "{{ .Values.oidc.secretName }}",
         {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -14,7 +14,11 @@ data:
         "enabled" : {{ .Values.oidc.enabled }},
         "useIDToken" : {{ .Values.oidc.useIDToken | default "false" }},
         "clientID" : "{{ .Values.oidc.clientID }}",
+        {{- if .Values.oidc.customSecret.enabled }}
+        "secretName" : "{{ .Values.oidc.customSecret.name }}",
+        {{- else }}
         "secretName" : "{{ .Values.oidc.secretName }}",
+        {{- end }}
         "authURL" : "{{ .Values.oidc.authURL }}",
         "loginRedirectURL" : "{{ .Values.oidc.loginRedirectURL }}",
         "discoveryURL" : "{{ .Values.oidc.discoveryURL }}",

--- a/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.oidc }}
-{{- if .Values.oidc.secretName }}
+{{- if and (not .Values.oidc.customSecret.enabled) .Values.oidc.secretName }}
 {{- if .Values.oidc.clientSecret }}
 apiVersion: v1
 kind: Secret

--- a/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.oidc }}
-{{- if and (not .Values.oidc.customSecret.enabled) .Values.oidc.secretName }}
+{{- if and (not .Values.oidc.existingCustomSecret.enabled) .Values.oidc.secretName }}
 {{- if .Values.oidc.clientSecret }}
 apiVersion: v1
 kind: Secret

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -286,6 +286,10 @@ oidc:
   clientID: "" # application/client client_id parameter obtained from provider, used to make requests to server
   clientSecret: "" # application/client client_secret parameter obtained from provider, used to make requests to server
   secretName: "kubecost-oidc-secret" # k8s secret where clientsecret will be stored
+  customSecret:
+    enabled: false
+    name: "" # name of the secret containing the client secret
+
   authURL: "https://my.auth.server/authorize" # endpoint for login to auth server
   loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
   discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -286,6 +286,9 @@ oidc:
   clientID: "" # application/client client_id parameter obtained from provider, used to make requests to server
   clientSecret: "" # application/client client_secret parameter obtained from provider, used to make requests to server
   secretName: "kubecost-oidc-secret" # k8s secret where clientsecret will be stored
+  # For use to provide a custom OIDC Secret. Overrides the usage of oidc.clientSecret and oidc.secretName.
+  # Should contain the field directly.
+  # Can be created using raw k8s secrets, external secrets, sealed secrets, or any other method.
   existingCustomSecret:
     enabled: false
     name: "" # name of the secret containing the client secret

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -286,7 +286,7 @@ oidc:
   clientID: "" # application/client client_id parameter obtained from provider, used to make requests to server
   clientSecret: "" # application/client client_secret parameter obtained from provider, used to make requests to server
   secretName: "kubecost-oidc-secret" # k8s secret where clientsecret will be stored
-  customSecret:
+  existingCustomSecret:
     enabled: false
     name: "" # name of the secret containing the client secret
 


### PR DESCRIPTION
## What does this PR change?

Enables the use of a custom secret. There is an alternative implementation we could take which would use the oidc.secretName for both the custom and non-custom secret. Currently they are two distinct values.

Fixes: #2612

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows the use of a variety of secret sources for the OIDC ClientSecret, including but not limited too:
- ExternalSecrets
- Vault
- SealedSecrets
- SOPs


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

## What risks are associated with merging this PR? What is required to fully test this PR?

The following iterations test it (though I recommend actually writing tests for the chart using helm-unittest).

Default OIDC behavior: 

```yaml
oidc:
  enabled: true
  clientID: "" # application/client client_id parameter obtained from provider, used to make requests to server
  clientSecret: "" # application/client client_secret parameter obtained from provider, used to make requests to server
  secretName: "kubecost-oidc-secret" # k8s secret where clientsecret will be stored
  customSecret:
    enabled: false
    name: "" # name of the secret containing the client secret
```

Enable Custom Secret

```yaml
oidc:
  enabled: true
  clientID: "" # application/client client_id parameter obtained from provider, used to make requests to server
  clientSecret: "" # application/client client_secret parameter obtained from provider, used to make requests to server
  secretName: "kubecost-oidc-secret" # k8s secret where clientsecret will be stored
  customSecret:
    enabled: true
    name: "testing-oidc" # name of the secret containing the client secret
```


## How was this PR tested?

With the above yamls


## Have you made an update to documentation? If so, please provide the corresponding PR.

