### PR TITLE
add proxy config to cloud cost deployment

### DIFF
--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -121,8 +121,20 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
             {{- end }}
-
-
+            {{- if .Values.systemProxy.enabled }}
+            - name: HTTP_PROXY
+              value: {{ .Values.systemProxy.httpProxyUrl }}
+            - name: http_proxy
+              value: {{ .Values.systemProxy.httpProxyUrl }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.systemProxy.httpsProxyUrl }}
+            - name: https_proxy
+              value: {{ .Values.systemProxy.httpsProxyUrl }}
+            - name: NO_PROXY
+              value: {{ .Values.systemProxy.noProxy }}
+            - name: no_proxy
+              value: {{ .Values.systemProxy.noProxy }}
+            {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}


### PR DESCRIPTION
## What does this PR change?
Adds the ability to define proxy information for the new CloudCost deployment.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Provides support for the environment variables `HTTP_PROXY`,`http_proxy`,`HTTPS_PROXY`,`https_proxy`,`NO_PROXY`, and `no_proxy`.

## Links to Issues or tickets this PR addresses or fixes
n/a

## What risks are associated with merging this PR? What is required to fully test this PR?
None? Uses standard Linux environment variables to define proxy details.

## How was this PR tested?
``` shell
helm template ./cost-analyzer \
  --set=kubecostAggregator.cloudCost.enabled=true \
  --set=kubecostProductConfigs.cloudIntegrationSecret="cloud-integrations" \
  --set=systemProxy.enabled=true \
  --set=systemProxy.httpProxyUrl="this-is-my-proxy-url" \
  --set=systemProxy.httpsProxyUrl="this-is-my-ssl-proxy-url" \
  --set=systemProxy.noProxy="this-is-my-noproxy-list" \
  | grep -i "# Source:\|this-is-my-proxy-url" -C5
```

## Have you made an update to documentation? If so, please provide the corresponding PR.
No. Not neccesary.
