### PR TITLE
option to hide diagnostics

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -344,7 +344,7 @@ data:
         }
 
         # to get memory profile from query service need to prefix all request by queryservice/
-        # for example if you want heap dump from query service end point should be 
+        # for example if you want heap dump from query service end point should be
         # /model/queryservice/debug/pprof/heap to get queryservice heap dumps
         location ~ /model/queryservice/(.*)$ {
             proxy_connect_timeout       600;
@@ -580,6 +580,15 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     {{- end }}
+        location = /model/hidediagnostics {
+            default_type text/html;
+            {{- if .Values.kubecostFrontend.hideDiagnostics }}
+            return 200 'true';
+            {{- else }}
+            return 200 'false';
+            {{- end }}
+        }
+
     {{- if .Values.kubecostAggregator.cloudCost.enabled }}
         location = /model/cloudCost/status {
             proxy_read_timeout          300;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -580,7 +580,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     {{- end }}
-        location = /model/hidediagnostics {
+        location = /model/hideDiagnostics {
             default_type text/html;
             {{- if .Values.kubecostFrontend.hideDiagnostics }}
             return 200 'true';

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -358,6 +358,7 @@ kubecostFrontend:
   #   proxy_buffers   4 512k;
   #   proxy_buffer_size   256k;
   #   large_client_header_buffers 4 64k;
+  # hideDiagnostics: false # used if the primary is not monitored. Supported in limited environments.
 
 #  api:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001


### PR DESCRIPTION
## What does this PR change?
add endpoint to disable certain diagnostics that are not accurate if the kubecost primary isn't monitoring itself.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
add endpoint to disable certain diagnostics that are not accurate if the kubecost primary isn't monitoring itself.


## Links to Issues or tickets this PR addresses or fixes
KC-123

## What risks are associated with merging this PR? What is required to fully test this PR?
none

## How was this PR tested?
both with null kubecostFrontend.disableDiagnostics null and true

## Have you made an update to documentation? If so, please provide the corresponding PR.
not needed.