### PR TITLE
Nginx route for debug profile end points of query service replicas

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -342,6 +342,21 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+
+        # to get memory profile from query service need to prefix all request by queryservice/
+        # for example if you want heap dump from query service end point should be 
+        # /model/queryservice/debug/pprof/heap to get queryservice heap dumps
+        location ~ /model/queryservice/(.*)$ {
+            proxy_connect_timeout       600;
+            proxy_send_timeout          600;
+            proxy_read_timeout          600;
+            proxy_pass http://queryservice/$1;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
     {{- end }}
 
 {{- if and (not .Values.agent) (not .Values.cloudAgent) (.Values.kubecostDeployment) (.Values.kubecostAggregator) .Values.kubecostAggregator.enabled }}


### PR DESCRIPTION
## What does this PR change?
* Add end point in Query service replicas to investigate memory issues and others in Query service replicas

## Does this PR rely on any other PRs?
*[ KCM PR](https://github.com/kubecost/kubecost-cost-model/pull/1839)

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Have ability to hit the KCM URL with /queryservice/debug/prof/<XXX> to investigate memory and other debug profile issues in Queryservice

## Links to Issues or tickets this PR addresses or fixes
[SELFHOST-838](https://kubecost.atlassian.net/browse/SELFHOST-838)
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

None
## How was this PR tested?
Refer KCM PR for extensive Test

## Have you made an update to documentation? If so, please provide the corresponding PR.
None


[SELFHOST-838]: https://kubecost.atlassian.net/browse/SELFHOST-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ