### PR TITLE
Route OIDC to aggregator

### DIFF
--- a/cost-analyzer/templates/aggregator-service.yaml
+++ b/cost-analyzer/templates/aggregator-service.yaml
@@ -16,6 +16,11 @@ spec:
     - name: tcp-api
       port: 9004
       targetPort: 9004
+    {{- if or .Values.saml.enabled .Values.oidc.enabled}}
+    - name: apiserver
+      port: 9008
+      targetPort: 9008
+    {{- end }}
   {{- with .Values.kubecostAggregator.extraPorts }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -246,7 +246,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://model/oidc/;
+            proxy_pass http://aggregator/oidc/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -268,11 +268,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            {{- if .Values.saml.enabled }}
             proxy_pass http://aggregator/login;
-            {{- else }}
-            proxy_pass http://model/login;
-            {{- end }}
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -285,11 +281,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            {{- if .Values.saml.enabled }}
             proxy_pass http://aggregator/logout;
-            {{- else }}
-            proxy_pass http://model/logout;
-            {{- end }}
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -313,7 +305,7 @@ data:
     {{ end }}
     {{- if .Values.oidc.enabled }}
         location /auth {
-            proxy_pass http://model/isAuthenticated;
+            proxy_pass http://aggregator/isAuthenticated;
         }
     {{- end }}
     {{- if .Values.saml.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -42,19 +42,10 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
     {{- end }}
-    {{- if .Values.saml }}
-    {{- if .Values.saml.enabled }}
+    {{- if or .Values.saml.enabled .Values.oidc.enabled}}
     - name: apiserver
-      port: 9004
-      targetPort: 9004
-    {{- end }}
-    {{- end }}
-    {{- if .Values.oidc }}
-    {{- if .Values.oidc.enabled }}
-    - name: apiserver
-      port: 9004
-      targetPort: 9004
-    {{- end }}
+      port: 9007
+      targetPort: 9007
     {{- end }}
 {{- if .Values.service.sessionAffinity.enabled }}
   sessionAffinity: ClientIP


### PR DESCRIPTION
## What does this PR change?
Route OIDC authentication calls to aggregator pod instead of costmodel

## Does this PR rely on any other PRs?
Yes; [KCM PR](https://github.com/kubecost/kubecost-cost-model/pull/2057)

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No visible impact; allows customers with OIDC to upgrade to 2.0/Aggregator

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/SELFHOST-1034

## What risks are associated with merging this PR? What is required to fully test this PR?
Risks - negligible
Testing - test that OIDC auth still works

## How was this PR tested?
Manually against Azure OIDC

## Have you made an update to documentation? If so, please provide the corresponding PR.
not required
