### PR TITLE
systemProxy and extraEnv

### DIFF
--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -148,8 +148,23 @@ spec:
               value: "false" # this pod should never run KC's concept of "ETL"
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API key.This GCP api key is expected to be here and is limited to accessing google's billing API.'
-              value: "true" # just in case, not sure if necessary
-
+          {{- if .Values.systemProxy.enabled }}
+            - name: HTTP_PROXY
+              value: {{ .Values.systemProxy.httpProxyUrl }}
+            - name: http_proxy
+              value: {{ .Values.systemProxy.httpProxyUrl }}
+            - name: HTTPS_PROXY
+              value:  {{ .Values.systemProxy.httpsProxyUrl }}
+            - name: https_proxy
+              value:  {{ .Values.systemProxy.httpsProxyUrl }}
+            - name: NO_PROXY
+              value:  {{ .Values.systemProxy.noProxy }}
+            - name: no_proxy
+              value:  {{ .Values.systemProxy.noProxy }}
+            {{- end }}
+            {{- if .Values.kubecostAggregator.extraEnv -}}
+            {{ toYaml .Values.kubecostAggregator.extraEnv | nindent 12 }}
+            {{- end }}
             {{- if $etlBackupBucketSecret }}
             # If this isn't set, we pretty much have to be in a read only state,
             # initialization will probably fail otherwise.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1002,6 +1002,9 @@ kubecostAggregator:
     # default storage class
     storageClass: ""
     storageRequest: 128Gi
+  # extraEnv:
+  # - name: SOME_VARIABLE
+  #   value: "some_value"
   # securityContext:
   #   runAsGroup: 1001
   #   runAsUser: 1001


### PR DESCRIPTION
## What does this PR change?
add support for http_proxy and extraEnv to aggregator

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Added support for http_proxy and extraEnv to aggregator

## Links to Issues or tickets this PR addresses or fixes
may fix:
https://github.com/duckdb/duckdb/issues/3836

## What risks are associated with merging this PR? What is required to fully test this PR?



## How was this PR tested?
templated with aggregator on and proxy values set:

```yaml
systemProxy:
  enabled: true
  httpProxyUrl: http://proxy-svc:3128
  httpsProxyUrl: http://proxy-svc:3128
  noProxy: localhost,127.0.0.1,.svc,.kubecost,10.0.0.0/8,192.0.0.0/8
kubecostAggregator:
  enabled: true
  extraEnv:
  - name: MYENV
    value: myvalue
```

result has proxy variables, indented properly

## Have you made an update to documentation? If so, please provide the corresponding PR.

updated values.yaml
