### PR TITLE
Fix incorrect trim-right whitespace in NOTES.txt

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -6,7 +6,7 @@
 {{- $PVNotExists := (empty (lookup "v1" "PersistentVolume" "" "")) }}
 {{- $EBSCSINotExists := (empty (lookup "apps/v1" "Deployment" "kube-system" "ebs-csi-controller")) }}
 
-{{- $servicePort := .Values.service.port | default 9090 -}}
+{{- $servicePort := .Values.service.port | default 9090 }}
 Kubecost has been successfully installed.
 
 {{ if (and $isEKS $isGT22) -}}


### PR DESCRIPTION
## What does this PR change?

This commit removes a trim-right-whitespace marker which was concatenating the NOTES.txt's header bar ("------") with its first line, "Kubecost has been successfully installed".

The trim-right-whitespace marker caused the template to print:

    ------Kubecost ...

While the desired format (I assume), and the behavior with this commit, is instead:

    ------
    Kubecost ...
