### PR TITLE
update savedReports and advancedReports in values.yml to reflect curr…

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -149,11 +149,10 @@ global:
         idle: "separate"
         rate: "cumulative"
         accumulate: false # daily resolution
-        filters:
-          - property: "cluster"
-            value: "cluster-one,cluster*" # supports wildcard filtering and multiple comma separated values
-          - property: "namespace"
-            value: "kubecost"
+        filters: # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api
+          - key: "cluster" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#allocation-apis-request-sizing-v2-api
+            operator: ":" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#filter-operators
+            value: "dev"
       - title: "Example Saved Report 1"
         window: "month"
         aggregateBy: "controllerKind"
@@ -161,10 +160,9 @@ global:
         idle: "share"
         rate: "monthly"
         accumulate: false
-        filters:
-          - property: "label"
-            value: "app:cost*,environment:kube*"
-          - property: "namespace"
+        filters: # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api
+          - key: "namespace" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#allocation-apis-request-sizing-v2-api
+            operator: "!:" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#filter-operators
             value: "kubecost"
       - title: "Example Saved Report 2"
         window: "2020-11-11T00:00:00Z,2020-12-09T23:59:59Z"
@@ -196,9 +194,10 @@ global:
     - title: "Example Advanced Report 0"
       window: "7d"
       aggregateBy: "namespace"
-      filters:
-        - property: "cluster"
-          value: "cluster-one"
+      filters: # same as allocation api filters Ref: https://docs.kubecost.com/apis/apis-overview/filters-api
+        - key: "cluster" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#allocation-apis-request-sizing-v2-api
+          operator: ":" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#filter-operators
+          value: "dev"
       cloudBreakdown: "service"
       cloudJoin: "label:kubernetes_namespace"
 


### PR DESCRIPTION
…ent filter schema

## What does this PR change?
The current examples in values.yaml no longer reflect the current report schema. This is because the back end has been updated to use v2 filters, but our values.yaml examples were never updated to reflect the schema change.

We(kubecost back end team) already broke by this feature by shipping v1.106. Any users that upgrade to v1.106 or newer and use this feature will have to update these report filters, otherwise reports from YAML will not load.

I would have preferred to make this change backwards compatible, however, the back end report change was not made in a backwards compatible way to support this, and I am not aware of a helm function that would let us convert to JSON using different keys. Example: values.yaml converts a 'filters2' yaml block to a 'filters' yaml block. (I would love to be wrong here)

https://helm.sh/docs/chart_template_guide/function_list/

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Provides examples on how to use filters with saved (allocation) reports and advanced reports

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/SELFHOST-903
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

## What risks are associated with merging this PR? What is required to fully test this PR?
can't make things worse; full testing is using these examples to successfully deploy saved (allocation) reports and advanced reports containing filters and no errors

## How was this PR tested?
spun up a new installation with helm, added reports, saw the filters are appearing

## Have you made an update to documentation? If so, please provide the corresponding PR.
n/a, documentation links to values.yaml
