### PR TITLE
Add http:// protocol to forecasting base URL

### DIFF
--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - name: CONFIG_PATH
               value: /var/configs/
             - name: KCM_BASE_URL
-              value: {{ template "cost-analyzer.serviceName" . }}:9090/model
+              value: http://{{ template "cost-analyzer.serviceName" . }}:9090/model
             - name: MODEL_STORAGE_PATH
               value: "/tmp/localrun/models"
             {{- range $key, $value := .Values.forecasting.env }}


### PR DESCRIPTION
## What does this PR change?
Fixes KCM base URL templating for forecasting

N/A release note

## How was this PR tested?
Updated in a live env, stopped breaking