### PR TITLE
Adopt global security contexts for Aggregator StatefulSet

### DIFF
--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -53,7 +53,10 @@ spec:
       restartPolicy: Always
       {{- if .Values.kubecostAggregator.securityContext }}
       securityContext:
-          {{- toYaml .Values.kubecostAggregator.securityContext | nindent 10 }}
+        {{- toYaml .Values.kubecostAggregator.securityContext | nindent 8 }}
+      {{- else if .Values.global.securityContext }}
+      securityContext:
+        {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{ end }}
       serviceAccountName: {{ template "aggregator.serviceAccountName" . }}
       volumes:
@@ -64,10 +67,9 @@ spec:
         {{- if $etlBackupBucketSecret }}
         - name: bucket-config
           secret:
-           defaultMode: 420
-           secretName: {{ $etlBackupBucketSecret }}
+            defaultMode: 420
+            secretName: {{ $etlBackupBucketSecret }}
         {{- end }}
-
       containers:
       {{- if .Values.kubecostAggregator.jaeger.enabled }}
         - name: embedded-jaeger
@@ -79,6 +81,9 @@ spec:
         {{- if .Values.kubecostAggregator.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.kubecostAggregator.containerSecurityContext | nindent 12 }}
+        {{- else if .Values.global.containerSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 -}}
         {{ end }}
           {{- if .Values.kubecostModel }}
           {{- if .Values.kubecostModel.openSourceOnly }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -83,7 +83,7 @@ spec:
             {{- toYaml .Values.kubecostAggregator.containerSecurityContext | nindent 12 }}
         {{- else if .Values.global.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.global.containerSecurityContext | nindent 12 -}}
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
         {{ end }}
           {{- if .Values.kubecostModel }}
           {{- if .Values.kubecostModel.openSourceOnly }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1001,23 +1001,23 @@ kubecostAggregator:
     # default storage class
     storageClass: ""
     storageRequest: 128Gi
-  securityContext:
-    runAsGroup: 1001
-    runAsUser: 1001
-    fsGroup: 1001
-    fsGroupChangePolicy: OnRootMismatch
-    seccompProfile:
-      type: RuntimeDefault
-    runAsNonRoot: true
-  containerSecurityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
-    capabilities:
-      drop:
-        - ALL
+  # securityContext:
+  #   runAsGroup: 1001
+  #   runAsUser: 1001
+  #   fsGroup: 1001
+  #   fsGroupChangePolicy: OnRootMismatch
+  #   seccompProfile:
+  #     type: RuntimeDefault
+  #   runAsNonRoot: true
+  # containerSecurityContext:
+  #   allowPrivilegeEscalation: false
+  #   readOnlyRootFilesystem: true
+  #   runAsNonRoot: true
+  #   seccompProfile:
+  #     type: RuntimeDefault
+  #   capabilities:
+  #     drop:
+  #       - ALL
 
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -225,7 +225,6 @@ global:
     fsGroup: 1001
     runAsGroup: 1001
     runAsUser: 1001
-
     fsGroupChangePolicy: OnRootMismatch
   containerSecurityContext:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
## What does this PR change?

Configures the Aggregator StatefulSet to be able to adopt the defaults from the `global` map if present. Also comments out the aggregator-specific security context settings allowing global values to take precedence.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows simpler Helm values for security contexts while still providing granular overrides.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

N/A


## What risks are associated with merging this PR? What is required to fully test this PR?

Aggregator may fail to work properly.

## How was this PR tested?

Tested by local templating and deploying to an OCP cluster, ensuring the Pod was deployed.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A