### PR TITLE
root user compatibility defaults

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -69,7 +69,7 @@ spec:
       {{- else if lt $nginxPort 1025 }}
       securityContext:
         runAsUser: 0
-              {{- else if .Values.global.securityContext }}
+      {{- else if .Values.global.securityContext }}
       securityContext:
         {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- else }}
@@ -331,7 +331,7 @@ spec:
             {{- end }}
           securityContext:
             runAsUser: 0
-            {{ end }}
+{{ end }}
       containers:
         {{- if .Values.global.gmp.enabled }}
         - name: {{ .Values.global.gmp.gmpProxy.name }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -69,7 +69,7 @@ spec:
       {{- else if lt $nginxPort 1025 }}
       securityContext:
         runAsUser: 0
-      {{- else if .Values.global.securityContext }}
+              {{- else if .Values.global.securityContext }}
       securityContext:
         {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- else }}
@@ -331,7 +331,7 @@ spec:
             {{- end }}
           securityContext:
             runAsUser: 0
-{{ end }}
+            {{ end }}
       containers:
         {{- if .Values.global.gmp.enabled }}
         - name: {{ .Values.global.gmp.gmpProxy.name }}
@@ -1147,7 +1147,7 @@ spec:
         {{- if .Values.kubecostFrontend.securityContext }}
           securityContext:
             {{- toYaml .Values.kubecostFrontend.securityContext | nindent 12 }}
-          {{- else if .Values.global.containerSecurityContext }}
+          {{- else if and .Values.global.containerSecurityContext (gt $nginxPort 1025) }}
           securityContext:
             {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
## What does this PR change?
Prevent applying new container security contraints when using root user.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Add a note that using ports under 1025 and root user will be deprecated in a future release.

## Links to Issues or tickets this PR addresses or fixes
#2710

## What risks are associated with merging this PR? What is required to fully test this PR?
Should be low risk and simply allow for backwards compatibility.

## How was this PR tested?
Using helm settings provider in issue:
```
service:
  host: kubecost
  port: 80
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

NA