### PR TITLE
[cherry-pick] Fix bug when deploying Aggregator + CloudCost with default ServiceAccount

### DIFF
--- a/cost-analyzer/templates/aggregator-cloud-cost-service-account.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-service-account.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.kubecostAggregator.cloudCost.enabled }}
-
-{{- if .Values.serviceAccount.create }}
+{{- if and .Values.serviceAccount.create .Values.kubecostAggregator.cloudCost.serviceAccountName }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -965,29 +965,25 @@ kubecostDeployment:
     configVolumeSize: 1Gi
     initImage: {}
 
-# The Kubecost Aggregator is a high scale implementation of kubecost
-# intended for large datasets and/or high query load.
-# At present, this should only be enabled when recommended
-# by Kubecost staff.
+## The Kubecost Aggregator is a high scale implementation of Kubecost intended
+## for large datasets and/or high query load. At present, this should only be
+## enabled when recommended by Kubecost staff.
+## 
 kubecostAggregator:
-  # by default, the aggregator uses the same service account as the cost analyzer
-  # if a custom service account is desired for the aggregator only, provide the name
-  # of a pre-existing service account for the Kubecost Aggregator to use here
-  #serviceAccountName:
+  enabled: false
+  replicas: 1
+  ## Creates a new pod to retrieve CloudCost data. By default it uses the same
+  ## serviceaccount as the cost-analyzer pod. A custom serviceaccount can be
+  ## specified.
+  cloudCost:
+    enabled: false
+    # serviceAccountName:
   jaeger:
     enabled: false
     image: jaegertracing/all-in-one
     imageVersion: latest
     # containerSecurityContext:
   # fullImageName:
-  cloudCost:
-    enabled: false
-    # by default, the aggregator cloud cost pod uses the same service account as the cost analyzer
-    # if a custom service account is desired for the aggregator cloud cost pod only, provide the name
-    # of a pre-existing service account for the Kubecost Aggregator cloud cost pod to use here
-    # serviceAccountName:
-  replicas: 1
-  enabled: false
   resources: {}
   env:
     "LOG_LEVEL": "info"


### PR DESCRIPTION
Cherry-pick of PR https://github.com/kubecost/cost-analyzer-helm-chart/pull/2699 into v1.107 branch.

The current workaround is to always set `.Values.kubecostAggregator.cloudCost.serviceAccountName` when using the Aggregator + CloudCost. Will defer to @cliffcolvin and @jessegoodier for whether we want to get this small fix into v1.107