### PR TITLE
Fix bug when deploying Aggregator + CloudCost with default ServiceAccount

### DIFF
--- a/cost-analyzer/templates/aggregator-cloud-cost-service-account.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-service-account.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.kubecostAggregator.cloudCost.enabled }}
-
-{{- if .Values.serviceAccount.create }}
+{{- if and .Values.serviceAccount.create .Values.kubecostAggregator.cloudCost.serviceAccountName }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -958,29 +958,25 @@ kubecostDeployment:
     configVolumeSize: 1Gi
     initImage: {}
 
-# The Kubecost Aggregator is a high scale implementation of kubecost
-# intended for large datasets and/or high query load.
-# At present, this should only be enabled when recommended
-# by Kubecost staff.
+## The Kubecost Aggregator is a high scale implementation of Kubecost intended
+## for large datasets and/or high query load. At present, this should only be
+## enabled when recommended by Kubecost staff.
+## 
 kubecostAggregator:
-  # by default, the aggregator uses the same service account as the cost analyzer
-  # if a custom service account is desired for the aggregator only, provide the name
-  # of a pre-existing service account for the Kubecost Aggregator to use here
-  #serviceAccountName:
+  enabled: false
+  replicas: 1
+  ## Creates a new pod to retrieve CloudCost data. By default it uses the same
+  ## serviceaccount as the cost-analyzer pod. A custom serviceaccount can be
+  ## specified.
+  cloudCost:
+    enabled: false
+    # serviceAccountName:
   jaeger:
     enabled: false
     image: jaegertracing/all-in-one
     imageVersion: latest
     # containerSecurityContext:
   # fullImageName:
-  cloudCost:
-    enabled: false
-    # by default, the aggregator cloud cost pod uses the same service account as the cost analyzer
-    # if a custom service account is desired for the aggregator cloud cost pod only, provide the name
-    # of a pre-existing service account for the Kubecost Aggregator cloud cost pod to use here
-    # serviceAccountName:
-  replicas: 1
-  enabled: false
   resources: {}
   env:
     "LOG_LEVEL": "info"


### PR DESCRIPTION
## What does this PR change?

Fixes the following bug

```sh
$ helm upgrade -i kubecost cost-analyzer --repo https://kubecost.github.io/cost-analyzer/ --devel -f values.yaml
Release "kubecost" does not exist. Installing it now.
Error: 1 error occurred:
	* serviceaccounts "kubecost-cost-analyzer" already exists
```

```yaml
kubecostAggregator:
  enabled: true
  cloudCost:
    enabled: true
kubecostModel:
  federatedStorageConfigSecret: federated-store
kubecostProductConfigs:
  cloudIntegrationSecret: cloud-integration
```

This error occurs because the Helm Chart is rendering duplicate ServiceAccount manifests. Shown below.

```
---
# Source: cost-analyzer/templates/aggregator-cloud-cost-service-account.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: kubecost-cost-analyzer
  namespace: kubecost
  labels:
    
    helm.sh/chart: cost-analyzer-1.106.3
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cloud-cost
    app.kubernetes.io/instance: release-name
    app: cloud-cost
---
# Source: cost-analyzer/templates/cost-analyzer-service-account-template.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: kubecost-cost-analyzer
  namespace: kubecost
  labels:
    
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.106.3
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
---
```

After this fix, I'm able to successfully `helm install` with the above configs. A ServiceAccount manifest is only created if `.Values.kubecostAggregator.cloudCost.serviceAccountName` is specified. Otherwise, it will use the ServiceAccount belonging to cost-analyzer.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows install of Aggregator CloudCost using the default `cost-analyzer` ServiceAccount.

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

I believe it is low risk. If others could help test this change with their current Helm configs that would be appreciated as well.

## How was this PR tested?

Deployed Aggregator using the configs shown above. Validated that the `kubecost-cloud-cost` starts correctly. Validated that the ServiceAccount had proper permissions to get CloudCost data.

## Have you made an update to documentation? If so, please provide the corresponding PR.

Updated comments in `values.yaml`
