### PR TITLE
Update modeling image: resilient to bad training data and CC endpoint behavior

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2244,7 +2244,7 @@ forecasting:
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
   # Example: fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.0.1
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:a408dc4
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:1603669
 
   # Resource specification block for the forecasting container.
   resources:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2244,7 +2244,7 @@ forecasting:
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
   # Example: fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.0.1
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:6e6946f
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:a408dc4
 
   # Resource specification block for the forecasting container.
   resources:


### PR DESCRIPTION
## What does this PR change?
See linked PRs

## Does this PR relate to any other PRs?
Includes changes from these PRs
- https://github.com/kubecost/kubecost-modeling/pull/20
- https://github.com/kubecost/kubecost-modeling/pull/21
- https://github.com/kubecost/kubecost-modeling/pull/22
- https://github.com/kubecost/kubecost-modeling/pull/23

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A

## How was this PR tested?
Deployed to live test env and observed successful training and FE forecast pages load