### PR TITLE
Adds documentation for the Kubecost Admission Controller

### DIFF
--- a/cost-analyzer/scripts/create-admission-controller-tls.sh
+++ b/cost-analyzer/scripts/create-admission-controller-tls.sh
@@ -1,23 +1,21 @@
 #!/bin/bash
 
 namespace=$1
-if [ "$namespace" == "" ]; then
+if [[ "${namespace}" == "" ]]; then
   namespace=kubecost
 fi
-
-DIRECTORY=$(cd `dirname $0` && pwd)
 
 echo -e "\nCreating certificates ..."
 mkdir certs
 openssl genrsa -out certs/tls.key 2048
-openssl req -new -key certs/tls.key -out certs/tls.csr -subj "/CN=webhook-server.$namespace.svc"
-openssl x509 -req -days 500 -extfile <(printf "subjectAltName=DNS:webhook-server.$namespace.svc") -in certs/tls.csr -signkey certs/tls.key -out certs/tls.crt
+openssl req -new -key certs/tls.key -out certs/tls.csr -subj "/CN=webhook-server.${namespace}.svc"
+openssl x509 -req -days 500 -extfile <(printf "subjectAltName=DNS:webhook-server.%s.svc" "${namespace}") -in certs/tls.csr -signkey certs/tls.key -out certs/tls.crt
 
 echo -e "\nCreating Webhook Server TLS Secret ..."
 kubectl create secret tls webhook-server-tls \
     --cert "certs/tls.crt" \
-    --key "certs/tls.key" -n $namespace
+    --key "certs/tls.key" -n "${namespace}"
 
 echo -e "\nUpdating values.yaml ..."
-ENCODED_CA=$(cat certs/tls.crt | base64 | tr -d '\n')
-sed -i '' 's@${CA_BUNDLE}@'"$ENCODED_CA"'@g' ../values.yaml
+ENCODED_CA=$(base64 < certs/tls.crt | tr -d '\n')
+sed -i '' 's@${CA_BUNDLE}@'"${ENCODED_CA}"'@g' ../values.yaml

--- a/cost-analyzer/scripts/create-admission-controller-tls.sh
+++ b/cost-analyzer/scripts/create-admission-controller-tls.sh
@@ -7,18 +7,17 @@ fi
 
 DIRECTORY=$(cd `dirname $0` && pwd)
 
-echo "Creating certificates"
+echo -e "\nCreating certificates ..."
 mkdir certs
 openssl genrsa -out certs/tls.key 2048
 openssl req -new -key certs/tls.key -out certs/tls.csr -subj "/CN=webhook-server.$namespace.svc"
 openssl x509 -req -days 500 -extfile <(printf "subjectAltName=DNS:webhook-server.$namespace.svc") -in certs/tls.csr -signkey certs/tls.key -out certs/tls.crt
 
-echo "Creating Webhook Server TLS Secret"
+echo -e "\nCreating Webhook Server TLS Secret ..."
 kubectl create secret tls webhook-server-tls \
     --cert "certs/tls.crt" \
     --key "certs/tls.key" -n $namespace
 
-
-echo "Updating values.yaml"
+echo -e "\nUpdating values.yaml ..."
 ENCODED_CA=$(cat certs/tls.crt | base64 | tr -d '\n')
-sed -i 's@${CA_BUNDLE}@'"$ENCODED_CA"'@g' ../values.yaml
+sed -i '' 's@${CA_BUNDLE}@'"$ENCODED_CA"'@g' ../values.yaml

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1085,8 +1085,15 @@ federatedETL:
       #   cpu: 100m
       #   memory: 500Mi
 
+## Kubecost Admission Controller (beta feature)
+## To use this feature, ensure you have run the `create-admission-controller.sh`
+## script. This generates a k8s secret with TLS keys/certificats and a
+## corresponding CA bundle.
+## 
 kubecostAdmissionController:
   enabled: false
+  secretName: webhook-server-tls
+  caBundle: ${CA_BUNDLE}
 
 # Enables or disables the Cost Event Audit pipeline, which tracks recent changes at cluster level
 # and provides an estimated cost impact via the Kubecost Predict API.
@@ -1205,11 +1212,6 @@ costEventsAudit:
 #  cloudIntegrationSecret: "cloud-integration"
 #  ingestPodUID: false # Enables using UIDs to uniquely ID pods. This requires either Kubecost's replicated KSM metrics, or KSM v2.1.0+. This may impact performance, and changes the default cost-model allocation behavior.
 #  regionOverrides: "region1,region2,region3" # list of regions which will override default costmodel provider regions
-
-#kubecostAdmissionController:
-#  enabled: true
-#  secretName: webhook-server-tls
-#  caBundle: ${CA_BUNDLE}
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates


### PR DESCRIPTION
## What does this PR change?

- Adds documentation for the Kubecost Admission Controller

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- N/a

## Links to Issues or tickets this PR addresses or fixes

- This PR provides documentation for https://github.com/kubecost/kubecost-cost-model/pull/1813

## What risks are associated with merging this PR? What is required to fully test this PR?

- None. Kubecost Admission Controller is not enabled by default.

## How was this PR tested?

Validated that none of the Kubecost Admission Controller secrets, environment variables, templates were rendered in a default configuration.

```
helm template cost-analyzer
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

