### PR TITLE
setting to 50h to match etl retention time

### DIFF
--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -72,10 +72,11 @@ prometheus:
           action: keep
           regex:  {{ template "cost-analyzer.networkCostsName" . }}
   server:
+    retention: 50h
     extraArgs:
       storage.tsdb.min-block-duration: 2h
       storage.tsdb.max-block-duration: 2h
-      storage.tsdb.retention: 10h
+      # storage.tsdb.retention: 10h
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -76,7 +76,8 @@ prometheus:
     extraArgs:
       storage.tsdb.min-block-duration: 2h
       storage.tsdb.max-block-duration: 2h
-      # storage.tsdb.retention: 10h
+      storage.tsdb.retention.time: 50h
+      # storage.tsdb.retention.size: 1Gi
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -73,11 +73,10 @@ prometheus:
           regex:  {{ template "cost-analyzer.networkCostsName" . }}
   server:
     retention: 50h
+    # retentionSize: 1Gi
     extraArgs:
       storage.tsdb.min-block-duration: 2h
       storage.tsdb.max-block-duration: 2h
-      storage.tsdb.retention.time: 50h
-      # storage.tsdb.retention.size: 1Gi
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -695,6 +695,8 @@ prometheus:
     #    operator: "Equal|Exists"
     #    value: "value"
     #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+    # retention: 50h This must be greater than or equal to etlHourlyStoreDurationHours
+    # retentionSize: should be significantly greater than the storage used in the number of hours set in etlHourlyStoreDurationHours
   alertmanager:
     enabled: false
     persistentVolume:
@@ -942,21 +944,21 @@ kubecostDeployment:
     configVolumeSize: 1Gi
     initImage: {}
 
-# The Kubecost Aggregator is a high scale implementation of kubecost 
+# The Kubecost Aggregator is a high scale implementation of kubecost
 # intended for large datasets and/or high query load.
-# At present, this should only be enabled when recommended 
+# At present, this should only be enabled when recommended
 # by Kubecost staff.
 kubecostAggregator:
   # by default, the aggregator uses the same service account as the cost analyzer
   # if a custom service account is desired for the aggregator only, provide the name
   # of a pre-existing service account for the Kubecost Aggregator to use here
-  #serviceAccountName: 
+  #serviceAccountName:
   jaeger:
     enabled: false
     image: jaegertracing/all-in-one
     imageVersion: latest
-    # containerSecurityContext: 
-  # fullImageName: 
+    # containerSecurityContext:
+  # fullImageName:
   cloudCost:
     enabled: false
     # by default, the aggregator cloud cost pod uses the same service account as the cost analyzer
@@ -1155,7 +1157,7 @@ federatedETL:
 ## To use this feature, ensure you have run the `create-admission-controller.sh`
 ## script. This generates a k8s secret with TLS keys/certificats and a
 ## corresponding CA bundle.
-## 
+##
 kubecostAdmissionController:
   enabled: false
   secretName: webhook-server-tls


### PR DESCRIPTION
## What does this PR change?
update hosted agent default retention to 50h to match best practices for being at least etl hourly retention

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Not needed


## What risks are associated with merging this PR? What is required to fully test this PR?
Confirmed that the settings have the intended impact:
```
    Args:
      --storage.tsdb.retention.time=50h
      --config.file=/etc/config/prometheus.yml
      --storage.tsdb.path=/data
      --web.console.libraries=/etc/prometheus/console_libraries
      --web.console.templates=/etc/prometheus/consoles
      --web.enable-lifecycle
      --query.max-concurrency=1
      --query.max-samples=1e+08
      --storage.tsdb.max-block-duration=2h
      --storage.tsdb.min-block-duration=2h
```

## How was this PR tested?
tested in several QA environments

## Have you made an update to documentation? If so, please provide the corresponding PR.

NA