### PR TITLE
Fix volumeMount in federator deployment

### DIFF
--- a/cost-analyzer/templates/federator-deployment-template.yaml
+++ b/cost-analyzer/templates/federator-deployment-template.yaml
@@ -54,9 +54,11 @@ spec:
           volumeMounts:
             - name: federator-config
               mountPath: /var/configs/federator
+            {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
             - name: federated-storage-config
               mountPath: /var/configs/etl/federated
               readOnly: true
+            {{- end }}
             {{- if .Values.federatedETL.federator.extraVolumeMounts }}
             {{- toYaml .Values.federatedETL.federator.extraVolumeMounts | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Fixes a templatization issue of federator-deployment-template.yaml so the `federated-storage-config` volume is only mounted if the `federatedStorageConfigSecret` value is populated, bringing this template into alignment with other similar ones.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows templating to succeed if `federatedETL.federator.enabled` is set to `true` with no other modifications.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

Federator fails.

## How was this PR tested?

Tested locally by templating and comparing results.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A
