### PR TITLE
only use pull_request_target

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch: {}
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
-  pull_request:
-    branches:
-      - develop
+  # pull_request:
+  #   branches:
+  #     - develop
 
 jobs:
   test-chart:


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Modifies the chart CI action to only use the `pull_request_target` trigger since this is the only trigger which will allow for testing of Replicated clusters.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Prevents duplicate CI actions where one will always fail.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

CI actions may still break.

## How was this PR tested?

Tested via PR #2800 

## Have you made an update to documentation? If so, please provide the corresponding PR.

