### PR TITLE
Update Cloud Cost ingestion control values

### DIFF
--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -106,6 +106,13 @@ spec:
             - name: FEDERATED_CLUSTER
               value: "true"
             {{- end}}
+            - name: CLOUD_COST_REFRESH_RATE_HOURS
+              value: {{ .Values.kubecostAggregator.cloudCost.refreshRateHours | default  6 | quote }}
+            - name: CLOUD_COST_QUERY_WINDOW_DAYS
+              value: {{ .Values.kubecostAggregator.cloudCost.queryWindowDays  | default  7 | quote }}
+            - name: CLOUD_COST_RUN_WINDOW_DAYS
+              value: {{ .Values.kubecostAggregator.cloudCost.runWindowDays | default 3 | quote }}
+
             {{- range $key, $value := .Values.kubecostAggregator.cloudCost.env }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -863,12 +863,6 @@ spec:
             {{- end }}
             - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
               value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}
-            - name: ETL_CLOUD_REFRESH_RATE_HOURS
-              value: {{ (quote .Values.kubecostModel.etlCloudRefreshRateHours) | default (quote 6) }}
-            - name: ETL_CLOUD_QUERY_WINDOW_DAYS
-              value: {{ (quote .Values.kubecostModel.etlCloudQueryWindowDays) | default (quote 7) }}
-            - name: ETL_CLOUD_RUN_WINDOW_DAYS
-              value: {{ (quote .Values.kubecostModel.etlCloudRunWindowDays) | default (quote 3) }}
             {{- if .Values.persistentVolume.dbPVEnabled }}
             - name: ETL_PATH_PREFIX
               value: "/var/db"
@@ -913,6 +907,12 @@ spec:
             - name: CLOUD_COST_TOP_N
               value: {{ (quote .topNItems) | default (quote 1000) }}
             {{- end }}
+            - name: CLOUD_COST_REFRESH_RATE_HOURS
+              value: {{ .Values.kubecostModel.cloudCost.refreshRateHours | default .Values.kubecostModel.etlCloudRefreshRateHours | default  6 | quote }}
+            - name: CLOUD_COST_QUERY_WINDOW_DAYS
+              value: {{ .Values.kubecostModel.cloudCost.queryWindowDays | default .Values.kubecostModel.etlCloudQueryWindowDays | default  7 | quote }}
+            - name: CLOUD_COST_RUN_WINDOW_DAYS
+              value: {{ .Values.kubecostModel.cloudCost.runWindowDays | default .Values.kubecostModel.etlCloudRunWindowDays | default 3 | quote }}
             - name: CONTAINER_STATS_ENABLED
               value: {{ (quote .Values.kubecostModel.containerStatsEnabled) | default (quote false) }}
             - name: RECONCILE_NETWORK


### PR DESCRIPTION
## What does this PR change?
This PR updates the variable names for CloudCost ingestion controls and adds new value locations for setting them under `kubecostModel.cloudCost` while still supporting the previous values at `kubecostModel.etlCloud...`. Additionally it surfaces the variables in the CloudCost pod where they can also be utilized

## Does this PR rely on any other PRs?
Changes here are supported by
https://github.com/kubecost/kubecost-cost-model/pull/1852
https://github.com/opencost/opencost/pull/2222


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Tested by templating against various combinations of values to ensure that the correct value appears in the env variable

## Have you made an update to documentation? If so, please provide the corresponding PR.

