### PR TITLE
add extraPorts config for development environments

### DIFF
--- a/cost-analyzer/templates/aggregator-service.yaml
+++ b/cost-analyzer/templates/aggregator-service.yaml
@@ -16,5 +16,8 @@ spec:
     - name: tcp-api
       port: 9004
       targetPort: 9004
+  {{- with .Values.kubecostAggregator.extraPorts }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -113,6 +113,9 @@ spec:
             - name: tcp-api
               containerPort: 9004
               protocol: TCP
+          {{- with.Values.kubecostAggregator.extraPorts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{ toYaml .Values.kubecostAggregator.resources | nindent 12 }}
           volumeMounts:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -494,6 +494,9 @@ spec:
           - name: tcp-frontend
             containerPort: 9090
             protocol: TCP
+        {{- with .Values.kubecostModel.extraPorts }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
           resources:
 {{ toYaml .Values.kubecostModel.resources | indent 12 }}
           readinessProbe:

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -31,6 +31,9 @@ spec:
     - name: tcp-model
       port: 9003
       targetPort: 9003
+  {{- with .Values.kubecostModel.extraPorts }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
     {{- if .Values.kubecostFrontend.enabled }}
     - name: tcp-frontend
       {{- if .Values.kubecostFrontend.tls }}

--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -118,6 +118,9 @@ spec:
             - name: tcp-model
               containerPort: 9003
               protocol: TCP
+          {{- with .Values.kubecostDeployment.queryService.extraPorts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.kubecostDeployment.queryService.resources | nindent 12 }}
           volumeMounts:

--- a/cost-analyzer/templates/query-service-service-template.yaml
+++ b/cost-analyzer/templates/query-service-service-template.yaml
@@ -15,5 +15,8 @@ spec:
     - name: tcp-query-service
       port: 9003
       targetPort: 9003
+  {{- with .Values.kubecostDeployment.queryService.extraPorts }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -540,6 +540,12 @@ kubecostModel:
     #    hosts:
     #      - cost-analyzer-model.local
   utcOffset: "+00:00"
+  # Optional - add extra ports to the cost-model container. For kubecost development purposes only - not recommended for users.
+  extraPorts: []
+    # - name: debug
+    #   port: 40000
+    #   targetPort: 40000
+    #   containerPort: 40000
 
 # etlUtils is a utility currently used by Kubecost internal support to implement specific functionality related to Thanos conversion.
 etlUtils:
@@ -979,6 +985,12 @@ kubecostDeployment:
     databaseVolumeSize: 100Gi
     configVolumeSize: 1Gi
     initImage: {}
+    # Optional - add extra ports to the query service container. For kubecost development purposes only - not recommended for users.
+    extraPorts: []
+      # - name: debug
+      #   port: 40000
+      #   targetPort: 40000
+      #   containerPort: 40000
 
 ## The Kubecost Aggregator is a high scale implementation of Kubecost intended
 ## for large datasets and/or high query load. At present, this should only be
@@ -1034,6 +1046,13 @@ kubecostAggregator:
   #   capabilities:
   #     drop:
   #       - ALL
+  #
+  # Optional - add extra ports to the aggregator container. For kubecost development purposes only - not recommended for users.
+  extraPorts: []
+    # - name: debug
+    #   port: 40000
+    #   targetPort: 40000
+    #   containerPort: 40000
 
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:


### PR DESCRIPTION
## What does this PR change?
Adds options for extra ports to a running installation. The only current use for this is attaching a debugger to a back end that is running through tilt (for development purposes only).

Note: I am open to alternatives here (especially if there is a cleaner way to do this!); the key thing is I need to open up a port to the back end specifically for delve.

This functionality is identical to opencost - see https://github.com/opencost/opencost-helm-chart/blob/main/charts/opencost/values.yaml#L51

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No impact - only current use is for internal development only.

## Links to Issues or tickets this PR addresses or fixes
n/a

## What risks are associated with merging this PR? What is required to fully test this PR?
To test the PR, see that an extra port can be configured to reach the back-end
Risks are very low - no change occurs for current users.

## How was this PR tested?
With `hackathon-tilt` branch of KCM

## Have you made an update to documentation? If so, please provide the corresponding PR.
not documenting this until we have a user-facing use for this
