### PR TITLE
update configmap reloader image

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -151,8 +151,8 @@ prometheus:
       ## configmap-reload container image
       ##
       image:
-        repository: public.ecr.aws/bitnami/configmap-reload
-        tag: 0.7.1
+        repository: public.ecr.aws/kubecost/prometheus-config-reloader
+        tag: v0.68.0
         pullPolicy: IfNotPresent
       ## Additional configmap-reload container arguments
       ##
@@ -172,7 +172,7 @@ prometheus:
       ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
       ##
       resources: {}
-     
+
   kube-state-metrics:
     disabled: false
   nodeExporter:


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Updates the Prometheus ConfigMap reloader image in the EKS values with the one changed in #2698. The same image has been copied to public.ecr.aws/kubecost.


## Does this PR rely on any other PRs?

No, is a follow-on fix from #2698

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows users to upgrade to 107 in EKS

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

Image can't be pulled or upgrade fails.

## How was this PR tested?

Pulled image locally

## Have you made an update to documentation? If so, please provide the corresponding PR.

See https://github.com/kubecost/docs/issues/816