### PR TITLE
Change chart on `develop` branch to use nightly images

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "1.108.0"
+appVersion: "development"
 description: A Helm chart that sets up Kubecost, Prometheus, and Grafana to monitor cloud costs.
 name: cost-analyzer
-version: "1.108.0"
+version: "2.0.0"
 annotations:
   "artifacthub.io/links": |
     - name: Homepage

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -658,6 +658,8 @@ Aggregator config reconciliation and common config
   image: {{ .Values.kubecostAggregator.fullImageName }}
   {{- else if .Values.imageVersion }}
   image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
+  {{- else if eq "development" .Chart.AppVersion }}
+  image: gcr.io/kubecost1/cost-model-nightly:latest
   {{- else }}
   image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
   {{- end }}
@@ -878,6 +880,8 @@ Aggregator config reconciliation and common config
   image: {{ .Values.kubecostModel.fullImageName }}
   {{- else if .Values.imageVersion }}
   image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
+  {{- else if eq "development" .Chart.AppVersion }}
+  image: gcr.io/kubecost1/cost-model-nightly:latest
   {{- else }}
   image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
   {{ end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -447,6 +447,8 @@ spec:
         - image: {{ .Values.kubecostModel.fullImageName }}
         {{- else if .Values.imageVersion }}
         - image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
+        {{- else if eq "development" .Chart.AppVersion }}
+        - image: gcr.io/kubecost1/cost-model-nightly:latest
         {{- else }}
         - image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
         {{- end }}
@@ -1005,6 +1007,8 @@ spec:
         - image: {{ .Values.kubecostFrontend.fullImageName }}
         {{- else if .Values.imageVersion }}
         - image: {{ .Values.kubecostFrontend.image }}:{{ .Values.imageVersion }}
+        {{- else if eq "development" .Chart.AppVersion }}
+        - image: gcr.io/kubecost1/frontend-nightly:latest
         {{- else }}
         - image: {{ .Values.kubecostFrontend.image }}:prod-{{ $.Chart.AppVersion }}
         {{- end }}

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -58,8 +58,8 @@ spec:
           image: {{ .Values.kubecostModel.fullImageName }}
           {{- else if .Values.imageVersion }}
           image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
-        {{- else if eq "development" .Chart.AppVersion }}
-        - image: gcr.io/kubecost1/cost-model-nightly:latest
+          {{- else if eq "development" .Chart.AppVersion }}
+          image: gcr.io/kubecost1/cost-model-nightly:latest
           {{- else }}
           image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
           {{- end }}

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -44,8 +44,8 @@ spec:
         {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
         - name: federated-storage-config
           secret:
-           defaultMode: 420
-           secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
+            defaultMode: 420
+            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
         {{- end }}
         - name: config-db
           {{- /* #TODO: make pv? */}}
@@ -58,6 +58,8 @@ spec:
           image: {{ .Values.kubecostModel.fullImageName }}
           {{- else if .Values.imageVersion }}
           image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
+        {{- else if eq "development" .Chart.AppVersion }}
+        - image: gcr.io/kubecost1/cost-model-nightly:latest
           {{- else }}
           image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
           {{- end }}

--- a/cost-analyzer/templates/etl-utils-deployment.yaml
+++ b/cost-analyzer/templates/etl-utils-deployment.yaml
@@ -47,8 +47,8 @@ spec:
           image: {{ .Values.kubecostModel.fullImageName }}
           {{- else if .Values.imageVersion }}
           image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
-        {{- else if eq "development" .Chart.AppVersion }}
-        - image: gcr.io/kubecost1/cost-model-nightly:latest
+          {{- else if eq "development" .Chart.AppVersion }}
+          image: gcr.io/kubecost1/cost-model-nightly:latest
           {{- else }}
           image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
           {{ end }}

--- a/cost-analyzer/templates/etl-utils-deployment.yaml
+++ b/cost-analyzer/templates/etl-utils-deployment.yaml
@@ -47,6 +47,8 @@ spec:
           image: {{ .Values.kubecostModel.fullImageName }}
           {{- else if .Values.imageVersion }}
           image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
+        {{- else if eq "development" .Chart.AppVersion }}
+        - image: gcr.io/kubecost1/cost-model-nightly:latest
           {{- else }}
           image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
           {{ end }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -147,6 +147,8 @@ spec:
         - image: {{ .Values.kubecostModel.fullImageName }}
         {{- else if .Values.imageVersion }}
         - image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
+        {{- else if eq "development" .Chart.AppVersion }}
+        - image: gcr.io/kubecost1/cost-model-nightly:latest
         {{- else }}
         - image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
         {{ end }}


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Modifies the state of the Helm chart on the `develop` branch so the `appVersion` is listed as `development`, causing deployment of the chart (again, only intended from the `develop` branch) pulls the nightly images for `cost-model` and `frontend`. This change is required because chart testing would always fail if modifications to the chart depended on modifications only found in these nightly images. This problem was apparent even before the development work on 2.0 began. In order for CI to work properly on the `develop` branch, this change is required.

**Note:** This change will likely require some modifications to the release process in that new minor versions, after the release branch is cut from `develop` MUST modify the `appVersion` field in `Chart.yaml` to point to the then-released version.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

No impact to end users as this change only affects the state on the `develop` branch which no users deploy.

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

As noted above, these changes probably necessitate changes to the release process and potentially other areas. I'm relying on those tagged for review here to understand those requirements and make the necessary changes.

## How was this PR tested?

Tested locally and in CI. Note that CI is currently failing on when it comes to deploying the Replicated clusters. These steps will be removed in a forthcoming PR. The tests are otherwise green for local KinD clusters.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A