### PR TITLE
bump tags in EKS values

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -114,7 +114,7 @@ prometheus:
     # clusterIDConfigmap: cluster-id-configmap
     image:
       repository: public.ecr.aws/kubecost/prometheus
-      tag: v2.47.2
+      tag: v2.48.1
     resources: {}
     # limits:
     #   cpu: 500m
@@ -152,7 +152,7 @@ prometheus:
       ## configmap-reload container image
       image:
         repository: public.ecr.aws/kubecost/prometheus-config-reloader
-        tag: v0.69.1
+        tag: v0.70.0
         pullPolicy: IfNotPresent
 
       ## Additional configmap-reload container arguments


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

In the EKS values file only:

* Bumps Prometheus image tag to `v2.48.1`
* Bumps Prometheus configmap reloader tag to `v0.70.0`

These values are already present in `develop` for the main values file and its subchart.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

