### PR TITLE
hideDiagnostics / hideOrphanedResources

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -612,15 +612,23 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     {{- end }}
-        location = /model/hideDiagnostics {
-            default_type text/html;
-            {{- if .Values.kubecostFrontend.hideDiagnostics }}
-            return 200 'true';
+
+        location = /model/hideOrphanedResources {
+            default_type 'application/json';
+            {{- if .Values.kubecostFrontend.hideOrphanedResources }}
+            return 200 '{"hideOrphanedResources": "true"}';
             {{- else }}
-            return 200 'false';
+            return 200 '{"hideOrphanedResources": "false"}';
             {{- end }}
         }
-
+        location = /model/hideDiagnostics {
+            default_type 'application/json';
+            {{- if .Values.kubecostFrontend.hideDiagnostics }}
+            return 200 '{"hideDiagnostics": "true"}';
+            {{- else }}
+            return 200 '{"hideDiagnostics": "false"}';
+            {{- end }}
+        }
     {{- if .Values.kubecostAggregator.cloudCost.enabled }}
         location = /model/cloudCost/status {
             proxy_read_timeout          300;

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -361,8 +361,8 @@ kubecostFrontend:
   #   proxy_buffers   4 512k;
   #   proxy_buffer_size   256k;
   #   large_client_header_buffers 4 64k;
-  # hideDiagnostics: false # used if the primary is not monitored. Supported in limited environments.
-  # hideOrphanedResources: false # OrphanedResources is a primary-cluster-only report. WIP to support agent clusters.
+  # hideDiagnostics: false  # useful if the primary is not monitored. Supported in limited environments.
+  # hideOrphanedResources: false  # OrphanedResources works on the primary-cluster's cloud-provider only.
 #  api:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -362,7 +362,7 @@ kubecostFrontend:
   #   proxy_buffer_size   256k;
   #   large_client_header_buffers 4 64k;
   # hideDiagnostics: false # used if the primary is not monitored. Supported in limited environments.
-
+  # hideOrphanedResources: false # OrphanedResources is a primary-cluster-only report. WIP to support agent clusters.
 #  api:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:


### PR DESCRIPTION
## What does this PR change?

Update #2651: format as json, add option to hideOrphanedResources

## Does this PR rely on any other PRs?
https://github.com/kubecost/kubecost-frontend/pull/544 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- *Limited support* 
- Adds option to hideDiagnostics and/or hideOrphanedResources.
- hideOrphanedResources hides the savings card. This card depends on Kubecost having access to the cloud services and is currently slow in large environments. There is a long-term change being discussed.

## Links to Issues or tickets this PR addresses or fixes
- https://kubecost.atlassian.net/browse/SELFHOST-944
- https://kubecost.atlassian.net/browse/SELFHOST-869


## What risks are associated with merging this PR? What is required to fully test this PR?
Next to none, simple change.

## How was this PR tested?

```
helm template kubecost ./cost-analyzer --set kubecostFrontend.hideOrphanedDiagnostics=true >.idea/hideorph.yaml
helm template kubecost ./cost-analyzer --set kubecostFrontend.hideDiagnostics=true >.idea/hidediag.yaml
```

and compare changes.
We also have a live POC running.

## Have you made an update to documentation? If so, please provide the corresponding PR.

updated helm values, otherwise will not be documented.
