### PR TITLE
fix NetPol with deny Egress setting

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-policy.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-policy.yaml
@@ -14,9 +14,6 @@ spec:
       {{- include "cost-analyzer.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Egress
-  egress:
-  - to:
-    - namespaceSelector: {}
 {{- else }}
 {{- if .Values.networkPolicy.sameNamespace}}
 metadata:


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Fixes the Egress statement in the NetworkPolicy to properly deny Egress.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Prevents egress properly.

## Links to Issues or tickets this PR addresses or fixes

Fixes #2816


## What risks are associated with merging this PR? What is required to fully test this PR?

Egress may still not be blocked. A cluster with a CNI plug-in implementing the NetworkPolicy API is required to test this.

## How was this PR tested?

Untested

## Have you made an update to documentation? If so, please provide the corresponding PR.

