### PR TITLE
remove replicasets from core (fix #2662)

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
@@ -35,7 +35,6 @@ rules:
       - services
       - resourcequotas
       - replicationcontrollers
-      - replicasets
       - limitranges
       - persistentvolumeclaims
       - persistentvolumes


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Removes an incorrectly-placed `replicasets` resource from the core API group.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Fixes an issue caused in #2662

## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

