### PR TITLE
Use image maps for network costs and cluster controller

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -38,7 +38,11 @@ spec:
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       containers:
       - name: {{ template "cost-analyzer.networkCostsName" . }}
+        {{- if eq (typeOf .Values.networkCosts.image) "string" }}
         image: {{ .Values.networkCosts.image }}
+        {{- else }}
+        image: {{ .Values.networkCosts.image.repository }}:{{ .Values.networkCosts.image.tag }}
+        {{- end}}
         {{- if .Values.networkCosts.extraArgs }}
         args:
           {{- toYaml .Values.networkCosts.extraArgs | nindent 8 }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -219,7 +219,7 @@ metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   strategy:
     rollingUpdate:
@@ -243,7 +243,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kubecost.clusterControllerName" . }}
+        {{- if eq (typeOf .Values.clusterController.image) "string" }}
         image: {{ .Values.clusterController.image }}
+        {{- else }}
+        image: {{ .Values.clusterController.image.repository }}:{{ .Values.clusterController.image.tag }}
+        {{- end}}
         imagePullPolicy: {{ .Values.clusterController.imagePullPolicy }}
         volumeMounts:
         - name: cluster-controller-keys

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -827,7 +827,9 @@ networkCosts:
   podSecurityPolicy:
     enabled: false
     # annotations: {}  # Add annotations to the PodSecurityPolicy for network-costs.
-  image: gcr.io/kubecost1/kubecost-network-costs:v0.17.2
+  image:
+    repository: gcr.io/kubecost1/kubecost-network-costs
+    tag: v0.17.2
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1111,7 +1111,9 @@ diagnostics:
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
-  image: gcr.io/kubecost1/cluster-controller:v0.13.0
+  image:
+    repository: gcr.io/kubecost1/cluster-controller
+    tag: v0.13.0
   imagePullPolicy: Always
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Uses a map to express images for network costs and cluster controller but does so in a backwards compatible way allowing the previous string value to take precedence and, if set to a map, the new method will take over.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows users to specify `image` as a map rather than a string, which then allows users to receive automatic updates about new versions of the image via Dependabot and others. This also standardizes the way of expressing images consistent with other templates in the same chart.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Closes #2401

## What risks are associated with merging this PR? What is required to fully test this PR?

Although this change was done in a backwards compatible way with both variations being tested, if someone is specifying the images in odd ways then it may not deploy properly...that's a real stretch.

## How was this PR tested?

Templating

## Have you made an update to documentation? If so, please provide the corresponding PR.


