### PR TITLE
add systemProxy env vars

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -335,6 +335,21 @@ spec:
           args:
           - "--web.listen-address=:{{ .Values.global.gmp.gmpProxy.port }}"
           - "--query.project-id={{ .Values.global.gmp.gmpProxy.projectId }}"
+          {{- if .Values.systemProxy.enabled }}
+          env:
+          - name: HTTP_PROXY
+            value: {{ .Values.systemProxy.httpProxyUrl }}
+          - name: http_proxy
+            value: {{ .Values.systemProxy.httpProxyUrl }}
+          - name: HTTPS_PROXY
+            value:  {{ .Values.systemProxy.httpsProxyUrl }}
+          - name: https_proxy
+            value:  {{ .Values.systemProxy.httpsProxyUrl }}
+          - name: NO_PROXY
+            value:  {{ .Values.systemProxy.noProxy }}
+          - name: no_proxy
+            value:  {{ .Values.systemProxy.noProxy }}
+          {{- end }}
           ports:
           - name: web
             containerPort: {{ .Values.global.gmp.gmpProxy.port | int }}
@@ -375,8 +390,24 @@ spec:
           ports:
           - name: aws-sigv4-proxy
             containerPort: {{ .Values.sigV4Proxy.port | int }}
-          {{- if .Values.sigV4Proxy.extraEnv }}
           env:
+          - name: AGENT_LOCAL_PORT
+            value: "{{ .Values.sigV4Proxy.port | int }}"
+          {{- if .Values.systemProxy.enabled }}
+          - name: HTTP_PROXY
+            value: {{ .Values.systemProxy.httpProxyUrl }}
+          - name: http_proxy
+            value: {{ .Values.systemProxy.httpProxyUrl }}
+          - name: HTTPS_PROXY
+            value:  {{ .Values.systemProxy.httpsProxyUrl }}
+          - name: https_proxy
+            value:  {{ .Values.systemProxy.httpsProxyUrl }}
+          - name: NO_PROXY
+            value:  {{ .Values.systemProxy.noProxy }}
+          - name: no_proxy
+            value:  {{ .Values.systemProxy.noProxy }}
+          {{- end }}
+          {{- if .Values.sigV4Proxy.extraEnv }}
           {{- toYaml .Values.sigV4Proxy.extraEnv | nindent 10 }}
           {{- end }}
         {{- end }}
@@ -384,6 +415,20 @@ spec:
         - name: ubbagent
           image: gcr.io/kubecost1/gcp-mp/ent/cost-model/ubbagent:1.0
           env:
+          {{- if .Values.systemProxy.enabled }}
+          - name: HTTP_PROXY
+            value: {{ .Values.systemProxy.httpProxyUrl }}
+          - name: http_proxy
+            value: {{ .Values.systemProxy.httpProxyUrl }}
+          - name: HTTPS_PROXY
+            value:  {{ .Values.systemProxy.httpsProxyUrl }}
+          - name: https_proxy
+            value:  {{ .Values.systemProxy.httpsProxyUrl }}
+          - name: NO_PROXY
+            value:  {{ .Values.systemProxy.noProxy }}
+          - name: no_proxy
+            value:  {{ .Values.systemProxy.noProxy }}
+          {{- end }}
           - name: AGENT_CONFIG_FILE
             value: "/etc/ubbagent/config.yaml"
           - name: AGENT_LOCAL_PORT

--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -81,6 +81,20 @@ spec:
             {{- if .Values.federatedETL.federator.extraEnv }}
             {{- toYaml .Values.federatedETL.federator.extraEnv | nindent 12 }}
             {{- end }}
+            {{- if .Values.systemProxy.enabled }}
+            - name: HTTP_PROXY
+              value: {{ .Values.systemProxy.httpProxyUrl }}
+            - name: http_proxy
+              value: {{ .Values.systemProxy.httpProxyUrl }}
+            - name: HTTPS_PROXY
+              value:  {{ .Values.systemProxy.httpsProxyUrl }}
+            - name: https_proxy
+              value:  {{ .Values.systemProxy.httpsProxyUrl }}
+            - name: NO_PROXY
+              value:  {{ .Values.systemProxy.noProxy }}
+            - name: no_proxy
+              value:  {{ .Values.systemProxy.noProxy }}
+            {{- end }}
       restartPolicy: Always
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       volumes:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -321,6 +321,7 @@ oidc:
     #       - "editor"
 
 # Adds an httpProxy as an environment variable. systemProxy.enabled must be `true`to have any effect.
+# this is used in environments that have firewall rules that prevent kubecost from accessing cloud provider resources
 # Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml
 systemProxy:
   enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -320,9 +320,11 @@ oidc:
     #     claimValues:
     #       - "editor"
 
-# Adds an httpProxy as an environment variable. systemProxy.enabled must be `true`to have any effect.
-# this is used in environments that have firewall rules that prevent kubecost from accessing cloud provider resources
-# Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml
+## Adds the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables to all
+## containers. Typically used in environments that have firewall rules which
+## prevent kubecost from accessing cloud provider resources.
+## Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml
+##
 systemProxy:
   enabled: false
   httpProxyUrl: ""


### PR DESCRIPTION
## What does this PR change?
Add systemProxy env variables to amp/gmp/federator containers

## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Added systemProxy env variables to amp/gmp/federator containers



## What risks are associated with merging this PR? What is required to fully test this PR?
Worst case would be spacing, but I verified each block was aligned, though I didn't deploy each.

## How was this PR tested?
changing gmp and amp, federator on:

```yaml
global:
  gmp:
    enabled: true
    prometheusServerEndpoint: https://localhost:8085/xxxxx/
    remoteWriteService: https://test.com
    sigv4:
      region: us-east-2
systemProxy:
  enabled: true
  httpProxyUrl: http://test
  httpsProxyUrl: http://test1
  noProxy: "0,localhost"
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

NA