### PR TITLE
change default nginx TLS port to 9090

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -1,5 +1,4 @@
 {{- if and (not .Values.agent) (not .Values.cloudAgent) }}
-{{- $nginxPort := int .Values.service.port | default 9090 -}}
 apiVersion: apps/v1
 {{- if and .Values.kubecostDeployment.statefulSet.enabled .Values.kubecostDeployment.leaderFollower.enabled }}
 kind: StatefulSet

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -56,20 +56,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.kubecostFrontend.tls }}
-      {{- if .Values.kubecostFrontend.tls.enabled }}
-      securityContext:
-        runAsUser: 0
-      {{- else }}
-      securityContext:
-        runAsUser: 1001
-        runAsGroup: 1001
-        fsGroup: 1001
-      {{- end }}
-      {{- else if lt $nginxPort 1025 }}
-      securityContext:
-        runAsUser: 0
-      {{- else if and .Values.global.platforms.openshift.enabled .Values.global.platforms.openshift.securityContext }}
+      {{- if .Values.global.platforms.openshift.enabled }}
       securityContext:
       {{- toYaml .Values.global.platforms.openshift.securityContext | nindent 8 }}
       {{- else if .Values.global.securityContext }}
@@ -1155,13 +1142,6 @@ spec:
         {{- else }}
         - image: gcr.io/kubecost1/frontend:prod-{{ $.Chart.AppVersion }}
         {{- end }}
-          {{- if .Values.kubecostFrontend.tls }}
-          {{- if .Values.kubecostFrontend.tls.enabled }}
-          command: ["nginx", "-g", "daemon off;"]
-          ports:
-            - containerPort: 443
-          {{- end }}
-          {{- end }}
           env:
             - name: GET_HOSTS_FROM
               value: dns
@@ -1172,7 +1152,7 @@ spec:
         {{- if .Values.kubecostFrontend.securityContext }}
           securityContext:
             {{- toYaml .Values.kubecostFrontend.securityContext | nindent 12 }}
-          {{- else if and .Values.global.containerSecurityContext (gt $nginxPort 1025) }}
+          {{- else  }}
           securityContext:
             {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
           {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.kubecostFrontend.enabled }}
 {{- if and (not .Values.agent) (not .Values.cloudAgent) }}
 {{- $serviceName := include "cost-analyzer.serviceName" . -}}
-{{- $nginxPort := .Values.service.targetPort | default 9090 -}}
 {{- if .Values.saml.enabled }}
 {{- if .Values.oidc.enabled }}
 {{- fail "SAML and OIDC cannot both be enabled" }}
@@ -175,20 +174,20 @@ data:
 {{- end }}
         ssl_certificate     /etc/ssl/certs/kc.crt;
         ssl_certificate_key /etc/ssl/certs/kc.key;
-        listen {{ $nginxPort }} ssl;
+        listen {{ .Values.service.targetPort }} ssl;
 {{- if .Values.kubecostFrontend.ipv6.enabled }}
-        listen [::]:{{ $nginxPort }} ssl;
+        listen [::]:{{ .Values.service.targetPort }} ssl;
 {{- end }}
 {{- else }}
-        listen {{ $nginxPort }};
+        listen {{ .Values.service.targetPort }};
 {{- if .Values.kubecostFrontend.ipv6.enabled }}
-        listen [::]:{{ $nginxPort }};
+        listen [::]:{{ .Values.service.targetPort }};
 {{- end }}
 {{- end }}
 {{- else }}
-        listen {{ $nginxPort }};
+        listen {{ .Values.service.targetPort }};
 {{- if .Values.kubecostFrontend.ipv6.enabled }}
-        listen [::]:{{ $nginxPort }};
+        listen [::]:{{ .Values.service.targetPort }};
 {{- end }}
 {{- end }}
         location /api/ {

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -175,9 +175,9 @@ data:
 {{- end }}
         ssl_certificate     /etc/ssl/certs/kc.crt;
         ssl_certificate_key /etc/ssl/certs/kc.key;
-        listen 443 ssl;
+        listen {{ $nginxPort }} ssl;
 {{- if .Values.kubecostFrontend.ipv6.enabled }}
-        listen [::]:443 ssl;
+        listen [::]:{{ $nginxPort }} ssl;
 {{- end }}
 {{- else }}
         listen {{ $nginxPort }};

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -1,6 +1,4 @@
 {{- if and (not .Values.agent) (not .Values.cloudAgent) }}
-{{- $nginxPort := .Values.service.targetPort | default 9090 -}}
-{{- $servicePort := .Values.service.port | default 9090 -}}
 kind: Service
 apiVersion: v1
 metadata:
@@ -41,8 +39,8 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       {{- end }}
-      port: {{ $servicePort }}
-      targetPort: {{ $nginxPort }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
     {{- end }}
     {{- if .Values.saml }}
     {{- if .Values.saml.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -36,33 +36,13 @@ spec:
   {{- end }}
     {{- if .Values.kubecostFrontend.enabled }}
     - name: tcp-frontend
-      {{- if .Values.kubecostFrontend.tls }}
-      {{- if .Values.kubecostFrontend.tls.enabled }}
-      port: 443
-      targetPort: 443
       {{- if (eq .Values.service.type "NodePort") }}
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       {{- end }}
-      {{- else }}
       port: {{ $servicePort }}
       targetPort: {{ $nginxPort }}
-      {{- if (eq .Values.service.type "NodePort") }}
-      {{- if .Values.service.nodePort }}
-      nodePort: {{ .Values.service.nodePort }}
-      {{- end }}
-      {{- end }}
-      {{- end}}
-      {{- else }}
-      port: {{ $servicePort }}
-      targetPort: {{ $nginxPort }}
-      {{- if (eq .Values.service.type "NodePort") }}
-      {{- if .Values.service.nodePort }}
-      nodePort: {{ .Values.service.nodePort }}
-      {{- end }}
-      {{- end }}
-      {{- end }}
     {{- end }}
     {{- if .Values.saml }}
     {{- if .Values.saml.enabled }}


### PR DESCRIPTION
## What does this PR change?
Prior to this PR, any frontend configuration using TLS would require nginx to run on port 443. Using ports under 1025 requires that the container run as root. 

There is no need to run nginx with a different port, though this is still configurable via 
```yaml
service:
  type: ClusterIP
  port: 9090
  targetPort: 9090
```
If a user wants to use port 443, they will need to modify the SCC to allow root. 
We do not recommend running any container as root.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Allow users to use TLS without requiring nginx run as root. The default nginx frontend port for all configurations is 9090


## What risks are associated with merging this PR? What is required to fully test this PR?
Unknown configurations requiring ports under 443.

## How was this PR tested?
```
helm upgrade -i kubecost-eks10 \
. \
--namespace kubecost-eks10 \
--create-namespace \
--set kubecostFrontend.tls.enabled=true \
--set kubecostFrontend.tls.secretName=kubecost-eks10 \
```
and
```
helm upgrade -i kubecost-eks10 \
. \
--namespace kubecost-eks10 \
--create-namespace \
--set kubecostFrontend.tls.enabled=false
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

