### PR TITLE
networkCosts service discovery

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -663,9 +663,12 @@ prometheus:
         - role: pod
       relabel_configs:
       # Scrape only the the targets matching the following metadata
-        - source_labels: [__meta_kubernetes_pod_label_app]
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
           action: keep
-          regex:  {{ template "cost-analyzer.networkCostsName" . }}
+          regex:  kubecost
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+          action: keep
+          regex:  network-costs
   server:
     # If clusterIDConfigmap is defined, instead use user-generated configmap with key CLUSTER_ID
     # to use as unique cluster ID in kubecost cost-analyzer deployment.
@@ -881,7 +884,10 @@ networkCosts:
   podMonitor:
     enabled: false
     additionalLabels: {}
-  additionalLabels: {}
+  # match the default extraScrapeConfig
+  additionalLabels:
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/name: network-costs
   nodeSelector: {}
   annotations: {}
   healthCheckProbes: {}


### PR DESCRIPTION
## What does this PR change?
Allow users to run the network costs daemonset in any namespace without having to configure the target in Kubecost bundled prometheus.

1. add additional labels to network cost pods
2. adjust default scrapeConfig to find pods with these labels

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Change networkCosts Prometheus service discovery to find the deamonset in any namespace

## What risks are associated with merging this PR? What is required to fully test this PR?
We are setting new default values:

```yaml
app.kubernetes.io/instance: kubecost
app.kubernetes.io/name: network-costs
```

IMO, we should add similar labels to all other pods too.

## How was this PR tested?
Tested in several different configs:
1. Default install with networkCost enabled
2. With serviceMonitor enabled in a BYO prometheus install
3. Upgrading an old kubecost install with new chart

## Have you made an update to documentation? If so, please provide the corresponding PR.
TBD, I think we should add the service discovery how to in the current doc: https://docs.kubecost.com/install-and-configure/advanced-configuration/network-costs-configuration#prometheus
