### PR TITLE
Update modeling image with fixed training of Cloud Costs, Assets, and Allocations

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2243,8 +2243,8 @@ forecasting:
   # fullImageName overrides the default image construction logic. The exact
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
-  # Example: fullImageName: gcr.io/kubecost1/forecasting:v0.0.1
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:c1e6aae5f9961ff4b8eaaae41f5aa6970bf81853
+  # Example: fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.0.1
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:6e6946f
 
   # Resource specification block for the forecasting container.
   resources:


### PR DESCRIPTION
## What does this PR change?
Fixes Cloud Cost, Asset, and Allocation training code. Should now be serving valid trained models for supported aggregates.

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A

## How was this PR tested?
Deployed to live env and observed FE showing forecasts that appeared to be based on real data