### PR TITLE
kubecost aggregator: Support for saml/oidc/ui defined teams

### DIFF
--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -85,6 +85,57 @@ spec:
         {{- else }}
         {{- fail "Kubecost Aggregator Enterprise Config requires .Values.kubecostModel.federatedStorageConfigSecret" }}
         {{- end }}
+        {{- if .Values.saml }}
+        {{- if .Values.saml.enabled }}
+        {{- if .Values.saml.secretName }}
+        - name: secret-volume
+          secret:
+            secretName: {{ .Values.saml.secretName }}
+        {{- end }}
+        {{- if .Values.saml.encryptionCertSecret }}
+        - name: saml-encryption-cert
+          secret:
+            secretName: {{ .Values.saml.encryptionCertSecret }}
+        {{- end }}
+        {{- if .Values.saml.decryptionKeySecret }}
+        - name: saml-decryption-key
+          secret:
+            secretName: {{ .Values.saml.decryptionKeySecret }}
+        {{- end }}
+        {{- if .Values.saml.metadataSecretName }}
+        - name: metadata-secret-volume
+          secret:
+            secretName: {{ .Values.saml.metadataSecretName }}
+        {{- end }}
+        {{- if .Values.saml.authSecretName }}
+        - name: saml-auth-secret
+          secret:
+            secretName: {{ .Values.saml.authSecretName }}
+        {{- end }}
+        {{- if .Values.saml.rbac.enabled }}
+        - name: saml-roles
+          configMap:
+            name: {{ template "cost-analyzer.fullname" . }}-saml
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.oidc }}
+        {{- if .Values.oidc.enabled }}
+        - name: oidc-config
+          configMap:
+            name: {{ template "cost-analyzer.fullname" . }}-oidc
+        {{- if and (not .Values.oidc.existingCustomSecret.enabled) .Values.oidc.secretName }}
+        - name: oidc-client-secret
+          secret:
+            secretName: {{ .Values.oidc.secretName }}
+        {{- end }}
+        {{- if .Values.oidc.existingCustomSecret.enabled }}
+        - name: oidc-client-secret
+          secret:
+            secretName: {{ .Values.oidc.existingCustomSecret.name }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
       containers:
         {{- include "aggregator.containerTemplate" . | nindent 8 }}
 

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -222,6 +222,11 @@ spec:
           secret:
             secretName: {{ .Values.saml.metadataSecretName }}
         {{- end }}
+        {{- if .Values.saml.authSecretName }}
+        - name: saml-auth-secret
+          secret:
+            secretName: {{ .Values.saml.authSecretName }}
+        {{- end }}
         {{- if .Values.saml.rbac.enabled }}
         - name: saml-roles
           configMap:
@@ -586,6 +591,10 @@ spec:
             {{- if .Values.saml.metadataSecretName }}
             - name: metadata-secret-volume
               mountPath: /var/configs/metadata-secret-volume
+            {{- end }}
+            {{- if .Values.saml.authSecretName }}
+            - name: saml-auth-secret
+              mountPath: /var/configs/saml-auth-secret
             {{- end }}
             {{- if .Values.saml.rbac.enabled }}
             - name: saml-roles

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -624,6 +624,46 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/rbacGroups {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/rbacGroups;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/teams {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/teams;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/team {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/team;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/users {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/users;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/user {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/user;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/debug/orchestrator {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/debug/orchestrator;

--- a/cost-analyzer/templates/kubecost-saml-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-saml-secret-template.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.saml }}
+{{- if and .Values.saml.authSecret .Values.saml.authSecretName }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.saml.authSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+stringData:
+  clientSecret: {{ .Values.saml.authSecret }}
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -272,6 +272,8 @@ saml:
   # isGLUUProvider: false # An additional URL parameter must be appended for GLUU providers
   # encryptionCertSecret: "kubecost-saml-cert" # k8s secret where the x509 certificate used to encrypt an Okta saml response is stored
   # decryptionKeySecret: "kubecost-sank-decryption-key" # k8s secret where the private key associated with the encryptionCertSecret is stored
+  # authSecret: "random string" # Aggregator only - this enables cost model and aggregator pods to share required information to decode SAML token
+  # authSecretName: "kubecost-saml-secret" # Aggregator only - k8s secret where the authSecret will be stored
   rbac:
     enabled: false
     # groups:


### PR DESCRIPTION
## What does this PR change?
Adds support for SAML, SAML filters, and OIDC in Aggregator.

## Does this PR rely on any other PRs?
Yes; https://github.com/kubecost/kubecost-cost-model/pull/1949

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds support for SAML, SAML filters, and OIDC in Aggregator.

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/SELFHOST-961
https://kubecost.atlassian.net/browse/SELFHOST-962

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
This affects all customers using aggregator with SAML, SAML filtering, or OIDC.

- OIDC functionality is untested; currently there is no test environment. Testing the functionality and correcting issues is in ticket https://kubecost.atlassian.net/browse/SELFHOST-1034.
- Customers using aggregator and SAML will need to configure saml.authSecret and saml.authSecretName so aggregator can parse and validate tokens issued by the cost-model pod. This should be temporary until the cost-model pod is no longer used for front end queries. If they do not, all queries to the aggregator pod will fail with a 403/forbidden.

## How was this PR tested?
Manually

## Have you made an update to documentation? If so, please provide the corresponding PR.
Not yet.
