### PR TITLE
IMP ingress className for prometheus server

### DIFF
--- a/cost-analyzer/templates/prometheus-server-ingress.yaml
+++ b/cost-analyzer/templates/prometheus-server-ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ template "prometheus.server.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+{{- if .Values.prometheus.server.ingress.className }}
+  ingressClassName: {{ .Values.prometheus.server.ingress.className }}
+{{- end }}
   rules:
   {{- range .Values.prometheus.server.ingress.hosts }}
     {{- $url := splitList "/" . }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -897,6 +897,7 @@ prometheus:
       ## If true, Prometheus server Ingress will be created
       ##
       enabled: false
+      # className: nginx
 
       ## Prometheus server Ingress annotations
       ##


### PR DESCRIPTION
## What does this PR change?

add ingress className for prometheus server

## Does this PR rely on any other PRs?

no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

add ingress className for prometheus server

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

it is improvement, there is no related issue ticket

## What risks are associated with merging this PR? What is required to fully test this PR?

there is no risk because Prometheus ingress class commented by default

## How was this PR tested?

```
- # Source: ops-monitoring/charts/cost-analyzer/charts/prometheus/templates/server-ingress.yaml
+ # Source: ops-monitoring/charts/cost-analyzer/templates/prometheus-server-ingress.yaml
  apiVersion: networking.k8s.io/v1
  kind: Ingress
  metadata:
    labels:
      component: "server"
      app: prometheus
      release: monitoring
      heritage: Helm
    name: monitoring-prometheus-server
    namespace: ops
  spec:
+   ingressClassName: nginx
    rules:
      - host: dev-general-kubecost-prometheus.domain.net
        http:
          paths:

            - path: /
              pathType: Prefix
              backend:
                service:
                  name: monitoring-prometheus-server
                  port:
                    number: 80
```
## Have you made an update to documentation? If so, please provide the corresponding PR.

no