### PR TITLE
Unset DB memory limit

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2317,7 +2317,6 @@ kubecostAggregator:
     "LOG_LEVEL": "info"
     "DB_READ_THREADS": "1"
     "DB_WRITE_THREADS": "1"
-    "DB_MEMORY_LIMIT": "500MB"
     "DB_CONCURRENT_INGESTION_COUNT": "3"
   persistentConfigsStorage:
     # default storage class


### PR DESCRIPTION
## What does this PR change?
This is a little too aggressive (it can cause OOM on nightly size data), and we've noticed that DDB obeys the K8s limits better than this limit (for some reason).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Removed the default env var `DB_MEMORY_LIMIT` setting for `kubecostAggregator`. If limiting the Aggregator memory, use the K8s limit first.