### PR TITLE
Fix Helm test, values linting

### DIFF
--- a/cost-analyzer/templates/tests/basic-health.yaml
+++ b/cost-analyzer/templates/tests/basic-health.yaml
@@ -1,32 +1,10 @@
 apiVersion: v1
-kind: Pod
+kind: ServiceAccount
 metadata:
-  name: basic-health
-  namespace: {{ .Release.Namespace }}
+  name: e2e-testing
   annotations:
     {{- include "kubecost.test.annotations" . | nindent 4 }}
-spec:
-  serviceAccountName: e2e-testing
-  restartPolicy: Never
-  containers:
-  - name: test-kubecost
-    image: alpine/k8s:1.26.9
-    command:
-      - /bin/sh
-    args:
-      - -c
-      - >-
-        svc=$(kubectl -n {{ .Release.Namespace }} get svc -l app.kubernetes.io/name=cost-analyzer -o json | jq -r .items[0].metadata.name);
-        echo Getting current Kubecost state.;
-        response=$(curl -sL http://${svc}:9090/model/getConfigs);
-        code=$(echo ${response} | jq .code);
-        if [ "$code" -eq 200 ]; then
-          echo "Got Kubecost working configuration. Successful."
-          exit 0
-        else 
-          echo "Failed to fetch Kubecost configuration. Response was $response"
-          exit 1
-        fi
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -57,9 +35,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
-kind: ServiceAccount
+kind: Pod
 metadata:
-  name: e2e-testing
+  name: basic-health
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- include "kubecost.test.annotations" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+spec:
+  serviceAccountName: e2e-testing
+  restartPolicy: Never
+  containers:
+  - name: test-kubecost
+    image: alpine/k8s:1.26.9
+    command:
+      - /bin/sh
+    args:
+      - -c
+      - >-
+        svc=$(kubectl -n {{ .Release.Namespace }} get svc -l app.kubernetes.io/name=cost-analyzer -o json | jq -r .items[0].metadata.name);
+        echo Getting current Kubecost state.;
+        response=$(curl -sL http://${svc}:9090/model/getConfigs);
+        code=$(echo ${response} | jq .code);
+        if [ "$code" -eq 200 ]; then
+          echo "Got Kubecost working configuration. Successful."
+          exit 0
+        else 
+          echo "Failed to fetch Kubecost configuration. Response was $response"
+          exit 1
+        fi

--- a/cost-analyzer/templates/tests/basic-health.yaml
+++ b/cost-analyzer/templates/tests/basic-health.yaml
@@ -1,38 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: e2e-testing
-  annotations:
-    {{- include "kubecost.test.annotations" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: e2e-testing-role
-  annotations:
-    {{- include "kubecost.test.annotations" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
-rules:
-- apiGroups: [""]
-  resources: ["services"]
-  verbs: ["list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: e2e-testing-rolebinding
-  annotations:
-    {{- include "kubecost.test.annotations" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
-subjects:
-- kind: ServiceAccount
-  name: e2e-testing
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: e2e-testing-role
-  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: Pod
@@ -42,7 +7,7 @@ metadata:
   annotations:
     {{- include "kubecost.test.annotations" . | nindent 4 }}
 spec:
-  serviceAccountName: e2e-testing
+  serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
   restartPolicy: Never
   containers:
   - name: test-kubecost

--- a/cost-analyzer/templates/tests/basic-health.yaml
+++ b/cost-analyzer/templates/tests/basic-health.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     {{- include "kubecost.test.annotations" . | nindent 4 }}
 spec:
-  serviceAccountName: tester
+  serviceAccountName: e2e-testing
   restartPolicy: Never
   containers:
   - name: test-kubecost
@@ -31,7 +31,9 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: test-role
+  name: e2e-testing-role
+  annotations:
+    {{- include "kubecost.test.annotations" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: [""]
@@ -41,19 +43,23 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: test-rolebinding
+  name: e2e-testing-rolebinding
+  annotations:
+    {{- include "kubecost.test.annotations" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
-  name: tester
+  name: e2e-testing
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: test-role
+  name: e2e-testing-role
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: tester
+  name: e2e-testing
+  annotations:
+    {{- include "kubecost.test.annotations" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1,9 +1,9 @@
 global:
   # zone: cluster.local (use only if your DNS server doesn't live in the same zone as kubecost)
   prometheus:
-    enabled: true # If false, Prometheus will not be installed -- Warning: Before changing this setting, please read to understand this setting https://docs.kubecost.com/install-and-configure/install/custom-prom
-    fqdn: http://cost-analyzer-prometheus-server.default.svc #example address of a prometheus to connect to. Include protocol (http:// or https://) Ignored if enabled: true
-    # insecureSkipVerify : false # If true, kubecost will not check the TLS cert of prometheus
+    enabled: true  # If false, Prometheus will not be installed -- Warning: Before changing this setting, please read to understand this setting https://docs.kubecost.com/install-and-configure/install/custom-prom
+    fqdn: http://cost-analyzer-prometheus-server.default.svc  # example address of a prometheus to connect to. Include protocol (http:// or https://) Ignored if enabled: true
+    # insecureSkipVerify: false  # If true, kubecost will not check the TLS cert of prometheus
     # queryServiceBasicAuthSecretName: dbsecret # kubectl create secret generic dbsecret -n kubecost --from-file=USERNAME --from-file=PASSWORD
     # queryServiceBearerTokenSecretName: mcdbsecret  # kubectl create secret generic mcdbsecret -n kubecost --from-file=TOKEN
 
@@ -16,10 +16,10 @@ global:
     # queryOffset: 3h # The offset to apply to all thanos queries in order to achieve synchronization on all cluster block stores
 
   grafana:
-    enabled: true # If false, Grafana will not be installed
-    domainName: cost-analyzer-grafana.default.svc #example grafana domain Ignored if enabled: true
-    scheme: "http" # http or https, for the domain name above.
-    proxy: true # If true, the kubecost frontend will route to your grafana through its service endpoint
+    enabled: true  # If false, Grafana will not be installed
+    domainName: cost-analyzer-grafana.default.svc  # example grafana domain Ignored if enabled: true
+    scheme: "http"  # http or https, for the domain name above.
+    proxy: true  # If true, the kubecost frontend will route to your grafana through its service endpoint
 #    fqdn: cost-analyzer-grafana.default.svc
 
   # Enable only when you are using GCP Marketplace ENT listing. Learn more at https://console.cloud.google.com/marketplace/product/kubecost-public/kubecost-ent
@@ -33,21 +33,21 @@ global:
   # Learn more at https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-unmanaged
   # --set prometheus.server.image.repository="gke.gcr.io/prometheus-engine/prometheus" \
   # --set prometheus.server.image.tag="v2.35.0-gmp.2-gke.0"
-    enabled: false # If true, kubecost will be configured to use GMP Prometheus image and query from Google Cloud Managed Service for Prometheus.
-    prometheusServerEndpoint: http://localhost:8085/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the GMP Prom proxy side car to the GMP database.
+    enabled: false  # If true, kubecost will be configured to use GMP Prometheus image and query from Google Cloud Managed Service for Prometheus.
+    prometheusServerEndpoint: http://localhost:8085/  # The prometheus service endpoint used by kubecost. The calls are forwarded through the GMP Prom proxy side car to the GMP database.
     gmpProxy:
       enabled: false
-      image: gke.gcr.io/prometheus-engine/frontend:v0.4.1-gke.0 # GMP Prometheus proxy image that serve as an endpoint to query metrics from GMP
+      image: gke.gcr.io/prometheus-engine/frontend:v0.4.1-gke.0  # GMP Prometheus proxy image that serve as an endpoint to query metrics from GMP
       imagePullPolicy: Always
       name: gmp-proxy
       port: 8085
-      projectId: YOUR_PROJECT_ID # example GCP project ID
+      projectId: YOUR_PROJECT_ID  # example GCP project ID
 
   # Amazon Managed Service for Prometheus
   amp:
-    enabled: false # If true, kubecost will be configured to remote_write and query from Amazon Managed Service for Prometheus.
-    prometheusServerEndpoint: http://localhost:8005/workspaces/<workspaceId>/ # The prometheus service endpoint used by kubecost. The calls are forwarded through the SigV4Proxy side car to the AMP workspace.
-    remoteWriteService: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspaceId>/api/v1/remote_write # The remote_write endpoint for the AMP workspace.
+    enabled: false  # If true, kubecost will be configured to remote_write and query from Amazon Managed Service for Prometheus.
+    prometheusServerEndpoint: http://localhost:8005/workspaces/<workspaceId>/  # The prometheus service endpoint used by kubecost. The calls are forwarded through the SigV4Proxy side car to the AMP workspace.
+    remoteWriteService: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/<workspaceId>/api/v1/remote_write  # The remote_write endpoint for the AMP workspace.
     sigv4:
       region: us-west-2
       # access_key: ACCESS_KEY # AWS Access key
@@ -65,8 +65,8 @@ global:
     name: mimir-proxy
     image: nginxinc/nginx-unprivileged
     port: 8085
-    mimirEndpoint: $mimir_endpoint #Your Mimir query endpoint. If your Mimir query endpoint is http://example.com/prometheus, replace $mimir_endpoint with http://example.com/
-    orgIdentifier: $your_tenant_ID #Your Grafana Mimir tenant ID
+    mimirEndpoint: $mimir_endpoint  # Your Mimir query endpoint. If your Mimir query endpoint is http://example.com/prometheus, replace $mimir_endpoint with http://example.com/
+    orgIdentifier: $your_tenant_ID  # Your Grafana Mimir tenant ID
     # basicAuth:
       # username: user
       # password: pwd
@@ -133,14 +133,14 @@ global:
         # - type: diagnostic          # Alerts when kubecost is unable to compute costs - ie: Prometheus unreachable
         #   window: 10m
 
-    alertmanager: # Supply an alertmanager FQDN to receive notifications from the app.
-      enabled: false # If true, allow kubecost to write to your alertmanager
-      fqdn: http://cost-analyzer-prometheus-server.default.svc #example fqdn. Ignored if prometheus.enabled: true
+    alertmanager:  # Supply an alertmanager FQDN to receive notifications from the app.
+      enabled: false  # If true, allow kubecost to write to your alertmanager
+      fqdn: http://cost-analyzer-prometheus-server.default.svc  # example fqdn. Ignored if prometheus.enabled: true
 
-   # Set saved Cost Allocation report(s) accessible from /reports
-   # Ref: http://docs.kubecost.com/saved-reports
+    # Set saved Cost Allocation report(s) accessible from /reports
+    # Ref: http://docs.kubecost.com/saved-reports
   savedReports:
-    enabled: false # If true, overwrites report parameters set through UI
+    enabled: false  # If true, overwrites report parameters set through UI
     reports:
       - title: "Example Saved Report 0"
         window: "today"
@@ -148,10 +148,10 @@ global:
         chartDisplay: "category"
         idle: "separate"
         rate: "cumulative"
-        accumulate: false # daily resolution
-        filters: # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api
-          - key: "cluster" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#allocation-apis-request-sizing-v2-api
-            operator: ":" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#filter-operators
+        accumulate: false  # daily resolution
+        filters:  # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api
+          - key: "cluster"  # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#allocation-apis-request-sizing-v2-api
+            operator: ":"  # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#filter-operators
             value: "dev"
       - title: "Example Saved Report 1"
         window: "month"
@@ -160,9 +160,9 @@ global:
         idle: "share"
         rate: "monthly"
         accumulate: false
-        filters: # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api
-          - key: "namespace" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#allocation-apis-request-sizing-v2-api
-            operator: "!:" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#filter-operators
+        filters:  # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api
+          - key: "namespace"  # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#allocation-apis-request-sizing-v2-api
+            operator: "!:"  # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#filter-operators
             value: "kubecost"
       - title: "Example Saved Report 2"
         window: "2020-11-11T00:00:00Z,2020-12-09T23:59:59Z"
@@ -170,18 +170,18 @@ global:
         chartDisplay: "category"
         idle: "hide"
         rate: "daily"
-        accumulate: true # entire window resolution
-        filters: [] # if no filters, specify empty array
+        accumulate: true  # entire window resolution
+        filters: []  # if no filters, specify empty array
 
   # Set saved Asset report(s) accessible from /reports
   # Ref: http://docs.kubecost.com/saved-reports
   assetReports:
-    enabled: false # If true, overwrites report parameters set through UI
+    enabled: false  # If true, overwrites report parameters set through UI
     reports:
     - title: "Example Asset Report 0"
       window: "today"
       aggregateBy: "type"
-      accumulate: false # daily resolution
+      accumulate: false  # daily resolution
       filters:
         - property: "cluster"
           value: "cluster-one"
@@ -189,14 +189,14 @@ global:
   # Set saved Advanced report(s) accessible from /reports
   # Ref: http://docs.kubecost.com/saved-reports
   advancedReports:
-    enabled: false # If true, overwrites report parameters set through UI
+    enabled: false  # If true, overwrites report parameters set through UI
     reports:
     - title: "Example Advanced Report 0"
       window: "7d"
       aggregateBy: "namespace"
-      filters: # same as allocation api filters Ref: https://docs.kubecost.com/apis/apis-overview/filters-api
-        - key: "cluster" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#allocation-apis-request-sizing-v2-api
-          operator: ":" # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#filter-operators
+      filters:  # same as allocation api filters Ref: https://docs.kubecost.com/apis/apis-overview/filters-api
+        - key: "cluster"  # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#allocation-apis-request-sizing-v2-api
+          operator: ":"  # Ref: https://docs.kubecost.com/apis/apis-overview/filters-api#filter-operators
           value: "dev"
       cloudBreakdown: "service"
       cloudJoin: "label:kubernetes_namespace"
@@ -204,7 +204,7 @@ global:
   # Set saved Cloud Cost report(s) accessible from /reports
   # Ref: http://docs.kubecost.com/saved-reports
   cloudCostReports:
-    enabled: false # If true, overwrites report parameters set through UI
+    enabled: false  # If true, overwrites report parameters set through UI
     reports:
       - title: "Cloud Cost Report 0"
         window: "today"
@@ -235,7 +235,7 @@ global:
       - ALL
 
 # generated at http://kubecost.com/install, used for alerts tracking and free trials
-kubecostToken: # ""
+kubecostToken:  # ""
 
 # Advanced pipeline for custom prices, enterprise key required
 pricingCsv:
@@ -243,7 +243,7 @@ pricingCsv:
   location:
     provider: "AWS"
     region: "us-east-1"
-    URI: s3://kc-csv-test/pricing_schema.csv # a valid file URI
+    URI: s3://kc-csv-test/pricing_schema.csv  # a valid file URI
     csvAccessCredentials: pricing-schema-access-secret
 
 # SAML integration for user management and RBAC, enterprise key required
@@ -283,20 +283,20 @@ saml:
 
 oidc:
   enabled: false
-  clientID: "" # application/client client_id parameter obtained from provider, used to make requests to server
-  clientSecret: "" # application/client client_secret parameter obtained from provider, used to make requests to server
+  clientID: ""  # application/client client_id parameter obtained from provider, used to make requests to server
+  clientSecret: ""  # application/client client_secret parameter obtained from provider, used to make requests to server
   # secretName: "kubecost-oidc-secret" # k8s secret where clientsecret will be stored
   # For use to provide a custom OIDC Secret. Overrides the usage of oidc.clientSecret and oidc.secretName.
   # Should contain the field directly.
   # Can be created using raw k8s secrets, external secrets, sealed secrets, or any other method.
   existingCustomSecret:
     enabled: false
-    name: "" # name of the secret containing the client secret
+    name: ""  # name of the secret containing the client secret
 
   # authURL: "https://my.auth.server/authorize" # endpoint for login to auth server
   # loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
   # discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
-  skipOnlineTokenValidation: false # if true, will skip accessing OIDC introspection endpoint for online token verification, and instead try to locally validate JWT claims
+  skipOnlineTokenValidation: false  # if true, will skip accessing OIDC introspection endpoint for online token verification, and instead try to locally validate JWT claims
   # hostedDomain: "example.com" # optional, blocks access to the auth domain specified in the hd claim of the provider ID token
   rbac:
     enabled: false
@@ -354,7 +354,7 @@ kubecostFrontend:
     periodSeconds: 10
     failureThreshold: 200
   ipv6:
-    enabled: true # disable if the cluster does not support ipv6
+    enabled: true  # disable if the cluster does not support ipv6
   # allow customizing nginx-conf server block
   # extraServerConfig: |-
   #   proxy_busy_buffers_size   512k;
@@ -406,7 +406,7 @@ kubecostMetrics:
       annotations: {}
 
     # Service Monitor for Kubecost Metrics
-    serviceMonitor: # the kubecost included prometheus uses scrapeConfigs and does not support service monitors. The following options assume an existing prometheus that supports serviceMonitors.
+    serviceMonitor:  # the kubecost included prometheus uses scrapeConfigs and does not support service monitors. The following options assume an existing prometheus that supports serviceMonitors.
       enabled: false
       additionalLabels: {}
       metricRelabelings: []
@@ -423,10 +423,10 @@ sigV4Proxy:
   imagePullPolicy: Always
   name: aps
   port: 8005
-  region: us-west-2 # The AWS region
-  host: aps-workspaces.us-west-2.amazonaws.com # The hostname for AMP service.
+  region: us-west-2  # The AWS region
+  host: aps-workspaces.us-west-2.amazonaws.com  # The hostname for AMP service.
   # role_arn: arn:aws:iam::<account>:role/role-name # The AWS IAM role to assume.
-  extraEnv: # Pass extra env variables to sigV4Proxy
+  extraEnv:  # Pass extra env variables to sigV4Proxy
   # - name: AWS_ACCESS_KEY_ID
   #   value: <access_key>
   # - name: AWS_SECRET_ACCESS_KEY
@@ -503,9 +503,9 @@ kubecostModel:
     requests:
       cpu: "200m"
       memory: "55Mi"
-    #limits:
-    #  cpu: "800m"
-    #  memory: "256Mi"
+    # limits:
+    #   cpu: "800m"
+    #   memory: "256Mi"
   livenessProbe:
     enabled: false
     initialDelaySeconds: 30
@@ -552,7 +552,7 @@ ingress:
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  paths: ["/"] # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing
+  paths: ["/"]  # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing
   pathType: ImplementationSpecific
   hosts:
     - cost-analyzer.local
@@ -574,21 +574,21 @@ affinity: {}
 # If true, creates a PriorityClass to be used by the cost-analyzer pod
 priority:
   enabled: false
-  name: "" # Provide name of existing priority class only. If left blank, upstream chart will create one from default template.
+  name: ""  # Provide name of existing priority class only. If left blank, upstream chart will create one from default template.
   # value: 1000000
 
 # If true, enable creation of NetworkPolicy resources.
 networkPolicy:
   enabled: false
-  denyEgress: true # create a network policy that denies egress from kubecost
-  sameNamespace: true # Set to true if cost analyzer and prometheus are on the same namespace
+  denyEgress: true  # create a network policy that denies egress from kubecost
+  sameNamespace: true  # Set to true if cost analyzer and prometheus are on the same namespace
 #  namespace: kubecost # Namespace where prometheus is installed
 
   # Cost-analyzer specific vars using the new template
   costAnalyzer:
-    enabled: false # If true, create a network policy for cost-analyzer
-    annotations: {} # annotations to be added to the network policy
-    additionalLabels: {} # additional labels to be added to the network policy
+    enabled: false  # If true, create a network policy for cost-analyzer
+    annotations: {}  # annotations to be added to the network policy
+    additionalLabels: {}  # additional labels to be added to the network policy
     # Examples rules:
     # ingressRules:
     #   - selectors: # allow ingress from self on all ports
@@ -623,7 +623,7 @@ extraVolumeMounts: []
 persistentVolume:
   size: 32Gi
   dbSize: 32.0Gi
-  enabled: true # Note that setting this to false means configurations will be wiped out on pod restart.
+  enabled: true  # Note that setting this to false means configurations will be wiped out on pod restart.
   # storageClass: "-" #
   # existingClaim: kubecost-cost-analyzer # a claim in the same namespace as kubecost
   labels: {}
@@ -644,14 +644,14 @@ remoteWrite:
     initImage: "gcr.io/kubecost1/sql-init"
     initImagePullPolicy: Always
     installLocal: true
-    remotePostgresAddress: "" # ignored if installing locally
+    remotePostgresAddress: ""  # ignored if installing locally
     ## PriorityClassName
     ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
     priorityClassName: ""
     persistentVolume:
       size: 200Gi
     auth:
-      password: admin # change me
+      password: admin  # change me
 
 prometheus:
   podSecurityPolicy:
@@ -698,7 +698,7 @@ prometheus:
       scrape_timeout: 60s
       evaluation_interval: 1m
       external_labels:
-        cluster_id: cluster-one # Each cluster should have a unique ID
+        cluster_id: cluster-one  # Each cluster should have a unique ID
     persistentVolume:
       size: 32Gi
       enabled: true
@@ -741,7 +741,7 @@ prometheus:
   #              action: keep
   #          queue_config:
   #            max_samples_per_send: 1000
-        #remote_read:
+        # remote_read:
         #  - url: "http://pgprometheus-adapter:9201/read"
     rules:
       groups:
@@ -800,8 +800,8 @@ networkCosts:
   port: 3001
   # this daemonset can use significant resources on large clusters: https://guide.kubecost.com/hc/en-us/articles/4407595973527-Network-Traffic-Cost-Allocation
   resources:
-    limits: # remove the limits by setting cpu: null
-      cpu: 500m # can be less, will depend on cluster size
+    limits:  # remove the limits by setting cpu: null
+      cpu: 500m  # can be less, will depend on cluster size
       # memory: it is not recommended to set a memory limit
     requests:
       cpu: 50m
@@ -820,7 +820,7 @@ networkCosts:
         # IPv4 Link Local Address Space
         - "169.254.0.0/16"
         # Private Address Ranges in RFC-1918
-        - "10.0.0.0/8" # Remove this entry if using Multi-AZ Kubernetes
+        - "10.0.0.0/8"  # Remove this entry if using Multi-AZ Kubernetes
         - "172.16.0.0/12"
         - "192.168.0.0/16"
 
@@ -862,7 +862,7 @@ networkCosts:
       azure-cloud-services: false
       # user defined services provide a way to define custom service endpoints which will label traffic metrics
       # falling within the defined address range.
-      #services:
+      # services:
       #  - service: "test-service-1"
       #    ips:
       #      - "19.1.1.2"
@@ -1049,7 +1049,7 @@ reporting:
   # googleAnalyticsTag is only included in our Enterprise offering.
   # googleAnalyticsTag: G-XXXXXXXXX
 
-serviceMonitor: # the kubecost included prometheus uses scrapeConfigs and does not support service monitors. The following options assume an existing prometheus that supports serviceMonitors.
+serviceMonitor:  # the kubecost included prometheus uses scrapeConfigs and does not support service monitors. The following options assume an existing prometheus that supports serviceMonitors.
   enabled: false
   additionalLabels: {}
   metricRelabelings: []
@@ -1067,12 +1067,12 @@ prometheusRule:
 
 supportNFS: false
 # initChownDataImage ensures all Kubecost filepath permissions on PV or local storage are set up correctly.
-initChownDataImage: "busybox" # Supports a fully qualified Docker image, e.g. registry.hub.docker.com/library/busybox:latest
+initChownDataImage: "busybox"  # Supports a fully qualified Docker image, e.g. registry.hub.docker.com/library/busybox:latest
 initChownData:
   resources: {}
-    #requests:
-    #  cpu: "50m"
-    #  memory: "20Mi"
+    # requests:
+    #   cpu: "50m"
+    #   memory: "20Mi"
 
 grafana:
   # namespace_datasources: kubecost # override the default namespace here
@@ -1113,7 +1113,7 @@ grafana:
       serve_from_sub_path: true
       root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana"
 serviceAccount:
-  create: true # Set this to false if you're bringing your own service account.
+  create: true  # Set this to false if you're bringing your own service account.
   annotations: {}
   # name: kc-test
 awsstore:
@@ -1195,7 +1195,7 @@ costEventsAudit:
 # These configs can also be set from the Settings page in the Kubecost product UI
 # Values in this block override config changes in the Settings UI on pod restart
 #
-#kubecostProductConfigs:
+# kubecostProductConfigs:
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.
 # Ref: https://github.com/kubecost/docs/blob/main/multi-cluster.md


### PR DESCRIPTION
## What does this PR change?

* Lints the main values file for comments in preparation for expanded testing.
* Fixes (through simplification) the basic-health test so all resources are only created when `helm test` is invoked. Leverage existing RBAC resources rather than creating anew.
* Renames the basic-health test resources with a better name.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Only user impact is, upon Kubecost installation, they will no longer see the basic-health test's ServiceAccount, Role, and RoleBinding which is correct.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

Values file could be malformed. Test may not execute properly.

## How was this PR tested?

Tested locally. Will also be tested in CI checks.

## Have you made an update to documentation? If so, please provide the corresponding PR.

