### PR TITLE
Add WATERFOWL_ENABLED env var to cost analyzer deployment

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -1043,6 +1043,10 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: kubecost-token
+            {{- if and (.Values.waterfowl) (gt (.Values.waterfowl.replicas | toString | atoi) 0) }}
+            - name: WATERFOWL_ENABLED
+              value: "true"
+            {{- end }}
         {{- if .Values.kubecostFrontend }}
         {{- if .Values.kubecostFrontend.fullImageName }}
         - image: {{ .Values.kubecostFrontend.fullImageName }}


### PR DESCRIPTION
## What does this PR change?
* Adds `WATERFOWL_ENABLED` to the cost analyzer deployment, allowing for configuration based on the enablement of Waterfowl.

## Does this PR rely on any other PRs?
* [It does indeed](https://github.com/kubecost/kubecost-cost-model/pull/1803).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* It won't directly impact users, but it will allow for more configuration by developers.

## What risks are associated with merging this PR? What is required to fully test this PR?
* Next to no risks, we're only adding an environment variable.

## How was this PR tested?
* Deployed to dev-1, confirmed that the environment variable is set when Waterfowl is enabled.