### PR TITLE
Return descriptive error if user is running Aggregator in v1.x and attempting to upgrade to 2.0

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,6 +1,8 @@
 
 
 --------------------------------------------------
+{{ include "kubecostV2-preconditions" . }}
+
 {{/*
 https://github.com/helm/helm/issues/8026#issuecomment-881216078
 */}}

--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,14 +1,7 @@
 
 
 --------------------------------------------------
-{{ include "kubecostV2-preconditions" . }}
-
-{{/*
-https://github.com/helm/helm/issues/8026#issuecomment-881216078
-*/}}
-{{- if ((.Values.thanos).store).enabled }}
-{{- fail "Kubecost no longer includes Thanos by default. Please see https://docs.kubecost.com/install-and-configure/install/thanos for more information." }}
-{{- end }}
+{{- include "kubecostV2-preconditions" . }}
 
 {{- if (.Values.podSecurityPolicy).enabled }}
 {{- fail "Kubecost no longer includes PodSecurityPolicy by default. Please take steps to preserve your existing PSPs before attempting the installation/upgrade again with the podSecurityPolicy values removed." }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -21,7 +21,6 @@ Set important variables before starting main templates
   {{- end }}
 {{- end }}
 
-
 {{/*
 Kubecost 2.0 preconditions
 */}}
@@ -29,37 +28,40 @@ Kubecost 2.0 preconditions
   {{/* Iterate through all StatefulSets in the namespace and check if any of them have a label indicating they are from
   a pre-2.0 Helm Chart (e.g. "helm.sh/chart: cost-analyzer-1.108.1"). If so, return an error message with details and
   documentation for how to properly upgrade to Kubecost 2.0 */}}
-  {{ $sts := (lookup "apps/v1" "StatefulSet" .Release.Namespace "") }}
-  {{ if not (empty $sts.items) }}
-    {{ range $index, $sts := $sts.items }}
-      {{ if contains "aggregator" $sts.metadata.name }}
-        {{ if $sts.metadata.labels }}
-          {{ $stsLabels := $sts.metadata.labels }}                  {{/* helm.sh/chart: cost-analyzer-1.108.1 */}}
-          {{ if hasKey $stsLabels "helm.sh/chart" }}
-            {{ $chartLabel := index $stsLabels "helm.sh/chart" }}   {{/* cost-analyzer-1.108.1 */}}
-            {{ $chartNameAndVersion := split "-" $chartLabel }}     {{/* _0:cost _1:analyzer _2:1.108.1 */}}
-            {{ if gt (len $chartNameAndVersion) 2 }}
-              {{ $chartVersion := $chartNameAndVersion._2 }}        {{/* 1.108.1 */}}
-              {{ if semverCompare "<2.0.0-0" $chartVersion }}
-                {{ fail "Detected an existing Aggregator StatefulSet in your namespace. Before upgrading to Kubecost 2.0, please `kubectl delete` this Statefulset. Refer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2" }}
-              {{ end }}
-            {{ end }}
-          {{ end }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
+  {{- $sts := (lookup "apps/v1" "StatefulSet" .Release.Namespace "") -}}
+  {{- if not (empty $sts.items) -}}
+    {{- range $index, $sts := $sts.items -}}
+      {{- if contains "aggregator" $sts.metadata.name -}}
+        {{- if $sts.metadata.labels -}}
+          {{- $stsLabels := $sts.metadata.labels -}}                  {{/* helm.sh/chart: cost-analyzer-1.108.1 */}}
+          {{- if hasKey $stsLabels "helm.sh/chart" -}}
+            {{- $chartLabel := index $stsLabels "helm.sh/chart" -}}   {{/* cost-analyzer-1.108.1 */}}
+            {{- $chartNameAndVersion := split "-" $chartLabel -}}     {{/* _0:cost _1:analyzer _2:1.108.1 */}}
+            {{- if gt (len $chartNameAndVersion) 2 -}}
+              {{- $chartVersion := $chartNameAndVersion._2 -}}        {{/* 1.108.1 */}}
+              {{- if semverCompare "<2.0.0-0" $chartVersion -}}
+                {{- fail "Detected an existing Aggregator StatefulSet in your namespace. Before upgrading to Kubecost 2.0, please `kubectl delete` this Statefulset. Refer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2" -}}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 
-  {{ if .Values.federatedETL }}
-    {{ if .Values.federatedETL.primaryCluster }}
-      {{ fail "In Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." }}
-    {{ end }}
-  {{ end }}
+  {{/*https://github.com/helm/helm/issues/8026#issuecomment-881216078*/}}
+  {{- if ((.Values.thanos).store).enabled -}}
+  {{- fail "Kubecost no longer includes Thanos by default. Please see https://docs.kubecost.com/install-and-configure/install/thanos for more information." -}}
+  {{- end -}}
 
-  {{ if not .Values.kubecostModel.etlFileStoreEnabled }}
-    {{ fail "Kubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." }}
-  {{ end }}
-{{ end }}
+  {{- if (.Values.federatedETL).primaryCluster -}}
+    {{- fail "In Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." -}}
+  {{- end -}}
+
+  {{- if not .Values.kubecostModel.etlFileStoreEnabled -}}
+    {{- fail "Kubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." -}}
+  {{- end -}}
+{{- end -}}
 
 
 {{/*

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -47,10 +47,6 @@ Kubecost 2.0 preconditions
   {{ if not .Values.kubecostModel.etlFileStoreEnabled }}
     {{ fail "Kubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." }}
   {{ end }}
-
-  {{ if not .Values.kubecostModel.etlFileStoreEnabled }}
-    {{ fail "Kubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." }}
-  {{ end }}
 {{ end }}
 
 


### PR DESCRIPTION
## What does this PR change?

Return descriptive error if user is running Aggregator in 1.x and attempting to upgrade to 2.0

## Does this PR rely on any other PRs?

It needs an accompanying Docs PR.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Users who deployed Aggregator in v1.107 or v1.108 will receive the following Helm error when upgrading to v2.0.

```
Error: UPGRADE FAILED: cannot patch "max-od-aggregator" with kind StatefulSet: StatefulSet.apps "max-od-aggregator" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```

This is an expected error due to changes in the Aggregator Helm template in 2.0. However, this error is difficult to understand. This PR attempts to get ahead of this error, and instead return a helpful message to users. Also directing them to additional documentation on how to resolve the issue.

## Links to Issues or tickets this PR addresses or fixes

## What risks are associated with merging this PR? What is required to fully test this PR?

If users are running Aggregator in 1.x but have removed the label `helm.sh/chart` from the StatefulSet, this logic will not catch their scenario. I would guess this is a minority of cases? For those who deploy via GitOps + `helm template`, this label should still exist in their StatefulSet.

## How was this PR tested?

```sh
# Errors when templating. The namespace it's pointed at currently has a v1.108.1 aggregator running.
$ helm template thomasn-agg-upgrade ./cost-analyzer --dry-run=server

Error: execution error at (cost-analyzer/templates/NOTES.txt:4:3): Detected an existing Aggregator StatefulSet in your namespace. Before upgrading to Kubecost 2.0, please `kubectl delete` this Statefulset. Refer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2
```

```sh
# Correctly see a failure here with an error message
$ helm upgrade -i thomasn-agg-upgrade ~/kubecost/cost-analyzer-helm-chart/cost-analyzer \
  --version 2.0.0-rc.1 \
  -f values.yaml

Error: UPGRADE FAILED: execution error at (cost-analyzer/templates/NOTES.txt:4:3): Detected an existing Aggregator StatefulSet in your namespace. Before upgrading to Kubecost 2.0, please `kubectl delete` this Statefulset. Refer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2

# Manual intervention
$ kubectl delete sts/thomasn-agg-upgrade-aggregator

# Success
$ helm upgrade -i thomasn-agg-upgrade ~/kubecost/cost-analyzer-helm-chart/cost-analyzer \
  --version 2.0.0-rc.1 \
  -f values.yaml

Release "thomasn-agg-upgrade" has been upgraded. Happy Helming!
NAME: thomasn-agg-upgrade
LAST DEPLOYED: Thu Jan 25 13:36:13 2024
NAMESPACE: thomasn-agg-upgrade
STATUS: deployed
REVISION: 13
NOTES:
--------------------------------------------------

Kubecost 2.0.0 has been successfully installed.

Please allow 5-10 minutes for Kubecost to gather metrics.

When configured, cost reconciliation with cloud provider billing data will have a 48 hour delay.

When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace thomasn-agg-upgrade deployment/thomasn-agg-upgrade-cost-analyzer 9090

Then, navigate to http://localhost:9090 in a web browser.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install

# Run the test again
$ helm rollback thomasn-agg-upgrade 1
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

TODO. Needs an accompanying PR update.