### PR TITLE
Add /savings/abandonedWorkloads/topline proxy for Aggregator

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -490,6 +490,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/savings/abandonedWorkloads/topline {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/abandonedWorkloads/topline;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/reports/allocation {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/reports/allocation;


### PR DESCRIPTION
## What does this PR change?
* Adds the `/savings/abandonedWorkloads/topline` proxy for Aggregator. 

## Does this PR rely on any other PRs?
* Nothing that's not already merged.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Topline abandoned workload queries will now use the DuckDB backend.

## Links to Issues or tickets this PR addresses or fixes
* Closes [SELFHOST-807](https://kubecost.atlassian.net/browse/SELFHOST-807).


[SELFHOST-807]: https://kubecost.atlassian.net/browse/SELFHOST-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ