### PR TITLE
fix networkCosts labels

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -243,6 +243,24 @@ app: aggregator
 {{- end -}}
 
 {{/*
+Create the networkcosts common labels. Note that because this is a daemonset, we don't want app.kubernetes.io/instance: to take the release name, which allows the scrape config to be static.
+*/}}
+{{- define "networkcosts.commonLabels" -}}
+app.kubernetes.io/instance: kubecost
+app.kubernetes.io/name: network-costs
+helm.sh/chart: {{ include "cost-analyzer.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app: kubecost-network-costs
+{{- end -}}
+{{- define "networkcosts.selectorLabels" -}}
+app.kubernetes.io/instance: kubecost
+app.kubernetes.io/name: network-costs
+{{- end }}
+
+{{/*
+{{- end -}}
+
+{{/*
 Create the selector labels.
 */}}
 {{- define "cost-analyzer.selectorLabels" -}}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-service-template.yaml
@@ -16,11 +16,10 @@ metadata:
 {{- end }}
 {{- end }}
   labels:
-    {{ unset (include "cost-analyzer.commonLabels" . | fromYaml) "app" | toYaml | nindent 4 }}
-    app: {{ template "cost-analyzer.networkCostsName" . }}
-{{- if .Values.networkCosts.service.labels }}
-{{ toYaml .Values.networkCosts.service.labels | indent 4 }}
-{{- end }}
+    {{- include "networkcosts.commonLabels" . | nindent 4 }}
+    {{- if .Values.networkCosts.service.labels }}
+    {{ toYaml .Values.networkCosts.service.labels | nindent 4 }}
+    {{- end }}
 spec:
   clusterIP: None
   ports:
@@ -29,7 +28,7 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.networkCosts.port | default 3001 }}
   selector:
-    app: {{ template "cost-analyzer.networkCostsName" . }}
+    {{- include "networkcosts.selectorLabels" . | nindent 4 }}
   type: ClusterIP
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "cost-analyzer.networkCostsName" . }}
+    {{- include "networkcosts.commonLabels" . | nindent 4 }}
     {{- if .Values.networkCosts.additionalLabels }}
     {{- toYaml .Values.networkCosts.additionalLabels | nindent 4 }}
     {{- end }}
@@ -17,7 +17,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "cost-analyzer.networkCostsName" . }}
+      {{- include "networkcosts.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.networkCosts.annotations }}
@@ -25,7 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: {{ template "cost-analyzer.networkCostsName" . }}
+        {{- include "networkcosts.commonLabels" . | nindent 8 }}
         {{- if .Values.networkCosts.additionalLabels }}
         {{- toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
         {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -6,10 +6,10 @@ metadata:
   name: {{ template "cost-analyzer.networkCostsName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
-{{- if .Values.networkCosts.additionalLabels }}
-{{ toYaml .Values.networkCosts.additionalLabels | indent 4 }}
-{{- end }}
+    app: {{ template "cost-analyzer.networkCostsName" . }}
+    {{- if .Values.networkCosts.additionalLabels }}
+    {{- toYaml .Values.networkCosts.additionalLabels | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.networkCosts.updateStrategy }}
   updateStrategy:
@@ -27,7 +27,7 @@ spec:
       labels:
         app: {{ template "cost-analyzer.networkCostsName" . }}
         {{- if .Values.networkCosts.additionalLabels }}
-        {{ toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
+        {{- toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
         {{- end }}
     spec:
     {{- if .Values.imagePullSecrets }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -895,9 +895,7 @@ networkCosts:
     enabled: false
     additionalLabels: {}
   # match the default extraScrapeConfig
-  additionalLabels:
-    app.kubernetes.io/instance: kubecost
-    app.kubernetes.io/name: network-costs
+  additionalLabels: {}
   nodeSelector: {}
   annotations: {}
   healthCheckProbes: {}


### PR DESCRIPTION
## What does this PR change?
Removes duplicate labels in networkCosts caused by #2677 

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Change labels for networkCosts daemonset

## Links to Issues or tickets this PR addresses or fixes
Fixes #2737 


## What risks are associated with merging this PR? What is required to fully test this PR?
Users have targets for the networkCost legacy labels. Unlikely, given that they are duplicated on other pods.

The previous labels were:

```sh
helm template kubecost kubecost/cost-analyzer --version 1.106.4 --set networkCosts.enabled=true --set global.prometheus.enabled=false|ag 'kind: daemonset' -A29
```
```yaml
kind: DaemonSet
metadata:
  name: kubecost-network-costs
  namespace: kubecost-agent
  labels:
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-1.106.4
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
spec:
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app: kubecost-network-costs
  template:
    metadata:
      labels:
        app: kubecost-network-cost
```

## How was this PR tested?
```sh
helm template kubecost ./cost-analyzer --set networkCosts.enabled=true --set global.prometheus.enabled=false|ag 'kind: daemonset' -A28
```
```yaml
kind: DaemonSet
metadata:
  name: kubecost-network-costs
  namespace: kubecost-agent
  labels:
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/name: network-costs
    helm.sh/chart: cost-analyzer-1.107.0
    app.kubernetes.io/managed-by: Helm
    app: kubecost-network-costs
spec:
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/instance: kubecost
      app.kubernetes.io/name: network-costs
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: kubecost
        app.kubernetes.io/name: network-costs
        helm.sh/chart: cost-analyzer-1.107.0
        app.kubernetes.io/managed-by: Helm
        app: kubecost-network-costs
```
Also verified that the scrape config is still working. 

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
