### PR TITLE
Introduce tests from Replicated Compatibility Matrix

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -174,3 +174,43 @@ jobs:
         with:
           api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
+
+  deploy-eks:
+    runs-on: ubuntu-latest
+    needs: test-chart
+    strategy:
+      matrix:
+        cluster:
+        - distribution: eks
+          version: v1.26
+        - distribution: eks
+          version: v1.27
+    steps:
+      - uses: actions/checkout@v4
+
+      # Outputs: `cluster-kubeconfig`, `cluster-id`
+      - name: Create Cluster
+        id: create-cluster
+        uses: replicatedhq/compatibility-actions/create-cluster@v1
+        with:
+          kubernetes-distribution: ${{ matrix.cluster.distribution }}
+          kubernetes-version: ${{ matrix.cluster.version }}
+          cluster-name: ${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}
+          timeout-minutes: 5
+          ttl: 10m
+          export-kubeconfig: true
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          # kubeconfig-path: /tmp/kubeconfig # optional, specifies path for Kubeconfig file
+
+      - name: Test
+        run: |
+          echo "Running a test"
+          kubectl get po -A
+
+      - name: Remove Cluster
+        id: remove-cluster
+        uses: replicatedhq/compatibility-actions/remove-cluster@v1
+        continue-on-error: true
+        with:
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -134,3 +134,43 @@ jobs:
             kubectl -n kubecost delete deployments,daemonsets,statefulsets,pods --all --force
           fi
           done
+
+  deploy-ocp:
+    runs-on: ubuntu-latest
+    needs: test-chart
+    strategy:
+      matrix:
+        cluster:
+        - distribution: openshift
+          version: 4.12.0-okd
+        - distribution: openshift
+          version: 4.13.0-okd
+    steps:
+      - uses: actions/checkout@v4
+
+      # Outputs: `cluster-kubeconfig`, `cluster-id`
+      - name: Create Cluster
+        id: create-cluster
+        uses: replicatedhq/compatibility-actions/create-cluster@v1
+        with:
+          kubernetes-distribution: ${{ matrix.cluster.distribution }}
+          kubernetes-version: ${{ matrix.cluster.version }}
+          cluster-name: ${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}
+          timeout-minutes: 5
+          ttl: 10m
+          export-kubeconfig: true
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          # kubeconfig-path: /tmp/kubeconfig # optional, specifies path for Kubeconfig file
+
+      - name: Test
+        run: |
+          echo "Running a test"
+          kubectl get po -A
+
+      - name: Remove Cluster
+        id: remove-cluster
+        uses: replicatedhq/compatibility-actions/remove-cluster@v1
+        continue-on-error: true
+        with:
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}


### PR DESCRIPTION
## What does this PR change?

Introduces OpenShift testing from Replicated's Compatibility Matrix with a placeholder for actual Helm chart tests. Due to a bug in upstream Helm client, which is needed to test for OCP values, the actual testing of a chart deployment on OCP will have to wait until that gets fixed in Helm 3.13. This PR introduces a matrix of both OpenShift and EKS clusters into the existing tests.


## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

None, internal CI only.

## Links to Issues or tickets this PR addresses or fixes

Follow-on from PRs #2792 and #2793. Those previous PRs could not gain access to repository secrets needed to call the Replicated API due to them coming from a fork.

## What risks are associated with merging this PR? What is required to fully test this PR?

CI could fail.

## How was this PR tested?

Tested in a separate fork and this repo.

## Have you made an update to documentation? If so, please provide the corresponding PR.

