### PR TITLE
[CI] checkout PR ref

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -2,6 +2,8 @@ name: Chart build
 
 on:
   workflow_dispatch: {}
+  # Normally using pull_request_target along with checking out the ref of the PR is not
+  # a good idea, but this is low risk since it's a Helm chart repo.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
   # pull_request:
@@ -15,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
@@ -73,6 +77,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
@@ -149,6 +155,8 @@ jobs:
           version: 4.13.0-okd
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Outputs: `cluster-kubeconfig`, `cluster-id`
       - name: Create Cluster
@@ -205,6 +213,8 @@ jobs:
           version: v1.27
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Outputs: `cluster-kubeconfig`, `cluster-id`
       - name: Create Cluster


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Checks out the ref of the actual PR rather than the base so the workflow can use both the saved secret and test against the contents of the PR. This is normally not a good idea from a security practice but we really have no other option if we want to test the actual PR against a something which requires accessing a repo secret. Risk is quite low; this is only a Helm chart repo.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

CI only

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

