### PR TITLE
Add /reports proxy to Waterfowl (based off the right branch this time)

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -488,6 +488,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/reports {
+            proxy_read_timeout          300;
+            proxy_pass http://waterfowl/reports;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
     {{- end }}
     {{- if .Values.waterfowl.cloudCost.enabled }}
         location = /model/cloudCost/status {

--- a/cost-analyzer/templates/waterfowl-deployment.yaml
+++ b/cost-analyzer/templates/waterfowl-deployment.yaml
@@ -167,6 +167,8 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
             {{- end }}
+            - name: KUBECOST_NAMESPACE
+              value: {{ .Release.Namespace }}
 
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## What does this PR change?
* Adds a proxy for the various `/report` endpoints in Waterfowl.

## Does this PR rely on any other PRs?
* [Yup yup](https://github.com/kubecost/kubecost-cost-model/pull/1798).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Scheduled reports will now query DuckDB instead of ETL.

## Links to Issues or tickets this PR addresses or fixes
* Addresses [this ticket](https://kubecost.atlassian.net/browse/SELFHOST-312).

## What risks are associated with merging this PR? What is required to fully test this PR?
* Any risks associated with this would relate to the underlying queries done to gather the report data. So, if we trust the underlying DuckDB queries, we can trust these reports.

## How was this PR tested?
* See the accompanying PR for testing notes.

## Have you made an update to documentation? If so, please provide the corresponding PR.
* I have not.