### PR TITLE
Add /budgets proxies for Waterfowl

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -496,6 +496,22 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/budget {
+            proxy_read_timeout          300;
+            proxy_pass http://waterfowl/budget;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/budgets {
+            proxy_read_timeout          300;
+            proxy_pass http://waterfowl/budgets;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
     {{- end }}
     {{- if .Values.waterfowl.cloudCost.enabled }}
         location = /model/cloudCost/status {

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -488,10 +488,52 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location = /model/reports {
+        location = /model/reports/allocation {
             proxy_read_timeout          300;
-            proxy_pass http://waterfowl/reports;
+            proxy_pass http://waterfowl/reports/allocation;
             proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/reports/asset {
+            proxy_read_timeout          300;
+            proxy_pass http://waterfowl/reports/asset;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/reports/advanced {
+            proxy_read_timeout          300;
+            proxy_pass http://waterfowl/reports/advanced;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/reports/cloudCost {
+            proxy_read_timeout          300;
+            proxy_pass http://waterfowl/reports/cloudCost;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/reports/group {
+            proxy_read_timeout          300;
+            proxy_pass http://waterfowl/reports/group;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        # this is a special case to handle /reports/group/:group in waterfowl. prior to waterfowl, this endpoint
+        # was handled by /model/, so no special case proxies were required. without this, /model/reports/groups/?foo=bar
+        # will be directed to /reports/groups?foo=bar (note the missing /model prefix)
+        location ~ ^/model/reports/group/ {
+            proxy_read_timeout          300;
+            proxy_pass http://waterfowl/reports/group/$is_args$args;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## What does this PR change?
- The initial primary purpose of this PR was to add `/budget(s)` proxies for Waterfowl. But after further testing, it was discovered that the `/reports` endpoints don't function as expected. So most of the changes here relate to those endpoints.

## Does this PR rely on any other PRs?
- [Yup yup](https://github.com/kubecost/kubecost-cost-model/pull/1808).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- `/budget(s)` endpoints will be backed by DuckDB instead of ETL.
- `/reports` endpoints will be properly handled.

## Links to Issues or tickets this PR addresses or fixes
- Closes [SELFHOST-321](https://kubecost.atlassian.net/browse/SELFHOST-321).

## What risks are associated with merging this PR? What is required to fully test this PR?
- `/budget(s)` and `/reports` endpoints should be fully tested, in particular [these endpoints](https://github.com/kubecost/kubecost-cost-model/blob/b9839a7b19d9621f5776f15895fe889c5be423b2/pkg/cmd/waterfowl/waterfowl.go#L269-L273).

## How was this PR tested?
- Verified that /budget(s) endpoints are proxied to Waterfowl.
- Verified that /budget(s) endpoints function as expected.

## Have you made an update to documentation? If so, please provide the corresponding PR.



[SELFHOST-321]: https://kubecost.atlassian.net/browse/SELFHOST-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ