### PR TITLE
frontend aggregator flag

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -719,6 +719,15 @@ data:
             return 204 'endpoint disabled';
         }
         {{ end }}
+
+        location /model/aggregatorEnabled {
+            {{- if .Values.kubecostAggregator.enabled }}
+            return 200 '{"aggregatorEnabled": "true"}';
+            {{- else }}
+            return 200 '{"aggregatorEnabled": "false"}';
+            {{- end }}
+        }
+
     }
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
add flag for frontend to determine if aggregator is enabled

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Not user facing


## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
helm templating

```sh
helm template kubecost ./cost-analyzer |ag aggregatorEnable -A1 -B1

        location /model/aggregatorEnabled {
            return 200 '{"aggregatorEnabled": "false"}';
        }
```
```sh
helm template kubecost ./cost-analyzer -f values-waterfowl.yaml |ag aggregatorEnable -A1 -B1 

        location /model/aggregatorEnabled {
            return 200 '{"aggregatorEnabled": "true"}';
        }
```

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA