### PR TITLE
network costs image name missing quotes

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -41,7 +41,7 @@ spec:
         {{- if eq (typeOf .Values.networkCosts.image) "string" }}
         image: {{ .Values.networkCosts.image }}
         {{- else }}
-        image: {{ .Values.networkCosts.image.repository }}:{{ .Values.networkCosts.image.tag }}
+        image: "{{ .Values.networkCosts.image.repository }}:{{ .Values.networkCosts.image.tag }}"
         {{- end}}
         {{- if .Values.networkCosts.extraArgs }}
         args:


### PR DESCRIPTION
## What does this PR change?
missing quotes on the image name construction.
`kubectl describe po <network-cost-pod> -n kubecost ` returned:
`Failed to apply default image tag "map[repository:gcr.io/kubecost1/kubecost-network-costs tag:v0.17.2]": couldn't parse image reference "map[repository:gcr.io/kubecost1/kubecost-network-costs tag:v0.17.2]": invalid reference format`

The image name returned was:
`Image:         map[repository:gcr.io/kubecost1/kubecost-network-costs tag:v0.17.2]`

## What risks are associated with merging this PR? What is required to fully test this PR?
The current confiiguration is not working. 

## How was this PR tested?
not tested

## Have you made an update to documentation? If so, please provide the corresponding PR.
not required, fix to work as expected

P.S: my first contribution ever, feedback is well-recieved 