### PR TITLE
fix fs permissions on mismatch

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-deployment.yaml
@@ -181,6 +181,10 @@ spec:
     {{- end }}
     {{- if .Values.server.securityContext }}
       securityContext:
+        {{- if not .Values.server.securityContext.fsGroup }}
+        fsGroupChangePolicy: OnRootMismatch
+        fsGroup: 1001
+        {{- end }}
     {{- toYaml .Values.server.securityContext | nindent 8 }}
     {{- else if and (.Values.global.platforms.openshift.enabled) (.Values.global.platforms.openshift.securityContext) }}
       securityContext:

--- a/cost-analyzer/values-thanos.yaml
+++ b/cost-analyzer/values-thanos.yaml
@@ -17,9 +17,10 @@ prometheus:
       storage.tsdb.min-block-duration: 2h
       storage.tsdb.max-block-duration: 2h
       storage.tsdb.retention: 2w
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1001
+    # these were previously being set by default.
+    # securityContext:
+    #   runAsNonRoot: true
+    #   runAsUser: 1001
     extraVolumes:
     - name: object-store-volume
       secret:
@@ -29,12 +30,13 @@ prometheus:
     sidecarContainers:
     - name: thanos-sidecar
       image: thanosio/thanos:v0.32.5
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        capabilities:
-          drop:
-          - ALL
+      # these were previously being set by default.
+      # securityContext:
+      #   allowPrivilegeEscalation: false
+      #   readOnlyRootFilesystem: true
+      #   capabilities:
+      #     drop:
+      #     - ALL
       args:
       - sidecar
       - --log.level=debug


### PR DESCRIPTION
## What does this PR change?
fixes prometheus file system permissions for backwards compatibility. 
remove scc from values-thanos.yaml, which is used for new thanos-based installs.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
fixes prometheus file system permissions for backwards compatibility. 

## What risks are associated with merging this PR? What is required to fully test this PR?

Risk of unknown user configuration conflicts. Though the code path should mostly impact users that followed Kubecost docs, and this is what tested.

## How was this PR tested?
tested on a net new install and upgrade of existing thanos instance

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
