### PR TITLE
Frontend: implements /productConfigs, adds default window size options

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -669,22 +669,6 @@ data:
         }
     {{- end }}
 
-        location = /model/hideOrphanedResources {
-            default_type 'application/json';
-            {{- if .Values.kubecostFrontend.hideOrphanedResources }}
-            return 200 '{"hideOrphanedResources": "true"}';
-            {{- else }}
-            return 200 '{"hideOrphanedResources": "false"}';
-            {{- end }}
-        }
-        location = /model/hideDiagnostics {
-            default_type 'application/json';
-            {{- if .Values.kubecostFrontend.hideDiagnostics }}
-            return 200 '{"hideDiagnostics": "true"}';
-            {{- else }}
-            return 200 '{"hideDiagnostics": "false"}';
-            {{- end }}
-        }
     {{- if .Values.kubecostAggregator.cloudCost.enabled }}
         location = /model/cloudCost/status {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
@@ -782,8 +766,10 @@ data:
                 {"defaultAssetWindow": "{{ .Values.kubecostProductConfigs.defaultAssetWindow }}"}\n
                 {"defaultAllocationWindow": "{{ .Values.kubecostProductConfigs.defaultAllocationWindow }}"}\n
                 {"defaultRequestSizingnWindow": "{{ .Values.kubecostProductConfigs.defaultRequestSizingnWindow }}"}\n
-                {"clusterControlerEnabled" : "{{ .Values.clusterController.enabled }}"}
-                {"isDiagnosticsPrimary": "{{ .Values.diagnostics.isDiagnosticsPrimary.enabled }}"}
+                {"clusterControlerEnabled" : "{{ .Values.clusterController.enabled }}"}\n
+                {"isDiagnosticsPrimary": "{{ .Values.diagnostics.isDiagnosticsPrimary.enabled }}"}\n
+                {"hideOrphanedResources": "{{ .Values.kubecostProductConfigs.hideOrphanedResources }}"}\n
+                {"hideDiagnostics": "{{ .Values.kubecostProductConfigs.hideDiagnostics }}"}\n
             ';
         }
 

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -785,11 +785,16 @@ data:
             {{- end }}
         }
 
-        location /model/defaultWindow {
+        location /productConfigs {
             default_type 'application/json';
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
-            return 200 '{"defaultWindow": "{{ .Values.kubecostProductConfigs.defaultWindow }}"}';
+            return 200 '\n
+                {"defaultAssetWindow": "{{ .Values.kubecostProductConfigs.defaultAssetWindow }}"}\n
+                {"defaultAllocationWindow": "{{ .Values.kubecostProductConfigs.defaultAllocationWindow }}"}\n
+                {"defaultRequestSizingnWindow": "{{ .Values.kubecostProductConfigs.defaultRequestSizingnWindow }}"}\n
+                {"clusterControlerEnabled" : "{{ .Values.clusterController.enabled }}"}
+            ';
         }
 
     }

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -785,6 +785,13 @@ data:
             {{- end }}
         }
 
+        location /model/defaultWindow {
+            default_type 'application/json';
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            return 200 '{"defaultWindow": "{{ .Values.kubecostProductConfigs.defaultWindow }}"}';
+        }
+
     }
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -766,7 +766,7 @@ data:
                 {"defaultAssetWindow": "{{ .Values.kubecostProductConfigs.defaultAssetWindow }}"}\n
                 {"defaultAllocationWindow": "{{ .Values.kubecostProductConfigs.defaultAllocationWindow }}"}\n
                 {"defaultRequestSizingnWindow": "{{ .Values.kubecostProductConfigs.defaultRequestSizingnWindow }}"}\n
-                {"clusterControlerEnabled" : "{{ .Values.clusterController.enabled }}"}\n
+                {"clusterControllerEnabled" : "{{ .Values.clusterController.enabled }}"}\n
                 {"isDiagnosticsPrimary": "{{ .Values.diagnostics.isDiagnosticsPrimary.enabled }}"}\n
                 {"hideOrphanedResources": "{{ .Values.kubecostProductConfigs.hideOrphanedResources }}"}\n
                 {"hideDiagnostics": "{{ .Values.kubecostProductConfigs.hideDiagnostics }}"}\n

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -742,18 +742,8 @@ data:
         }
         {{ end }}
 
-        location /model/multi-cluster-diagnostics-enabled {
-            default_type 'application/json';
-            {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
-            {{- if or .Values.global.thanos.enabled (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
-            return 200 '{"multi-cluster-diagnostics-enabled": "true"}';
-            {{- end }}
-            {{- else }}
-            return 200 '{"multi-cluster-diagnostics-enabled": "false"}';
-            {{- end }}
-        }
-        {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
-        {{- if or .Values.global.thanos.enabled (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
+
+        {{- if .Values.diagnostics.isDiagnosticsPrimary.enabled }}
         location /model/multi-cluster-diagnostics {
             default_type 'application/json';
             proxy_read_timeout          300;
@@ -774,7 +764,6 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         {{- end }}
-        {{- end }}
 
         location /model/aggregatorEnabled {
             default_type 'application/json';
@@ -794,6 +783,7 @@ data:
                 {"defaultAllocationWindow": "{{ .Values.kubecostProductConfigs.defaultAllocationWindow }}"}\n
                 {"defaultRequestSizingnWindow": "{{ .Values.kubecostProductConfigs.defaultRequestSizingnWindow }}"}\n
                 {"clusterControlerEnabled" : "{{ .Values.clusterController.enabled }}"}
+                {"isDiagnosticsPrimary": "{{ .Values.diagnostics.isDiagnosticsPrimary.enabled }}"}
             ';
         }
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1317,7 +1317,9 @@ costEventsAudit:
 # These configs can also be set from the Settings page in the Kubecost product UI
 # Values in this block override config changes in the Settings UI on pod restart
 #
-# kubecostProductConfigs:
+kubecostProductConfigs:
+  defaultWindow: 30d
+
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.
 # Ref: https://github.com/kubecost/docs/blob/main/multi-cluster.md

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1318,7 +1318,9 @@ costEventsAudit:
 # Values in this block override config changes in the Settings UI on pod restart
 #
 kubecostProductConfigs:
-  defaultWindow: 30d
+  defaultAllocationWindow: 30d
+  defaultAssetWindow: 30d
+  defaultRequestSizingnWindow: 30d
 
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -389,8 +389,6 @@ kubecostFrontend:
   #   proxy_buffers   4 512k;
   #   proxy_buffer_size   256k;
   #   large_client_header_buffers 4 64k;
-  # hideDiagnostics: false  # useful if the primary is not monitored. Supported in limited environments.
-  # hideOrphanedResources: false  # OrphanedResources works on the primary-cluster's cloud-provider only.
 #  api:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:
@@ -1321,7 +1319,8 @@ kubecostProductConfigs:
   defaultAllocationWindow: 30d
   defaultAssetWindow: 30d
   defaultRequestSizingnWindow: 30d
-
+  hideDiagnostics: false  # useful if the primary is not monitored. Supported in limited environments.
+  hideOrphanedResources: false  # OrphanedResources works on the primary-cluster's cloud-provider only.
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.
 # Ref: https://github.com/kubecost/docs/blob/main/multi-cluster.md


### PR DESCRIPTION
## What does this PR change?
Add new parameters for:

```yaml
kubecostProductConfigs:
  defaultAllocationWindow: 30d
  defaultAssetWindow: 30d
  defaultRequestSizingnWindow: 30d
```
Moves these new and not-yet-implemented options from `kubecostFrontend` to:

```yaml
kubecostProductConfigs:
  hideDiagnostics: false  # useful if the primary is not monitored. Supported in limited environments.
  hideOrphanedResources: false  # OrphanedResources works on the primary-cluster's cloud-provider only.
```

Moves isDiagnosticsPrimary from a dedicated location block to the new section and changes logic to allow `isDiagnosticsPrimary` to be true even if the local cluster is not monitored (hosted) 
@thomasvn FYI, we still need to update the service, deployment and backend logic to allow this.

## Does this PR rely on any other PRs?
New FE PR tbd

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Change Kubecost default query window to 30d, which is now configurable via:  `kubecostProductConfigs.defaultWindow=30d`

## What risks are associated with merging this PR? What is required to fully test this PR?

Functional testing will be done when frontend changes are done.

## How was this PR tested?

```sh
helm template kubecost ../cost-analyzer |ag productConfigs -A15
        location /productConfigs {
            default_type 'application/json';
            add_header 'Access-Control-Allow-Origin' '*' always;
            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
            return 200 '\n
                {"defaultAssetWindow": "30d"}\n
                {"defaultAllocationWindow": "30d"}\n
                {"defaultRequestSizingnWindow": "30d"}\n
                {"clusterControlerEnabled" : "false"}\n
                {"isDiagnosticsPrimary": "false"}\n
                {"hideOrphanedResources": "false"}\n
                {"hideDiagnostics": "false"}\n
            ';
        }
```
## Have you made an update to documentation? If so, please provide the corresponding PR.

