### PR TITLE
bump cluster-controller-0.13.0

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1034,7 +1034,7 @@ kubecostAggregator:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.12.0
+  image: gcr.io/kubecost1/cluster-controller:v0.13.0
   imagePullPolicy: Always
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
## What does this PR change?
Bumps cluster controller to 0.13.0 for CVE

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Allows  the default installation to use cluster-controller:0.13.0

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

