### PR TITLE
Add the `retention` and `readonly` configs to the MultiClusterDiagnostics feature

### DIFF
--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -119,7 +119,7 @@ spec:
             {{- else }}
               value: "false"
             {{- end }}
-            {{- if and .Values.diagnostics.isDiagnosticsPrimary.enabled .Values.diagnostics.isDiagnosticsPrimary.retention }}
+            {{- if and .Values.diagnostics.isDiagnosticsPrimary.enabled }}
             - name: DIAGNOSTICS_RETENTION
               value: {{ .Values.diagnostics.isDiagnosticsPrimary.retention | default "7d" }}
             {{- end }}

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -113,6 +113,16 @@ spec:
             {{- else }}
               value: "false"
             {{- end }}
+            - name: DIAGNOSTICS_PRIMARY_READONLY
+            {{- if and .Values.diagnostics.isDiagnosticsPrimary.enabled .Values.diagnostics.isDiagnosticsPrimary.readonly }}
+              value: "true"
+            {{- else }}
+              value: "false"
+            {{- end }}
+            {{- if and .Values.diagnostics.isDiagnosticsPrimary.enabled .Values.diagnostics.isDiagnosticsPrimary.retention }}
+            - name: DIAGNOSTICS_RETENTION
+              value: {{ .Values.diagnostics.isDiagnosticsPrimary.retention | default "7d" }}
+            {{- end }}
             - name: DIAGNOSTICS_COLLECT_HELM_VALUES
             {{- if and .Values.reporting.valuesReporting .Values.diagnostics.collectHelmValues }}
               value: "true"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2353,20 +2353,31 @@ kubecostAggregator:
 ##
 diagnostics:
   enabled: true
+
+  ## The primary aggregates all diagnostic data and handles API requests. It's
+  ## also responsible for deleting diagnostic data (on disk & bucket) beyond
+  ## retention. When in readonly mode it does not push its own diagnostic data
+  ## to the bucket.
+  isDiagnosticsPrimary:
+    enabled: false
+    retention: "7d"
+    readonly: false
+
   ## How frequently to run & push diagnostics. Defaults to 5 minutes.
   pollingInterval: "300s"
+
   ## Creates a new Diagnostic file in the bucket for every run.
   keepDiagnosticHistory: false
+
   ## Pushes the cluster's Kubecost Helm Values to the bucket once upon startup.
   ## This may contain sensitive information and is roughly 30kb per cluster.
   collectHelmValues: false
-  ## The primary aggregates all diagnostic data and serves HTTP queries.
-  isDiagnosticsPrimary:
-    enabled: false
+
   resources:
     requests:
       cpu: "10m"
       memory: "20Mi"
+
   securityContext: {}
 
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown


### PR DESCRIPTION
## What does this PR change?
- Adds support for the new environment variables `DIAGNOSTICS_RETENTION` and `DIAGNOSTICS_PRIMARY_READONLY`

## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/2060
- https://github.com/kubecost/kubecost-cost-model/pull/2066

## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

## What risks are associated with merging this PR? What is required to fully test this PR?

## How was this PR tested?

```yaml
# values-diagnostics.yaml
diagnostics:
  enabled: true
  isDiagnosticsPrimary:
    enabled: true
kubecostModel:
  federatedStorageConfigSecret: federated-store
prometheus:
  server:
    global:
      external_labels:
        cluster_id: thomasn-diagnostics
```

```sh
# Successfully templated the configs
$ helm template thomasn-diagnostics ./cost-analyzer -f values-diagnostics.yaml -s templates/diagnostics-deployment.yaml -s templates/diagnostics-service.yaml -s templates/cost-analyzer-frontend-config-map-template.yaml > diagnostics.yaml
```


## Have you made an update to documentation? If so, please provide the corresponding PR.
