### PR TITLE
[AMP/Sigv4] Use http protocol and port 8005

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -46,7 +46,7 @@ global:
   # Amazon Managed Service for Prometheus
   amp:
     enabled: false # If true, kubecost will be configured to remote_write and query from Amazon Managed Service for Prometheus.
-    prometheusServerEndpoint: https://localhost:8085/workspaces/<workspaceId>/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the SigV4Proxy side car to the AMP workspace.
+    prometheusServerEndpoint: http://localhost:8005/workspaces/<workspaceId>/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the SigV4Proxy side car to the AMP workspace.
     remoteWriteService: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspaceId>/api/v1/remote_write # The remote_write endpoint for the AMP workspace.
     sigv4:
       region: us-west-2
@@ -969,7 +969,7 @@ kubecostDeployment:
 ## The Kubecost Aggregator is a high scale implementation of Kubecost intended
 ## for large datasets and/or high query load. At present, this should only be
 ## enabled when recommended by Kubecost staff.
-## 
+##
 kubecostAggregator:
   enabled: false
   replicas: 1


### PR DESCRIPTION
## What does this PR change?
Use http protocol and port 8005 for amp proxy
Kubecost docs is using correct value https://docs.kubecost.com/install-and-configure/install/custom-prom/aws-amp-integration#setting-up-the-environment

Without this change getting next errors

```shell
observability-v2-cost-analyzer-7444995bd6-v4rjk cost-model 2023-11-01T08:04:38.071944134Z ERR CostModel.ComputeAllocation: query context error Errors:
observability-v2-cost-analyzer-7444995bd6-v4rjk cost-model   Request Error: query error: 'Post "https://localhost:8005/workspaces/ws-9ffe0100-9a5d-1111-1111-fe96c6f13c99/api/v1/query?query=avg%28avg_over_time%28kube_replicaset_owner%7Bowner_kind%3D%22Rollout%22%2C+%7D%5B1h%5D%29%29+by+%28replicaset%2C+namespace%2C+owner_kind%2C+owner_name%2C+cluster_id%29&time=1698811200": http: server gave HTTP response to HTTPS client' fetching query 'avg(avg_over_time(kube_replicaset_owner{owner_kind="Rollout", }[1h])) by (replicaset, namespace, owner_kind, owner_name, cluster_id)'
```

```shell
https://localhost:8085/workspaces/ws-9ffe0100-1111-1111-b352-fe96c6f13c99/api/v1/query?query=max%28max_over_time%28container_memory_working_set_bytes%7Bcontainer%21%3D%22%22%2C+container_name%21%3D%22POD%22%2C+container%21%3D%22POD%22%2C+%7D%5B1h%5D%29%29+by+%28container_name%2C+container%2C+pod_name%2C+pod%2C+namespace%2C+instance%2C+cluster_id%29&time=1698796800”: dial tcp [::1]:8085: connect: connection refused’ fetching query ‘max(max_over_time(container_memory_working_set_bytes{container!=“”, container_name!=“POD”, container!=“POD”, }[1h])) by (container_name, container, pod_name, pod, namespace, instance, cluster_id)’
  Parse Error: Prometheus communication error: max(max_over_time(container_memory_working_set_bytes{container!=“”, container_name!=“POD”, container!=“POD”, }[1h])) by (container_name, container, pod_name, pod, namespace, instance, cluster_id)
for Query: max(max_over_time(container_memory_working_set_bytes{container!=“”, container_name!=“POD”, container!=“POD”, }[1h])) by (container_name, container, pod_name, pod, namespace, instance, cluster_id)
```


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No impact

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
No risks

## How was this PR tested?
Deployed to eks cluster using AMP backend

## Have you made an update to documentation? If so, please provide the corresponding PR.
Docs is using correct values already
