### PR TITLE
Create emptyDir to fix permissions problem on /var/configs/waterfowl in Aggregator StatefulSet configuration

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -723,6 +723,16 @@ Aggregator config reconciliation and common config
     {{- if eq (include "aggregator.deployMethod" .) "statefulset" }}
     - name: aggregator-db-storage
       mountPath: /var/configs/waterfowl/duckdb
+    - name: aggregator-staging
+      # Aggregator uses /var/configs/waterfowl as a "staging" directory for
+      # things like intermediate-state files pre-ingestion. In order to avoid a
+      # permission problem similar to
+      # https://github.com/kubernetes/kubernetes/issues/81676, we create an
+      # emptyDir at this path.
+      #
+      # This hasn't been observed as a problem in cost-analyzer, likely because
+      # of the init container that gives everything under /var/configs 777.
+      mountPath: /var/configs/waterfowl
     {{- end }}
     {{- if .Values.saml }}
     {{- if .Values.saml.enabled }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -67,6 +67,9 @@ spec:
     {{- end }}
       serviceAccountName: {{ template "aggregator.serviceAccountName" . }}
       volumes:
+        - name: aggregator-staging
+          emptyDir:
+            sizeLimit: {{ .Values.kubecostAggregator.stagingEmptyDirSizeLimit }}
         {{- $etlBackupBucketSecret := "" }}
         {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
             {{- $etlBackupBucketSecret = .Values.kubecostModel.federatedStorageConfigSecret }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2308,6 +2308,15 @@ kubecostAggregator:
   # `deployMethod: "statefulset"`
   replicas: 1
 
+  # stagingEmptyDirSizeLimit changes how large the "staging"
+  # /var/configs/waterfowl emptyDir is. It only takes effect in StatefulSet
+  # configurations of Aggregator, other configurations are unaffected.
+  #
+  # It should be set to approximately 8x the size of the largest bingen file in
+  # object storage. For example, if your largest bingen file is a daily
+  # Allocation file with size 300MiB, this value should be set to approximately
+  # 2400Mi. In most environments, the default should suffice.
+  stagingEmptyDirSizeLimit: 2Gi
 
   resources: {}
     # requests:


### PR DESCRIPTION
In a statefulset aggregator config, we were observing errors like this:

```
2024-01-23T16:57:12.710877825Z ERR Ingestor: insert error: failed to write parquet for file federated/qa-gcp1/etl/bingen/allocations/1d/1705363200-1705449600: error writing container parquet file: error making directory /var/configs/waterfowl/parquet/kubernetes/qa-gcp1/container/1d: mkdir /var/configs/waterfowl/parquet: permission denied
```

Some debugging commands to add context:
```
→ k exec -it -n kubecost-cloudcost kubecost-cloudcost-aggregator-0 -- mkdir /var/configs/waterfowl/parquet mkdir: cannot create directory '/var/configs/waterfowl/parquet': Permission denied command terminated with exit code 1
```

```
→ k exec -it -n kubecost-cloudcost kubecost-cloudcost-aggregator-0 -- ls -alh /var/configs total 68K
drwxrwsr-x 5 root 1001 4.0K Jan 18 10:50 .
drwxr-xr-x 1 root root 4.0K Jan 23 16:52 ..
-rw-r--r-- 1 1001 1001    2 Jan 23 16:52 advanced-reports.json
-rw-r--r-- 1 1001 1001    2 Jan 23 16:52 asset-reports.json
-rw-r--r-- 1 1001 1001    2 Jan 23 16:52 budgets.json
-rw-r--r-- 1 1001 1001    2 Jan 23 16:52 cloud-cost-reports.json
-rw-r--r-- 1 1001 1001  112 Jan 23 00:36 collections.json
drwxrwsrwt 3 root 1001  100 Jan 23 16:52 etl
-rw-r--r-- 1 1001 1001  378 Jan 23 16:52 group-reports.json
drwxrws--- 2 root 1001  16K Dec 21 21:23 lost+found
-rw-r--r-- 1 1001 1001    2 Jan 23 16:52 recurring-budget-rules.json
-rw-r--r-- 1 1001 1001    2 Jan 23 16:52 reports.json
-rw-r--r-- 1 1001 1001    2 Jan 23 16:52 teams.json
-rw-r--r-- 1 1001 1001    2 Jan 23 16:52 users.json
drwxr-sr-x 3 root 1001 4.0K Jan 22 19:05 waterfowl
```

(note that the `/var/configs/waterfowl` directory is owned by user root and the container process' group (1001) does not have write permission, this is what I suspect the source of the error is)

This issue seems to back up the theory:
https://github.com/kubernetes/kubernetes/issues/81676

Fixed by adding an emptyDir, though I'm worried that its a little large.


## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A

## How was this PR tested?
Deployed to an env that was failing with the error, the error stopped happening.