### PR TITLE
networkCosts selector

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -250,11 +250,10 @@ app.kubernetes.io/instance: kubecost
 app.kubernetes.io/name: network-costs
 helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app: kubecost-network-costs
+app: {{ template "cost-analyzer.networkCostsName" . }}
 {{- end -}}
 {{- define "networkcosts.selectorLabels" -}}
-app.kubernetes.io/instance: kubecost
-app.kubernetes.io/name: network-costs
+app: {{ template "cost-analyzer.networkCostsName" . }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## What does this PR change?
Revert to old selector while keeping as much of the best-practice labels as possible.
The update to the networkCosts selector labels, while ideal, prevents helm upgrades. 

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
NA, revert change from #2741

## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
A few tests. 
- upgrade from 1.106.4
- upgrade from 1.107.0
- check that prometheus is still finding the target and scraping


## Have you made an update to documentation? If so, please provide the corresponding PR.

```sh
helm template kubecost ./cost-analyzer --set networkCosts.enabled=true --set global.prometheus.enabled=false|ag 'kind: daemonset' -A28
```
```yaml
kind: DaemonSet
metadata:
  name: kubecost-network-costs
  namespace: kubecost-agent
  labels:
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/name: network-costs
    helm.sh/chart: cost-analyzer-1.107.0
    app.kubernetes.io/managed-by: Helm
    app: kubecost-network-costs
spec:
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app: kubecost-network-costs
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: kubecost
        app.kubernetes.io/name: network-costs
        helm.sh/chart: cost-analyzer-1.107.0
        app.kubernetes.io/managed-by: Helm
        app: kubecost-network-costs
```