### PR TITLE
pv sizing proxy for wf

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -537,6 +537,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/savings/persistentVolumeSizing {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/persistentVolumeSizing;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/reports/allocation {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/reports/allocation;


### PR DESCRIPTION
## What does this PR change?
Adds proxy for PV sizing in waterfowl

## Does this PR rely on any other PRs?
Yes https://github.com/kubecost/kubecost-cost-model/pull/1851

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Enables PV right sizing in waterfowl

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
https://kubecost.atlassian.net/browse/SELFHOST-317


## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

