### PR TITLE
serve_from_sub_path to false for Grafana 10

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1194,7 +1194,7 @@ grafana:
 #  set root_url to "%(protocol)s://%(domain)s:%(http_port)s/kubecost/grafana". No change is necessary here if kubecost runs at a root URL
   grafana.ini:
     server:
-      serve_from_sub_path: true
+      serve_from_sub_path: false  # Set to false on Grafana v10+
       root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana"
 serviceAccount:
   create: true  # Set this to false if you're bringing your own service account.


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Changes the value of `serve_from_sub_path` from `true` to `false` in the main values file which sets the grafana.ini. This was necessary to support the bump to Grafana 10. 

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows them to access Grafana dashboards from Kubecost where it has been installed with Grafana 10+

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

xref: https://github.com/grafana/grafana/issues/70110


## What risks are associated with merging this PR? What is required to fully test this PR?

Grafana access could still be partially affected.

## How was this PR tested?

Tested in internal nightly.

## Have you made an update to documentation? If so, please provide the corresponding PR.

