### PR TITLE
Get node label from k8s service discovery

### DIFF
--- a/cost-analyzer/charts/prometheus/values.yaml
+++ b/cost-analyzer/charts/prometheus/values.yaml
@@ -1310,6 +1310,9 @@ serverFiles:
             regex: ([^:]+)(?::\d+)?;(\d+)
             replacement: $1:$2
           - action: labelmap
+            regex: __meta_kubernetes_node_name
+            replacement: node
+          - action: labelmap
             regex: __meta_kubernetes_service_label_(.+)
           - source_labels: [__meta_kubernetes_namespace]
             action: replace


### PR DESCRIPTION
## What does this PR change?
This is a companion to https://github.com/opencost/opencost/pull/2423

## Does this PR rely on any other PRs?
Without the changes from [opencost/2423](https://github.com/opencost/opencost/pull/2423) this _will_ break queries in kubecost.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
If you've setup your own `relabel_configs` you need to add the following configuration manually:
```yaml
          - action: labelmap
            regex: __meta_kubernetes_node_name
            replacement: node
```

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
Without the changes from the linked PR some queries will stop working, this should happen immediately and get caught by tests

## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

