### PR TITLE
Prometheus Alertmanager ConfigmapReload disabled by default

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/alertmanager-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-deployment.yaml
@@ -88,8 +88,8 @@ spec:
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
           args:
-            - --volume-dir=/etc/config
-            - --webhook-url=http://127.0.0.1:9093{{ .Values.alertmanager.prefixURL }}/-/reload
+            - --watched-dir=/etc/config
+            - --reload-url=http://127.0.0.1:9093{{ .Values.alertmanager.prefixURL }}/-/reload
           resources:
 {{ toYaml .Values.configmapReload.alertmanager.resources | indent 12 }}
           volumeMounts:

--- a/cost-analyzer/charts/prometheus/templates/alertmanager-statefulset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/alertmanager-statefulset.yaml
@@ -92,8 +92,8 @@ spec:
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
           args:
-            - --volume-dir=/etc/config
-            - --webhook-url=http://localhost:9093{{ .Values.alertmanager.prefixURL }}/-/reload
+            - --watched-dir=/etc/config
+            - --reload-url=http://localhost:9093{{ .Values.alertmanager.prefixURL }}/-/reload
           resources:
 {{ toYaml .Values.configmapReload.alertmanager.resources | indent 12 }}
           volumeMounts:

--- a/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - --{{ $key }}={{ $value }}
           {{- end }}
           {{- range .Values.configmapReload.prometheus.extraVolumeDirs }}
-            - --volume-dir={{ . }}
+            - --watched-dir={{ . }}
           {{- end }}
           resources:
           {{- toYaml .Values.configmapReload.prometheus.resources | nindent 12 }}

--- a/cost-analyzer/charts/prometheus/templates/server-statefulset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - --{{ $key }}={{ $value }}
           {{- end }}
           {{- range .Values.configmapReload.prometheus.extraVolumeDirs }}
-            - --volume-dir={{ . }}
+            - --watched-dir={{ . }}
           {{- end }}
           resources:
 {{ toYaml .Values.configmapReload.prometheus.resources | indent 12 }}

--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -351,7 +351,7 @@ configmapReload:
   alertmanager:
     ## If false, the configmap-reload container will not be deployed
     ##
-    enabled: true
+    enabled: false
 
     ## configmap-reload container name
     ##


### PR DESCRIPTION
## What does this PR change?

- Default disable Prometheus's Alertmanager ConfigmapReload container.
- Fix the arguments being passed to Alertmanager ConfigmapReload. Big thanks to @chipzoller!

Originally, the issue was that the new `quay.io/prometheus-operator/prometheus-config-reloader` image was failing to start because it was being passed incorrect parameters.

```
$ kubectl describe pod thomasn-alerts-prometheus-alertmanager-544d587f9b-xlx77

Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
  Normal   Scheduled  26s               default-scheduler  Successfully assigned thomasn-alerts/thomasn-alerts-prometheus-alertmanager-544d587f9b-xlx77 to gke-qa-gcp1-default-pool-169fb9bb-sock
  Normal   Pulled     23s               kubelet            Container image "quay.io/prometheus/alertmanager:v0.25.0" already present on machine
  Normal   Created    23s               kubelet            Created container prometheus-alertmanager
  Normal   Started    23s               kubelet            Started container prometheus-alertmanager
  Normal   Pulled     7s (x3 over 23s)  kubelet            Container image "quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0" already present on machine
  Normal   Created    7s (x3 over 23s)  kubelet            Created container prometheus-alertmanager-configmap-reload
  Normal   Started    7s (x3 over 22s)  kubelet            Started container prometheus-alertmanager-configmap-reload
  Warning  BackOff    5s (x3 over 20s)  kubelet            Back-off restarting failed container prometheus-alertmanager-configmap-reload in pod thomasn-alerts-prometheus-alertmanager-544d587f9b-xlx77_thomasn-alerts(ffc5cec8-7511-4807-97b4-82958d3161b6)
```

```
$ kubectl logs thomasn-alerts-prometheus-alertmanager-544d587f9b-xlx77 -c prometheus-alertmanager-configmap-reload

unknown long flag '--volume-dir'
```

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Affects users deploying Prometheus Alertmanager via the cost-analyzer-helm-chart. However, I suspect there are few.
- For those users, the ConfigmapReloader will be default disabled. When they update their alerting configs in the configmap, it will require a hard restart of the Alertmanager pod.

## Links to Issues or tickets this PR addresses or fixes

- Fixes small bug originally introduced in PR https://github.com/kubecost/cost-analyzer-helm-chart/pull/2698

## What risks are associated with merging this PR? What is required to fully test this PR?

- Minor risks to existing users deploying Prometheus Alertmanager via the cost-analyzer-helm-chart

## How was this PR tested?

Now seeing successful logs from the `prometheus-alertmanager-configmap-reload` container

```
level=info ts=2023-11-16T21:22:50.099152251Z caller=main.go:115 msg="Starting prometheus-config-reloader" version="(version=0.68.0, branch=refs/tags/v0.68.0, revision=52526e3b0cfb5f3deaa967998ff88
level=info ts=2023-11-16T21:22:50.099323059Z caller=main.go:116 build_context="(go=go1.20.7, platform=linux/amd64, user=Action-Run-ID-6123005285, date=20230908-14:54:18, tags=unknown)"
level=info ts=2023-11-16T21:22:50.105095687Z caller=reloader.go:237 msg="started watching config file and directories for changes" cfg= out= dirs=/etc/config
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

- Not needed.
