### PR TITLE
Begin Helm testing

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -72,7 +72,7 @@ jobs:
         run: helm install --wait --wait-for-jobs kubecost . -n kubecost --create-namespace --set global.prometheus.enabled=false --set global.grafana.enabled=false
 
       - name: Wait for ready 
-        run: kubectl wait --namespace kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=60s
+        run: kubectl wait --namespace kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=120s
 
       - name: Run Helm tests 
         run: helm test -n kubecost kubecost

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -69,5 +69,10 @@ jobs:
   
       - name: Install Kubecost chart
         working-directory: ./cost-analyzer
-        run: |
-          helm install --wait --wait-for-jobs kubecost . --namespace kubecost --create-namespace --set global.prometheus.enabled=false --set global.grafana.enabled=false
+        run: helm install --wait --wait-for-jobs kubecost . -n kubecost --create-namespace --set global.prometheus.enabled=false --set global.grafana.enabled=false
+
+      - name: Wait for ready 
+        run: kubectl wait --namespace kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=60s
+
+      - name: Run Helm tests 
+        run: helm test -n kubecost kubecost

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -69,7 +69,7 @@ jobs:
   
       - name: Install Kubecost chart
         working-directory: ./cost-analyzer
-        run: helm install --wait --wait-for-jobs kubecost . -n kubecost --create-namespace --set global.prometheus.enabled=false --set global.grafana.enabled=false
+        run: helm install --wait --wait-for-jobs kubecost . -n kubecost --create-namespace
 
       - name: Wait for ready 
         run: kubectl wait --namespace kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=120s

--- a/cost-analyzer/templates/tests/_helpers.tpl
+++ b/cost-analyzer/templates/tests/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "kubecost.test.annotations" -}}
+helm.sh/hook: test
+{{- end -}}
+
+{{- define "kyverno.test.image" -}}
+{{- template "kyverno.image" (dict "image" .Values.test.image "defaultTag" "latest") -}}
+{{- end -}}
+
+{{- define "kyverno.test.imagePullPolicy" -}}
+{{- default .Values.admissionController.container.image.pullPolicy .Values.test.image.pullPolicy -}}
+{{- end -}}

--- a/cost-analyzer/templates/tests/_helpers.tpl
+++ b/cost-analyzer/templates/tests/_helpers.tpl
@@ -3,11 +3,3 @@
 {{- define "kubecost.test.annotations" -}}
 helm.sh/hook: test
 {{- end -}}
-
-{{- define "kyverno.test.image" -}}
-{{- template "kyverno.image" (dict "image" .Values.test.image "defaultTag" "latest") -}}
-{{- end -}}
-
-{{- define "kyverno.test.imagePullPolicy" -}}
-{{- default .Values.admissionController.container.image.pullPolicy .Values.test.image.pullPolicy -}}
-{{- end -}}

--- a/cost-analyzer/templates/tests/basic-health.yaml
+++ b/cost-analyzer/templates/tests/basic-health.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: basic-health
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "kubecost.test.annotations" . | nindent 4 }}
+spec:
+  serviceAccountName: tester
+  restartPolicy: Never
+  containers:
+  - name: test-kubecost
+    image: alpine/k8s:1.26.9
+    command:
+      - /bin/sh
+    args:
+      - -c
+      - >-
+        svc=$(kubectl -n {{ .Release.Namespace }} get svc -l app.kubernetes.io/name=cost-analyzer -o json | jq -r .items[0].metadata.name);
+        echo Getting current Kubecost state.;
+        response=$(curl -sL http://${svc}:9090/model/getConfigs);
+        code=$(echo ${response} | jq .code);
+        if [ "$code" -eq 200 ]; then
+          echo "Got Kubecost working configuration. Successful."
+          exit 0
+        else 
+          echo "Failed to fetch Kubecost configuration. Response was $response"
+          exit 1
+        fi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-rolebinding
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: tester
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: test-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tester
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

* Creates the first actual test as part of the Helm chart. In this test, basic health is determined which functions as an e2e test of all the components in the Kubecost stack (minus Grafana for the moment).
* Plumbs in Helm testing into CI.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows users to run Kubecost tests in their own environment should they wish, but otherwise is an internal change in CI.

## Links to Issues or tickets this PR addresses or fixes


## What risks are associated with merging this PR? What is required to fully test this PR?

None

## How was this PR tested?

Tested locally and in CI

## Have you made an update to documentation? If so, please provide the corresponding PR.

