### PR TITLE
Update kubecost-modeling to API-stable version

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2243,7 +2243,7 @@ forecasting:
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
   # Example: fullImageName: gcr.io/kubecost1/forecasting:v0.0.1
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:54b0247a8986e4d2eb781f424487dcdd85e3e559
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:c1e6aae5f9961ff4b8eaaae41f5aa6970bf81853
 
   # Resource specification block for the forecasting container.
   resources:


### PR DESCRIPTION
## What does this PR change?
Updates the kubecost-modeling image to the most recent stable image.

This image also happens to have all previous vulnerabilities removed because it was overhauled with chainguard.

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A

## How was this PR tested?
This change is running in a live environment, behaves as expected.