### PR TITLE
remove frontend aggregator image fork

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -956,7 +956,7 @@ spec:
             - name: NETWORK_COSTS_PORT
               value: {{ quote .Values.networkCosts.port | default (quote 3001) }}
             # ADVANCED_NETWORK_STATS is a feature offered by Kubecost that gives you network
-            # insights of your Kubernetes resources with cloud services. The feature is 
+            # insights of your Kubernetes resources with cloud services. The feature is
             # enabled when network cost is enabled and one of the service tagging is enabled
             {{- if .Values.networkCosts.config.services }}
             {{- $services := .Values.networkCosts.config.services -}}
@@ -1143,8 +1143,6 @@ spec:
         - image: {{ .Values.kubecostFrontend.fullImageName }}
         {{- else if .Values.imageVersion }}
         - image: {{ .Values.kubecostFrontend.image }}:{{ .Values.imageVersion }}
-        {{- else if .Values.kubecostAggregator.enabled }}
-        - image: {{ .Values.kubecostFrontend.image }}:prod-aggregator-{{ $.Chart.AppVersion }}
         {{- else }}
         - image: {{ .Values.kubecostFrontend.image }}:prod-{{ $.Chart.AppVersion }}
         {{ end }}


### PR DESCRIPTION
## What does this PR change?
frontend image for aggregator was previously independent. the changes are now merged into a single frontend image.

Tested:
```sh
helm template aggregator ./cost-analyzer -f .idea/aggregator.nightly.yaml|ag image:                      
        - image: gcr.io/kubecost1/cost-model:prod-1.107.1
        - image: gcr.io/kubecost1/frontend:prod-1.107.1
```