### PR TITLE
remove init container from qsr

### DIFF
--- a/cost-analyzer/templates/query-service-deployment-template.yaml
+++ b/cost-analyzer/templates/query-service-deployment-template.yaml
@@ -75,18 +75,6 @@ spec:
         {{- if .Values.kubecostDeployment.queryService.extraVolumes }}
         {{- toYaml .Values.kubecostDeployment.queryService.extraVolumes | nindent 8 }}
         {{- end }}
-      initContainers:
-        - name: config-db-perms-fix
-          image: {{ .Values.kubecostDeployment.queryService.initImage.repository | default "busybox"}}:{{ .Values.kubecostDeployment.queryService.initImage.tag | default "stable"}}
-          imagePullPolicy: {{ .Values.kubecostDeployment.queryService.initImage.pullPolicy | default "IfNotPresent"}}
-          command: ["sh", "-c", "/bin/chmod -R 777 /var/configs && /bin/chmod -R 777 /var/db"]
-          volumeMounts:
-            - name: persistent-configs
-              mountPath: /var/configs
-            - name: database-storage
-              mountPath: /var/db
-          securityContext:
-            runAsUser: 0
       containers:
         - name: query-service
           {{- if .Values.kubecostModel }}


### PR DESCRIPTION
## What does this PR change?
removes init container from query service statefulset
This is no longer needed, because:
```yaml
  fsGroup: 1001
  fsGroupChangePolicy: OnRootMismatch
```

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Removes init container from query service statefulset. This init container no longer has a purpose. And it ran as root.

## What risks are associated with merging this PR? What is required to fully test this PR?
Unknown user configurations

## How was this PR tested?
running in qa-gcp1 test cluster

## Have you made an update to documentation? If so, please provide the corresponding PR.

NA