### PR TITLE
update helm notes

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -7,7 +7,7 @@
 {{- $EBSCSINotExists := (empty (lookup "apps/v1" "Deployment" "kube-system" "ebs-csi-controller")) }}
 
 {{- $servicePort := .Values.service.port | default 9090 }}
-Kubecost has been successfully installed.
+Kubecost {{ .Chart.Version }} has been successfully installed.
 
 {{ if (and $isEKS $isGT22) -}}
 
@@ -27,14 +27,12 @@ ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTE
 
 Please allow 5-10 minutes for Kubecost to gather metrics.
 
-If you have configured cloud-integrations, it can take up to 48 hours for cost reconciliation to occur.
-
-When using Durable storage (Enterprise Edition), please allow up to 4 hours for data to be collected and the UI to be healthy.
+When configured, cost reconciliation with cloud provider billing data will have a 48 hour delay.
 
 When pods are Ready, you can enable port-forwarding with the following command:
 
     kubectl port-forward --namespace {{ .Release.Namespace }} deployment/{{ template "cost-analyzer.fullname" . }} {{ $servicePort }}
 
-Next, navigate to http://localhost:{{ $servicePort }} in a web browser.
+Then, navigate to http://localhost:{{ $servicePort }} in a web browser.
 
 Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install


### PR DESCRIPTION
## What does this PR change?

Update helm notes, removing the Thanos delay comment, add version infomation.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Update helm notes, removing the Thanos delay comment, add version infomation.


## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
local helm upgrade. output:
```
Kubecost 1.106.3 has been successfully installed.

Please allow 5-10 minutes for Kubecost to gather metrics.

When configured, cost reconciliation with cloud provider billing data will have a 48 hour delay.

When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090

Then, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install
```


## Have you made an update to documentation? If so, please provide the corresponding PR.

NA