### PR TITLE
SELFHOST-315

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -528,6 +528,13 @@ data:
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        location = /model/savings/localLowDisks {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/localLowDisks;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/reports/allocation {
             proxy_read_timeout          300;


### PR DESCRIPTION
## What does this PR change?
* Adds a `/savings/localLowDisks` proxy for Aggregator.

## Does this PR rely on any other PRs?
* [It does indeed](https://github.com/kubecost/kubecost-cost-model/pull/1845).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* The query to find underutilized disks will now be backed by DuckDB.

## Links to Issues or tickets this PR addresses or fixes
* Closes [SELFHOST-315](https://kubecost.atlassian.net/browse/SELFHOST-315).

## How was this PR tested?
* See accompanying PR for testing notes.

[SELFHOST-315]: https://kubecost.atlassian.net/browse/SELFHOST-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ