### PR TITLE
liveness and readiness probes to 10s from 30s

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -370,14 +370,14 @@ kubecostFrontend:
   # Define a readiness probe for the Kubecost frontend container.
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 10
     periodSeconds: 10
     failureThreshold: 200
 
   # Define a liveness probe for the Kubecost frontend container.
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 10
     periodSeconds: 10
     failureThreshold: 200
   ipv6:
@@ -540,14 +540,14 @@ kubecostModel:
   # Define a readiness probe for the Kubecost cost-model container.
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 10
     periodSeconds: 10
     failureThreshold: 200
 
   # Define a liveness probe for the Kubecost cost-model container.
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 10
     periodSeconds: 10
     failureThreshold: 200
   extraArgs: []


### PR DESCRIPTION
## What does this PR change?
update liveness and readiness probes to 10s from 30s

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes



## What risks are associated with merging this PR? What is required to fully test this PR?
Really low risk- this has nothing to do with when the pod is forcibly restarted. 

It is simply how long until kubecost can possibly serve requests. And will only serve requests if cost-model has status 200.

## How was this PR tested?
helm upgrade of existing deployment.
```yaml
    livenessProbe:
      failureThreshold: 200
      httpGet:
        path: /healthz
        port: 9003
        scheme: HTTP
      initialDelaySeconds: 10
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 1
    name: cost-analyzer-frontend
    readinessProbe:
      failureThreshold: 200
      httpGet:
        path: /healthz
        port: 9003
        scheme: HTTP
      initialDelaySeconds: 10
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 1
```


## Have you made an update to documentation? If so, please provide the corresponding PR.

