### PR TITLE
remove duplicate Prometheus StatefulSet affinity

### DIFF
--- a/cost-analyzer/charts/prometheus/templates/server-statefulset.yaml
+++ b/cost-analyzer/charts/prometheus/templates/server-statefulset.yaml
@@ -34,10 +34,6 @@ spec:
         {{ toYaml .Values.server.statefulSet.labels | nindent 8 }}
         {{- end}}
     spec:
-{{- if .Values.server.affinity }}
-      affinity:
-{{ toYaml .Values.server.affinity | indent 8 }}
-{{- end }}
 {{- if .Values.server.priorityClassName }}
       priorityClassName: "{{ .Values.server.priorityClassName }}"
 {{- end }}


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Removes the duplicate `affinity{}` struct in the Prometheus StatefulSet template.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

No impact but makes the output correct by removing duplicate.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Closes #2755


## What risks are associated with merging this PR? What is required to fully test this PR?

StatefulSet affinity may not work.

## How was this PR tested?

Templated and installed

## Have you made an update to documentation? If so, please provide the corresponding PR.

