### PR TITLE
[docs] Update link to Persistent Volume documentation

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -628,7 +628,7 @@ extraVolumes: []
 ##
 extraVolumeMounts: []
 
-# Define persistence volume for cost-analyzer, more information at https://github.com/kubecost/docs/blob/main/install-and-configure/install/storage.md
+# Define persistence volume for cost-analyzer, more information at https://docs.kubecost.com/install-and-configure/install/storage
 persistentVolume:
   size: 32Gi
   dbSize: 32.0Gi

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -628,7 +628,7 @@ extraVolumes: []
 ##
 extraVolumeMounts: []
 
-# Define persistence volume for cost-analyzer, more information at https://github.com/kubecost/docs/blob/main/storage.md
+# Define persistence volume for cost-analyzer, more information at https://github.com/kubecost/docs/blob/main/install-and-configure/install/storage.md
 persistentVolume:
   size: 32Gi
   dbSize: 32.0Gi


### PR DESCRIPTION
## What does this PR change?
Updates link to Persistent Volume documentation.

## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
While reading through `values.yaml` users will now be redirected to the correct documentation instead of a 404 page with the old link.

<img width="1511" alt="Screenshot 2023-12-05 at 13 23 15" src="https://github.com/kubecost/cost-analyzer-helm-chart/assets/55045459/6e49911e-d23c-4e6f-baf7-ccd4f0f16a06">


## Links to Issues or tickets this PR addresses or fixes
N/A
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
None, as this is just a documentation related change.

## How was this PR tested?
Not required.

## Have you made an update to documentation? If so, please provide the corresponding PR.
This is the PR that updates the documentation.
