### PR TITLE
[Proposal] Users must set flag `upgrade.toV2=true` if upgrading from Kubecostv1

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,6 +1,8 @@
 
 
 --------------------------------------------------
+{{- include "kubecostV2-preconditions" . }}
+
 {{/*
 https://github.com/helm/helm/issues/8026#issuecomment-881216078
 */}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -25,13 +25,18 @@ Set important variables before starting main templates
 {{/*
 Kubecost 2.0 preconditions
 */}}
-{{ if .Values.federatedETL }}
-  {{ if .Values.federatedETL.primaryCluster }}
-    {{ fail "In Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." }}
+{{ define "kubecostV2-preconditions" }}
+  {{ if and (semverCompare "<2.0.0-0" .Chart.Version) (not .Values.upgradeToKubecostV2) }}
+    {{ fail "\n\nYou are attempting to upgrade to Kubecost 2.0. Please refer to the following documentation and talk to your Kubecost representative before upgrading, as there are potential breaking changes: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2 \n\nWhen ready to upgrade, set `.Values.upgradeToKubecostV2=true`." }}
   {{ end }}
-{{ end }}
-{{ if not .Values.kubecostModel.etlFileStoreEnabled }}
-  {{ fail "Kubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." }}
+  {{ if .Values.federatedETL }}
+    {{ if .Values.federatedETL.primaryCluster }}
+      {{ fail "In Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." }}
+    {{ end }}
+  {{ end }}
+  {{ if not .Values.kubecostModel.etlFileStoreEnabled }}
+    {{ fail "Kubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." }}
+  {{ end }}
 {{ end }}
 
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -26,8 +26,8 @@ Set important variables before starting main templates
 Kubecost 2.0 preconditions
 */}}
 {{ define "kubecostV2-preconditions" }}
-  {{ if and (semverCompare "<2.0.0-0" .Chart.Version) (not .Values.upgradeToKubecostV2) }}
-    {{ fail "\n\nYou are attempting to upgrade to Kubecost 2.0. Please refer to the following documentation and talk to your Kubecost representative before upgrading, as there are potential breaking changes: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2 \n\nWhen ready to upgrade, set `.Values.upgradeToKubecostV2=true`." }}
+  {{ if and (semverCompare "<2.0.0-0" .Chart.Version) (not .Values.upgrade.toV2) }}
+    {{ fail "\n\nYou are attempting to upgrade to Kubecost 2.0. Please refer to the following documentation and talk to your Kubecost representative before upgrading, as there are potential breaking changes: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2 \n\nWhen ready to upgrade, set `.Values.upgrade.toV2=true`." }}
   {{ end }}
   {{ if .Values.federatedETL }}
     {{ if .Values.federatedETL.primaryCluster }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2822,6 +2822,12 @@ kubecostAdmissionController:
 costEventsAudit:
   enabled: false
 
+## This flag is only required for users upgrading from 1.x to 2.x. Ensure users
+## are aware of any changes that might need to be made to their architecture
+## before continuing with the upgrade.
+## 
+upgradeToKubecostV2: false
+
 ## Disable updates to kubecost from the frontend UI and via POST request
 ##
 # readonly: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2825,7 +2825,7 @@ costEventsAudit:
 ## This flag is only required for users upgrading from 1.x to 2.x. Ensure users
 ## are aware of any changes that might need to be made to their architecture
 ## before continuing with the upgrade.
-## 
+##
 upgradeToKubecostV2: false
 
 ## Disable updates to kubecost from the frontend UI and via POST request

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2822,11 +2822,12 @@ kubecostAdmissionController:
 costEventsAudit:
   enabled: false
 
-## This flag is only required for users upgrading from 1.x to 2.x. Ensure users
-## are aware of any changes that might need to be made to their architecture
-## before continuing with the upgrade.
+## This flag is only required for users upgrading to a new version of Kubecost
+## which require a flag set. The flag is used to ensure users are aware of
+## important (potentially breaking) changes included in the new version.
 ##
-upgradeToKubecostV2: false
+upgrade:
+  toV2: false
 
 ## Disable updates to kubecost from the frontend UI and via POST request
 ##


### PR DESCRIPTION
## What does this PR change?

- Users must set flag `upgrade.toV2=true` if upgrading from Kubecostv1
- Intended to act as a safeguard in environments that frequently/continuously upgrade their deployments. Need to ensure that they're aware of the architectural requirements for Kubecost 2.0.
- Open to feedback on the idea, the wording, or the flag.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Flag required to be set when upgrading to KubecostV2.

## Links to Issues or tickets this PR addresses or fixes

None

## What risks are associated with merging this PR? What is required to fully test this PR?

Risk is creating added friction to the user experience when going to Kubecost 2.0.

## How was this PR tested?

```yaml
# Chart.yaml
version: "1.108.1"
```

```sh
# Error thrown
$ helm template ./cost-analyzer
Error: execution error at (cost-analyzer/templates/NOTES.txt:4:4):

You are attempting to upgrade to Kubecost 2.0. Please refer to the following documentation and talk to your Kubecost representative before upgrading, as there are potential breaking changes:
https://docs.kubecost.com/install-and-configure/install/kubecostv2

When ready to upgrade, set `.Values.upgrade.toV2=true`.

Use --debug flag to render out invalid YAML
```

```sh
# Successfully upgrade
$ helm template ./cost-analyzer --set upgrade.toV2=true
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

TODO: Need to generate documentation for users upgrading up to Kubecost 2.0. (e.g. Thanos users, FedETL users, single-cluster users).
