### PR TITLE
clean up agent values - fix diagnostic pod logic

### DIFF
--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.diagnostics.enabled }}
-{{- if or .Values.global.thanos.enabled (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) -}}
+{{- if or ( not (empty .Values.prometheus.server.extraSecretMounts )) (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) -}}
 
 {{- if eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one" }}
 {{- fail "Error: The 'cluster_id' is set to default 'cluster-one'. Please update so that the diagnostics service can uniquely identify data coming from this cluster." }}
@@ -46,7 +46,7 @@ spec:
           secret:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
-        {{- else if .Values.global.thanos.enabled }}
+        {{- else }}
         - name: federated-storage-config
           secret:
             defaultMode: 420

--- a/cost-analyzer/values-agent.yaml
+++ b/cost-analyzer/values-agent.yaml
@@ -1,3 +1,4 @@
+
 # Kubecost running as an Agent is designed for external hosting. The current setup deploys a
 # kubecost-agent pod, low data retention prometheus server + thanos sidecar, and node-exporter.
 networkCosts:
@@ -7,7 +8,8 @@ networkCosts:
   #     amazon-web-services: true
   #     google-cloud-services: true
   #     azure-cloud-services: true
-
+thanos:
+  storeSecretName:  kubecost-agent-object-store
 
 global:
   thanos:
@@ -17,7 +19,7 @@ global:
     proxy: false
 # Agent enables specific features designed to enhance the metrics exporter deployment
 # with enhancements designed for external hosting.
-agent: true
+# agent: true
 # agentKeySecretName: kubecost-agent-object-store
 agentCsi:
   enabled: false
@@ -27,21 +29,15 @@ agentCsi:
     parameters: {}
     secretObjects: {}
 
-
-# No Grafana configuration is required.
-grafana:
-  sidecar:
-    dashboards:
-      enabled: false
-    datasources:
-      defaultDatasourceEnabled: false
+kubecostFrontend:
+  enabled: false
 
 # Exporter Pod
-kubecostMetrics:
-  exporter:
-    enabled: true
-    exportClusterInfo: true
-    exportClusterCache: true
+# kubecostMetrics:
+#   exporter:
+#     enabled: true
+#     exportClusterInfo: true
+#     exportClusterCache: true
 
 # Prometheus defaults to low retention (10h), disables KSM, and attaches a thanos-sidecar
 # for exporting metrics.
@@ -51,26 +47,6 @@ prometheus:
   kube-state-metrics:
     enabled: false
     disabled: true
-  extraScrapeConfigs: |
-    - job_name: kubecost-agent
-      honor_labels: true
-      scrape_interval: 1m
-      scrape_timeout: 60s
-      metrics_path: /metrics
-      scheme: http
-      dns_sd_configs:
-      - names:
-        - kubecost-agent-agent
-        type: 'A'
-        port: 9005
-    - job_name: kubecost-networking
-      kubernetes_sd_configs:
-        - role: pod
-      relabel_configs:
-      # Scrape only the the targets matching the following metadata
-        - source_labels: [__meta_kubernetes_pod_label_app]
-          action: keep
-          regex:  {{ template "cost-analyzer.networkCostsName" . }}
   server:
     retention: 50h
     # retentionSize: 1Gi


### PR DESCRIPTION
## What does this PR change?
- update hosted agent to run diagnostics with thanos
- clean up agent values 


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixed logic in diagnostic pod deployment

## What risks are associated with merging this PR? What is required to fully test this PR?
Unknown configs, though I believe this risk is low.

## How was this PR tested?
Local install, will be sharing with a customer asap.

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
