### PR TITLE
add nodeSelector ability to awsstore

### DIFF
--- a/cost-analyzer/templates/awsstore-deployment-template.yaml
+++ b/cost-analyzer/templates/awsstore-deployment-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "cost-analyzer.fullname" . }}-awsstore
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -28,6 +28,10 @@ spec:
       serviceAccountName: awsstore-serviceaccount
       {{- if .Values.awsstore.priorityClassName }}
       priorityClassName: "{{ .Values.awsstore.priorityClassName }}"
+      {{- end }}
+      {{- with .Values.awsstore.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - image: {{ .Values.awsstore.imageNameAndVersion }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1207,11 +1207,14 @@ serviceAccount:
   # name: kc-test
 awsstore:
   useAwsStore: false
-  # imageNameAndVersion: gcr.io/kubecost1/awsstore:latest  # Name and version of the container image for AWSStore.
+  imageNameAndVersion: gcr.io/kubecost1/awsstore:latest  # Name and version of the container image for AWSStore.
   createServiceAccount: false
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   priorityClassName: ""
+  # Use a custom nodeSelector for AWSStore.
+  nodeSelector: {}
+    # kubernetes.io/arch: amd64
 
 ## Federated ETL Architecture
 ## Ref: https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Follow-up from #2601

Adds `nodeSelector` map to awsstore.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows them to specify nodeSelector just for awsstore.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Follow-up from #2601

## What risks are associated with merging this PR? What is required to fully test this PR?

May not work

## How was this PR tested?

Template

## Have you made an update to documentation? If so, please provide the corresponding PR.

No