### PR TITLE
Minor template fixes

### DIFF
--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -67,7 +67,9 @@ spec:
               subPath: download_dashboards.sh
             - name: storage
               mountPath: "/var/lib/grafana"
+              {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
           {{- range .Values.extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
@@ -179,7 +181,9 @@ spec:
 {{- end}}
             - name: storage
               mountPath: "/var/lib/grafana"
+              {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
           {{- range .Values.extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}

--- a/cost-analyzer/charts/grafana/templates/deployment.yaml
+++ b/cost-analyzer/charts/grafana/templates/deployment.yaml
@@ -96,8 +96,10 @@ spec:
               value: "{{ .Values.sidecar.dashboards.folder }}"
             - name: ERROR_THROTTLE_SLEEP
               value: "{{ .Values.sidecar.dashboards.error_throttle_sleep }}"
+          {{- with .Values.sidecar.resources }}
           resources:
-{{ toYaml .Values.sidecar.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: sc-dashboard-volume
               mountPath: {{ .Values.sidecar.dashboards.folder | quote }}

--- a/cost-analyzer/charts/grafana/templates/role.yaml
+++ b/cost-analyzer/charts/grafana/templates/role.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
-{{- if .Values.rbac.create }}
+{{ if and .Values.global.grafana.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -10,12 +9,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.rbac.pspEnabled }}
 rules:
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']
   resourceNames:  [{{ template "grafana.fullname" . }}]
-{{- end }}
-{{- end }}
 {{ end }}

--- a/cost-analyzer/charts/grafana/templates/rolebinding.yaml
+++ b/cost-analyzer/charts/grafana/templates/rolebinding.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
-{{- if .Values.rbac.create -}}
+{{ if and .Values.global.grafana.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -17,5 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "grafana.serviceAccountName" . }}
-{{- end -}}
 {{ end }}

--- a/cost-analyzer/charts/grafana/values.yaml
+++ b/cost-analyzer/charts/grafana/values.yaml
@@ -260,13 +260,7 @@ sidecar:
     repository: kiwigrid/k8s-sidecar
     tag: 1.25.1
     pullPolicy: IfNotPresent
-  resources:
-#   limits:
-#     cpu: 100m
-#     memory: 100Mi
-#   requests:
-#     cpu: 50m
-#     memory: 50Mi
+  resources: {}
   dashboards:
     enabled: false
     # label that the configmaps with dashboards are marked with

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -467,10 +467,10 @@ spec:
         - image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
         {{- else }}
         - image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
-        {{ end }}
+        {{- end }}
         {{- else }}
         - image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
-        {{ end }}
+        {{- end }}
           name: cost-model
         {{- if .Values.kubecostModel.extraArgs }}
           args:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -307,16 +307,18 @@ spec:
             claimName: {{ template "cost-analyzer.fullname" . }}-db
 {{- end }}
 {{- end }}
-      initContainers:
 {{- if .Values.supportNFS }}
+      initContainers:
         - name: config-db-perms-fix
         {{- if .Values.initChownDataImage }}
           image: {{ .Values.initChownDataImage }}
         {{- else }}
           image: busybox
         {{- end }}
+          {{- with .Values.initChownData.resources }}
           resources:
-{{ toYaml .Values.initChownData.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if and (.Values.kubecostModel.etlToDisk | default true) .Values.persistentVolume.dbPVEnabled }}
           command: ["sh", "-c", "/bin/chmod -R 777 /var/configs && /bin/chmod -R 777 /var/db"]
           {{- else }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -531,6 +531,7 @@ kubecostModel:
     #  - secretName: cost-analyzer-model-tls
     #    hosts:
     #      - cost-analyzer-model.local
+  utcOffset: "+00:00"
 
 # etlUtils is a utility currently used by Kubecost internal support to implement specific functionality related to Thanos conversion.
 etlUtils:


### PR DESCRIPTION
## What does this PR change?

Makes minor adjustments to templates to fix invalid outputs addressing things like null/empty string fields, empty structs, or resources which are (basically) empty. These fixes make it so that the fully rendered output is conformant for Kubernetes linters. Two of the most visible changes:

1. Role and RoleBinding for Grafana will not be created when PSP is not in use. 
2. UTC_OFFSET now has a value of `+00:00` (adopted from EKS values) whereas previously the env var was set with an empty value.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

No user impact

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

Change has an unintended consequence.

## How was this PR tested?

Templated locally for each change.

## Have you made an update to documentation? If so, please provide the corresponding PR.

