### PR TITLE
helm changes to add enterprise network enabled flag

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -954,7 +954,7 @@ spec:
             # enabled when network cost is enabled and one of the service tagging is enabled
             {{- if .Values.networkCosts.config.services }}
             {{- $services := .Values.networkCosts.config.services -}}
-            {{- if or (index $services "google-cloud-services") (index $services "aws-cloud-services") (index $services "azure-cloud-services")}}
+            {{- if or (index $services "google-cloud-services") (index $services "amazon-web-services") (index $services "azure-cloud-services")}}
             - name: ADVANCED_NETWORK_STATS
               value: "true"
             {{- else}}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -949,6 +949,16 @@ spec:
             {{- if .Values.networkCosts.enabled }}
             - name: NETWORK_COSTS_PORT
               value: {{ quote .Values.networkCosts.port | default (quote 3001) }}
+            {{- if .Values.networkCosts.config.services }}
+            {{- $services := .Values.networkCosts.config.services -}}
+            {{- if or (index $services "google-cloud-services") (index $services "aws-cloud-services") (index $services "azure-cloud-services")}}
+            - name: ENTERPRISE_NETWORK_ENABLED
+              value: "true"
+            {{- else}}
+            - name: ENTERPRISE_NETWORK_ENABLED
+              value: "false"
+            {{- end}}
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- /*

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -949,13 +949,16 @@ spec:
             {{- if .Values.networkCosts.enabled }}
             - name: NETWORK_COSTS_PORT
               value: {{ quote .Values.networkCosts.port | default (quote 3001) }}
+            # ADVANCED_NETWORK_STATS is a feature offered by Kubecost that gives you network
+            # insights of your Kubernetes resources with cloud services. The feature is 
+            # enabled when network cost is enabled and one of the service tagging is enabled
             {{- if .Values.networkCosts.config.services }}
             {{- $services := .Values.networkCosts.config.services -}}
             {{- if or (index $services "google-cloud-services") (index $services "aws-cloud-services") (index $services "azure-cloud-services")}}
-            - name: ENTERPRISE_NETWORK_ENABLED
+            - name: ADVANCED_NETWORK_STATS
               value: "true"
             {{- else}}
-            - name: ENTERPRISE_NETWORK_ENABLED
+            - name: ADVANCED_NETWORK_STATS
               value: "false"
             {{- end}}
             {{- end }}


### PR DESCRIPTION
## What does this PR change?
Enabled enterprise network when and of the service tagging is enabled https://docs.kubecost.com/install-and-configure/advanced-configuration/network-costs-configuration#cloud-provider-service-tagging 

## Does this PR rely on any other PRs?
KCM PR 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Have ability to enable enterprise networking

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
In my cluster helm upgrading with the helm values

## Have you made an update to documentation? If so, please provide the corresponding PR.
Not yet!
