### PR TITLE
disable node exporter by default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1514,9 +1514,10 @@ prometheus:
 
   # node-export must be disabled if there is an existing daemonset: https://guide.kubecost.com/hc/en-us/articles/4407601830679-Troubleshoot-Install#a-name-node-exporter-a-issue-failedscheduling-kubecost-prometheus-node-exporter
   nodeExporter:
-    ## If false, node-exporter will not be installed
+    ## If false, node-exporter will not be installed.
+    ## This is disabled by default in Kubecost 2.0, though it can be enabled as needed.
     ##
-    enabled: true
+    enabled: false
 
     ## If true, node-exporter pods share the host network namespace
     ##


### PR DESCRIPTION
## What does this PR change?
disable node exporter by default

## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Disable node exporter by default, it can be reenabled as needed.

## What risks are associated with merging this PR? What is required to fully test this PR?
Reserved instances will display a message that node-exporter is required, but this report is only useful for single cluster users.

## How was this PR tested?
helm installs

## Have you made an update to documentation? If so, please provide the corresponding PR.
@bstuder99 can you look for our node exporter docs and add a message about the default?
