### PR TITLE
Fix nesting of collection cache enabling flag

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -812,6 +812,14 @@ Aggregator config reconciliation and common config
     - name: OIDC_SKIP_ONLINE_VALIDATION
       value: {{ (quote .Values.oidc.skipOnlineTokenValidation) | default (quote false) }}
     {{- end}}
+    {{- if .Values.kubecostAggregator }}
+    {{- if .Values.kubecostAggregator.collections }}
+    {{- if (((.Values.kubecostAggregator).collections).cache) }}
+    - name: COLLECTIONS_MEMORY_CACHE_ENABLED
+      value: {{ (quote .Values.kubecostAggregator.collections.cache.enabled) | default (quote true) }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.saml }}
     {{- if .Values.saml.enabled }}
     - name: SAML_ENABLED

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -905,8 +905,6 @@ spec:
             - name: ADVANCED_NETWORK_STATS
               value: "false"
             {{- end}}
-            - name: COLLECTIONS_MEMORY_CACHE_ENABLED
-              value: {{ (quote .Values.kubecostModel.collections.cache.enabled) | default (quote true) }}
             {{- end }}
             {{- end }}
             {{- end }}


### PR DESCRIPTION
## What does this PR change?
Fixes some bad nesting for a new env var for collections.

## Does this PR rely on any other PRs?
No

## How was this PR tested?
Manually

### Without the values, the default works, and is "on"
![Screenshot from 2024-01-19 11-21-10](https://github.com/kubecost/cost-analyzer-helm-chart/assets/8070055/87685439-6a9c-46f4-9634-63b4f46a2b18)
![Screenshot from 2024-01-19 11-22-03](https://github.com/kubecost/cost-analyzer-helm-chart/assets/8070055/8dbc19f9-fe29-4d5b-be3b-d767162c41ea)

### Without the values, the cache can be turned off
![Screenshot from 2024-01-19 11-16-47](https://github.com/kubecost/cost-analyzer-helm-chart/assets/8070055/9834dfd9-40a6-43ec-b448-e29df6fe90ec)
![Screenshot from 2024-01-19 11-17-16](https://github.com/kubecost/cost-analyzer-helm-chart/assets/8070055/2f72a5f5-3eda-480a-a10b-c4d2c7fe812f)
