### PR TITLE
feat(cost-analyzer): add Services sessionAffinity option

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -73,4 +73,14 @@ spec:
       targetPort: 9004
     {{- end }}
     {{- end }}
+{{- if .Values.service.sessionAffinity.enabled }}
+  sessionAffinity: ClientIP
+  {{- if .Values.service.sessionAffinity.timeoutSeconds }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.service.sessionAffinity.timeoutSeconds }}
+  {{- end }}
+{{- else }}
+  sessionAffinity: None
+{{- end }}
 {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -637,6 +637,9 @@ service:
   # nodePort:
   labels: {}
   annotations: {}
+  sessionAffinity:
+    enabled: false # Makes sure that connections from a client are passed to the same Pod each time, when set to `true`. You should set it when you enabled authentication through OIDC or SAML integration.
+    timeoutSeconds: 10800
 
 # Enabling long-term durable storage with Postgres requires an enterprise license
 remoteWrite:


### PR DESCRIPTION
resolves #2757

## What does this PR change?

Introduction of values being usable for enabling `kubecost-cost-analyzer` Service `sessionAffinity`. So that we do not need to stick to the default none stickiness behaviour within the Kubernetes Service.

## Does this PR rely on any other PRs?

no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- `kubecost-cost-analyzer` Service can be configured to stay sticky with the client session to a Pod with `service.sessionAffinity.enabled: true`

## Links to Issues or tickets this PR addresses or fixes

resolves #2757

## What risks are associated with merging this PR? What is required to fully test this PR?

no risk added, testing possible through setting the values as described

## How was this PR tested?

`helm template . --set=service.sessionAffinity.enabled=true`

## Have you made an update to documentation? If so, please provide the corresponding PR.

