### PR TITLE
add variable for nginx timeout

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -194,9 +194,9 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location /model/ {
-            proxy_connect_timeout       600;
-            proxy_send_timeout          600;
-            proxy_read_timeout          600;
+            proxy_connect_timeout       {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_send_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://model/;
             proxy_redirect off;
             proxy_http_version 1.1;
@@ -320,9 +320,9 @@ data:
       {{- end }}
 
         location /model/allocation {
-            proxy_connect_timeout       600;
-            proxy_send_timeout          600;
-            proxy_read_timeout          600;
+            proxy_connect_timeout       {{ .Values.kubecostFrontend.timeoutSeconds | default 600 }};
+            proxy_send_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 600 }};
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 600 }};
             proxy_pass http://queryservice/allocation;
             proxy_redirect off;
             proxy_http_version 1.1;
@@ -332,9 +332,9 @@ data:
         }
 
         location /model/assets {
-            proxy_connect_timeout       600;
-            proxy_send_timeout          600;
-            proxy_read_timeout          600;
+            proxy_connect_timeout       {{ .Values.kubecostFrontend.timeoutSeconds | default 600 }};
+            proxy_send_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 600 }};
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 600 }};
             proxy_pass http://queryservice/assets;
             proxy_redirect off;
             proxy_http_version 1.1;
@@ -347,9 +347,9 @@ data:
         # for example if you want heap dump from query service end point should be
         # /model/queryservice/debug/pprof/heap to get queryservice heap dumps
         location ~ /model/queryservice/(.*)$ {
-            proxy_connect_timeout       600;
-            proxy_send_timeout          600;
-            proxy_read_timeout          600;
+            proxy_connect_timeout       {{ .Values.kubecostFrontend.timeoutSeconds | default 600 }};
+            proxy_send_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 600 }};
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 600 }};
             proxy_pass http://queryservice/$1;
             proxy_redirect off;
             proxy_http_version 1.1;
@@ -367,7 +367,7 @@ data:
     {{- end }}
 
         location = /model/allocation {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/allocation;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -385,7 +385,7 @@ data:
         }
         {{ end }}
         location = /model/allocation/view {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/allocation/view;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -393,7 +393,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/allocation/summary {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/allocation/summary;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -401,7 +401,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/allocation/summary/topline {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/allocation/summary/topline;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -409,7 +409,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/assets {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/assets;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -442,7 +442,7 @@ data:
             return 501 "<b>Aggregator does not support this endpoint.</b>";
         }
         location = /model/savings/requestSizingV2 {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/savings/requestSizingV2;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -450,7 +450,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/savings/requestSizingV2/topline {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/savings/requestSizingV2/topline;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -458,7 +458,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/cloudCost {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/cloudCost;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -466,7 +466,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/cloudCost/view/graph {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/cloudCost/view/graph;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -474,7 +474,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/cloudCost/view/totals {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/cloudCost/view/totals;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -482,7 +482,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/cloudCost/view/table {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/cloudCost/view/table;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -490,7 +490,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/clusters/status {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/clusters/status;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -498,7 +498,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/savings {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/savings;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -506,7 +506,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/savings/abandonedWorkloads {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/savings/abandonedWorkloads;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -514,7 +514,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/savings/abandonedWorkloads/topline {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/savings/abandonedWorkloads/topline;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -522,7 +522,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/savings/unclaimedVolumes {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/savings/unclaimedVolumes;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -530,7 +530,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/savings/localLowDisks {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/savings/localLowDisks;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -538,7 +538,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/savings/persistentVolumeSizing {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/savings/persistentVolumeSizing;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -546,7 +546,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/reports/allocation {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/reports/allocation;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -554,7 +554,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/reports/asset {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/reports/asset;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -562,7 +562,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/reports/advanced {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/reports/advanced;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -570,7 +570,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/reports/cloudCost {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/reports/cloudCost;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -578,7 +578,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/reports/group {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/reports/group;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -589,14 +589,14 @@ data:
         # was handled by /model/, so no special case proxies were required. without this, /model/reports/groups/?foo=bar
         # will be directed to /reports/groups?foo=bar (note the missing /model prefix)
         location ~ ^/model/reports/group/ {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/reports/group/$is_args$args;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/budget {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/budget;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -604,7 +604,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/budgets {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/budgets;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -631,7 +631,7 @@ data:
         }
     {{- if .Values.kubecostAggregator.cloudCost.enabled }}
         location = /model/cloudCost/status {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://cloudCost/cloudCost/status;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -639,7 +639,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/cloudCost/rebuild {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://cloudCost/cloudCost/rebuild;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -647,7 +647,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/cloudCost/repair {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://cloudCost/cloudCost/repair;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -655,7 +655,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/cloudCost/integration/export {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://cloudCost/cloudCost/integration/export;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -663,7 +663,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/cloudCost/integration/enable {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://cloudCost/cloudCost/integration/enable;
             proxy_redirect off;
             proxy_set_header Connection "";
@@ -671,7 +671,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         location = /model/cloudCost/integration/disable {
-            proxy_read_timeout          300;
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://cloudCost/cloudCost/integration/disable;
             proxy_redirect off;
             proxy_set_header Connection "";

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -355,6 +355,7 @@ kubecostFrontend:
     failureThreshold: 200
   ipv6:
     enabled: true  # disable if the cluster does not support ipv6
+  # timeoutSeconds: 600  # should be rarely used, but can be increased if needed
   # allow customizing nginx-conf server block
   # extraServerConfig: |-
   #   proxy_busy_buffers_size   512k;


### PR DESCRIPTION
## What does this PR change?
adds variable for setting nginx timeouts

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

https://github.com/kubecost/cost-analyzer-helm-chart/issues/2774

## What risks are associated with merging this PR? What is required to fully test this PR?

No changes to default configuration, small risk to user setting value that prevents helm upgrades.

## How was this PR tested?

Templated with default values and setting 
`kubecostFrontend.timeoutSeconds=750`


## Have you made an update to documentation? If so, please provide the corresponding PR.

Added values.yaml example 