### PR TITLE
Updates defaults for Multi-cluster Diagnostics feature.

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -729,14 +729,12 @@ data:
 
         location /model/multi-cluster-diagnostics-enabled {
             default_type 'application/json';
-            {{- if .Values.diagnostics.isDiagnosticsPrimary.enabled }}
-            {{- if .Values.diagnostics.enabled }}
+            {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
             {{- if or .Values.global.thanos.enabled (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
             return 200 '{"multi-cluster-diagnostics-enabled": "true"}';
+            {{- end }}
             {{- else }}
             return 200 '{"multi-cluster-diagnostics-enabled": "false"}';
-            {{- end }}
-            {{- end }}
             {{- end }}
         }
         {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1078,10 +1078,10 @@ kubecostAggregator:
     #   containerPort: 40000
   securityContext: {}  # Define a securityContext for the aggregator pod. This will take highest precedence.
 
-## Kubecost Diagnostic Pod (beta, disabled by default until GA) Enables the
-## Kubecost primary to report health/diagnostics of all agent clusters. Each
-## agent cluster sends its health/diagnostic data to a storage bucket. Future
-## versions may include repairing & alerting from the primary.
+## Kubecost Multi-cluster Diagnostics (beta)
+## A single view into the health of all agent clusters. Each agent cluster sends
+## its diagnostic data to a storage bucket. Future versions may include
+## repairing & alerting from the primary.
 ## Ref: https://docs.kubecost.com/install-and-configure/install/diagnostics
 ##
 diagnostics:
@@ -1089,15 +1089,13 @@ diagnostics:
   ## How frequently to run & push diagnostics. Defaults to 5 minutes.
   pollingInterval: "300s"
   ## Creates a new Diagnostic file in the bucket for every run.
-  keepDiagnosticHistory: true
+  keepDiagnosticHistory: false
   ## Pushes the cluster's Kubecost Helm Values to the bucket once upon startup.
   ## This may contain sensitive information and is roughly 30kb per cluster.
   collectHelmValues: false
-  ## Only needs to be enabled on the primary cluster. When enabled, will
-  ## download the diagnostic files from the bucket and serve HTTP queries.
+  ## The primary aggregates all diagnostic data and serves HTTP queries.
   isDiagnosticsPrimary:
-    enabled: true
-
+    enabled: false
   resources:
     requests:
       cpu: "10m"


### PR DESCRIPTION
## What does this PR change?

- `.Values.diagnostics.keepDiagnosticHistory=false` by default. Reduces load placed on bucket & diagnostics service.
- `.Values.diagnostics.isDiagnosticsPrimary.enabled=false` by default. Only one cluster needs this, and we shouldn't be enabling the service on all clusters by default.
- Fixes logic in configmap

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

We plan to default enable the Multi-cluster Diagnostics in v1.108. If users are running a Thanos or FedETL setup, they will see the following files uploaded to their storage buckets `/diagnostics/CLUSTER_ID.json`. One per cluster.

## Links to Issues or tickets this PR addresses or fixes

None

## What risks are associated with merging this PR? What is required to fully test this PR?

This has been internally used and under test for ~1 month.

The risk is that the new feature does not work for users, or causes unnecessary load. However based on the default configurations of this feature, I believe load should be minimal. Additionally, because all this logic is contained in a separate`deployment/kubecost-diagnostics`, there should be no impact to the main `deployment/kubecost-cost-analyzer`.

## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

TODO

