### PR TITLE
Set Gunicorn worker timeout to 1200 seconds

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2256,7 +2256,10 @@ forecasting:
       memory: 1Gi
 
   # Set environment variables for the forecasting container as key/value pairs.
-  env: {}
+  env:
+    # -t is the worker timeout which primarily affects model training time;
+    # if it is not high enough, training workers may die mid training
+    "GUNICORN_CMD_ARGS": "--log-level info -t 1200"
 
   # Define a priority class for the forecasting Deployment.
   priority:


### PR DESCRIPTION
## What does this PR change?
Sets the modeling container's Gunicorn worker timeout to 1200 seconds (instead of the default 30 seconds) to give training workers enough time to train models.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A

## How was this PR tested?
Tested in the live qa-gcp1 environment and noted that after the change, workers were able to train successfully instead of timing out.