### PR TITLE
Replace ConfigMap reloader

### DIFF
--- a/cost-analyzer/charts/prometheus/README.md
+++ b/cost-analyzer/charts/prometheus/README.md
@@ -183,8 +183,8 @@ Parameter | Description | Default
 `configmapReload.prometheus.enabled` | If false, the configmap-reload container for Prometheus will not be deployed | `true`
 `configmapReload.prometheus.containerSecurityContext` | securityContext for container | `{}`
 `configmapReload.prometheus.name` | configmap-reload container name | `configmap-reload`
-`configmapReload.prometheus.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
-`configmapReload.prometheus.image.tag` | configmap-reload container image tag | `v0.5.0`
+`configmapReload.prometheus.image.repository` | configmap-reload container image repository | `quay.io/prometheus-operator/prometheus-config-reloader`
+`configmapReload.prometheus.image.tag` | configmap-reload container image tag | `v0.68.0`
 `configmapReload.prometheus.image.pullPolicy` | configmap-reload container image pull policy | `IfNotPresent`
 `configmapReload.prometheus.extraArgs` | Additional configmap-reload container arguments | `{}`
 `configmapReload.prometheus.extraVolumeDirs` | Additional configmap-reload volume directories | `{}`
@@ -192,8 +192,8 @@ Parameter | Description | Default
 `configmapReload.prometheus.resources` | configmap-reload pod resource requests & limits | `{}`
 `configmapReload.alertmanager.enabled` | If false, the configmap-reload container for AlertManager will not be deployed | `true`
 `configmapReload.alertmanager.name` | configmap-reload container name | `configmap-reload`
-`configmapReload.alertmanager.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
-`configmapReload.alertmanager.image.tag` | configmap-reload container image tag | `v0.5.0`
+`configmapReload.alertmanager.image.repository` | configmap-reload container image repository | `quay.io/prometheus-operator/prometheus-config-reloader`
+`configmapReload.alertmanager.image.tag` | configmap-reload container image tag | `v0.68.0`
 `configmapReload.alertmanager.image.pullPolicy` | configmap-reload container image pull policy | `IfNotPresent`
 `configmapReload.alertmanager.extraArgs` | Additional configmap-reload container arguments | `{}`
 `configmapReload.alertmanager.extraVolumeDirs` | Additional configmap-reload volume directories | `{}`

--- a/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
@@ -50,8 +50,8 @@ spec:
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
           args:
-            - --volume-dir=/etc/config
-            - --webhook-url=http://127.0.0.1:9090{{ .Values.server.prefixURL }}/-/reload
+            - --watched-dir=/etc/config
+            - --reload-url=http://127.0.0.1:9090{{ .Values.server.prefixURL }}/-/reload
           {{- range $key, $value := .Values.configmapReload.prometheus.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}

--- a/cost-analyzer/charts/prometheus/templates/server-statefulset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-statefulset.yaml
@@ -51,8 +51,8 @@ spec:
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
           args:
-            - --volume-dir=/etc/config
-            - --webhook-url=http://127.0.0.1:9090{{ .Values.server.prefixURL }}/-/reload
+            - --watched-dir=/etc/config
+            - --reload-url=http://127.0.0.1:9090{{ .Values.server.prefixURL }}/-/reload
           {{- range $key, $value := .Values.configmapReload.prometheus.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}

--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -307,8 +307,6 @@ alertmanager:
     type: ClusterIP
 
 ## Monitors ConfigMap changes and POSTs to a URL
-## Ref: https://github.com/jimmidyson/configmap-reload
-##
 configmapReload:
   prometheus:
     ## If false, the configmap-reload container will not be deployed
@@ -322,8 +320,8 @@ configmapReload:
     ## configmap-reload container image
     ##
     image:
-      repository: jimmidyson/configmap-reload
-      tag: v0.9.0
+      repository: quay.io/prometheus-operator/prometheus-config-reloader
+      tag: v0.68.0
       pullPolicy: IfNotPresent
 
     ## Additional configmap-reload container arguments
@@ -362,8 +360,8 @@ configmapReload:
     ## configmap-reload container image
     ##
     image:
-      repository: jimmidyson/configmap-reload
-      tag: v0.9.0
+      repository: quay.io/prometheus-operator/prometheus-config-reloader
+      tag: v0.68.0
       pullPolicy: IfNotPresent
 
     ## Additional configmap-reload container arguments

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -20181,11 +20181,11 @@ spec:
       serviceAccountName: kubecost-prometheus-server
       containers:
         - name: prometheus-server-configmap-reload
-          image: "jimmidyson/configmap-reload:v0.9.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0"
           imagePullPolicy: "IfNotPresent"
           args:
-            - --volume-dir=/etc/config
-            - --webhook-url=http://127.0.0.1:9090/-/reload
+            - --watched-dir=/etc/config
+            - --reload-url=http://127.0.0.1:9090/-/reload
           resources:
             {}
           securityContext:


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Replaces the previous ConfigMap reloader with the Prometheus operator's official reloader.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

No user impact. This is an under-the-hood swap out.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

[GTM-71](https://kubecost.atlassian.net/browse/GTM-71) (internal Kubecost)


## What risks are associated with merging this PR? What is required to fully test this PR?

ConfigMap reloading might not happen upon change of the source.

## How was this PR tested?

Tested locally. Changed resource `configmap/kubecost-prometheus-server`, tailed logs, observed reloader.



## Have you made an update to documentation? If so, please provide the corresponding PR.



[GTM-71]: https://kubecost.atlassian.net/browse/GTM-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ