### PR TITLE
[SELFHOST-1031] route predict API to aggregator

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -783,6 +783,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/prediction/speccost {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/prediction/speccost;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
     {{- end }}
 
         location = /model/hideOrphanedResources {


### PR DESCRIPTION
## What does this PR change?
routes prediction API to aggregator

## Does this PR rely on any other PRs?
https://github.com/kubecost/kubecost-cost-model/pull/2069

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
none, existing functionality port

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/SELFHOST-1031



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

