### PR TITLE
Longer timeout; run CI on forks

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -2,6 +2,8 @@ name: Chart build
 
 on:
   workflow_dispatch: {}
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
   pull_request:
     branches:
       - develop
@@ -156,7 +158,7 @@ jobs:
           kubernetes-distribution: ${{ matrix.cluster.distribution }}
           kubernetes-version: ${{ matrix.cluster.version }}
           cluster-name: ${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}
-          timeout-minutes: 5
+          timeout-minutes: 10
           ttl: 10m
           export-kubeconfig: true
           api-token: ${{ secrets.REPLICATED_API_TOKEN }}
@@ -196,7 +198,7 @@ jobs:
           kubernetes-distribution: ${{ matrix.cluster.distribution }}
           kubernetes-version: ${{ matrix.cluster.version }}
           cluster-name: ${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}
-          timeout-minutes: 5
+          timeout-minutes: 10
           ttl: 10m
           export-kubeconfig: true
           api-token: ${{ secrets.REPLICATED_API_TOKEN }}


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

* Lengthens timeouts for Replicated cluster builds
* Enables workflow to run from forks

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows their PRs to successfully call the cluster build workflow.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

PRs may still not result in the service being called. And some security risk may be incurred by using `pull_request_target` as a trigger.

## How was this PR tested?

Untested

## Have you made an update to documentation? If so, please provide the corresponding PR.

