### PR TITLE
multi-cluster prometheus check

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -54,9 +54,9 @@ Kubecost 2.0 preconditions
   {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0.\nKubecost no longer includes Thanos by default. \nPlease see https://docs.kubecost.com/install-and-configure/install/kubecostv2 for more information.\nIf you have any questions or concerns, please reach out to us at product@kubecost.com" -}}
   {{- end -}}
 
-  {{- if or ((.Values.global.amp).enabled) ((.Values.global.gmp).enabled) ((.Values.global.thanos.)queryService) ((.Values.global.mimirProxy).enabled -}}
+  {{- if or ((.Values.global.amp).enabled) ((.Values.global.gmp).enabled) ((.Values.global.thanos).queryService) ((.Values.global.mimirProxy).enabled) -}}
     {{- if or (not (.Values.federatedETL).federatedCluster) (not (.Values.upgrade).toV2) -}}
-      {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0. \nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2\nIf you have any questions or concerns, please reach out to us at product@kubecost.com\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
+      {{- fail "\n\nMulti-Cluster-Prometheus Error:\nYou are attempting to upgrade to Kubecost 2.x\nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2\nIf you have any questions or concerns, please reach out to us at product@kubecost.com\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
     {{- end -}}
   {{- end -}}
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -54,8 +54,10 @@ Kubecost 2.0 preconditions
   {{- fail "Kubecost no longer includes Thanos by default. Please see https://docs.kubecost.com/install-and-configure/install/thanos for more information." -}}
   {{- end -}}
 
-  {{- if (.Values.federatedETL).primaryCluster -}}
-    {{- fail "In Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." -}}
+  {{- if or ((.Values.global.amp).enabled) ((.Values.global.gmp).enabled) -}}
+    {{- if or (not (.Values.federatedETL).federatedCluster) (not (.Values.upgrade).toV2) -}}
+      {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0. \nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2 \n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
+    {{- end -}}
   {{- end -}}
 
   {{- if not .Values.kubecostModel.etlFileStoreEnabled -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -51,12 +51,12 @@ Kubecost 2.0 preconditions
 
   {{/*https://github.com/helm/helm/issues/8026#issuecomment-881216078*/}}
   {{- if ((.Values.thanos).store).enabled -}}
-  {{- fail "Kubecost no longer includes Thanos by default. Please see https://docs.kubecost.com/install-and-configure/install/thanos for more information." -}}
+  {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0.\nKubecost no longer includes Thanos by default. \nPlease see https://docs.kubecost.com/install-and-configure/install/kubecostv2 for more information." -}}
   {{- end -}}
 
-  {{- if or ((.Values.global.amp).enabled) ((.Values.global.gmp).enabled) -}}
+  {{- if or ((.Values.global.amp).enabled) ((.Values.global.gmp).enabled) ((.Values.global.thanos.)queryService) ((.Values.global.mimirProxy).enabled -}}
     {{- if or (not (.Values.federatedETL).federatedCluster) (not (.Values.upgrade).toV2) -}}
-      {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0. \nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2 \n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
+      {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0. \nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2 \n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
     {{- end -}}
   {{- end -}}
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -51,12 +51,12 @@ Kubecost 2.0 preconditions
 
   {{/*https://github.com/helm/helm/issues/8026#issuecomment-881216078*/}}
   {{- if ((.Values.thanos).store).enabled -}}
-  {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0.\nKubecost no longer includes Thanos by default. \nPlease see https://docs.kubecost.com/install-and-configure/install/kubecostv2 for more information." -}}
+  {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0.\nKubecost no longer includes Thanos by default. \nPlease see https://docs.kubecost.com/install-and-configure/install/kubecostv2 for more information.\nIf you have any questions or concerns, please reach out to us at product@kubecost.com" -}}
   {{- end -}}
 
   {{- if or ((.Values.global.amp).enabled) ((.Values.global.gmp).enabled) ((.Values.global.thanos.)queryService) ((.Values.global.mimirProxy).enabled -}}
     {{- if or (not (.Values.federatedETL).federatedCluster) (not (.Values.upgrade).toV2) -}}
-      {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0. \nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2 \n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
+      {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0. \nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2\nIf you have any questions or concerns, please reach out to us at product@kubecost.com\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
     {{- end -}}
   {{- end -}}
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -54,7 +54,7 @@ Kubecost 2.0 preconditions
   {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.0.\nKubecost no longer includes Thanos by default. \nPlease see https://docs.kubecost.com/install-and-configure/install/kubecostv2 for more information.\nIf you have any questions or concerns, please reach out to us at product@kubecost.com" -}}
   {{- end -}}
 
-  {{- if or ((.Values.global.amp).enabled) ((.Values.global.gmp).enabled) ((.Values.global.thanos).queryService) ((.Values.global.mimirProxy).enabled) -}}
+  {{- if or (((.Values.global).amp).enabled) (((.Values.global).gmp).enabled) (((.Values.global).thanos).queryService) (((.Values.global).mimirProxy).enabled) -}}
     {{- if or (not (.Values.federatedETL).federatedCluster) (not (.Values.upgrade).toV2) -}}
       {{- fail "\n\nMulti-Cluster-Prometheus Error:\nYou are attempting to upgrade to Kubecost 2.x\nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2\nIf you have any questions or concerns, please reach out to us at product@kubecost.com\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
     {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -245,6 +245,13 @@ global:
         seccompProfile:
           type: RuntimeDefault
 
+## This flag is only required for users upgrading to a new version of Kubecost.
+## The flag is used to ensure users are aware of important
+## (potentially breaking) changes included in the new version.
+##
+upgrade:
+  toV2: false
+
 # generated at http://kubecost.com/install, used for alerts tracking and free trials
 kubecostToken:  # ""
 


### PR DESCRIPTION
## What does this PR change?
Kubecost 2.0 does not support multi-cluster prometheus without using federatedETL. This check prevents upgrading to 2.0 if GMP or AMP are enabled and federatedETL.federatedCluster is not true

this is the message when upgrading if these condiions are not met:

```
Error: UPGRADE FAILED: execution error at (cost-analyzer/templates/NOTES.txt:4:4): 

Multi-Cluster-Prometheus Error:
You are attempting to upgrade to Kubecost 2.x
Support for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. 
If this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.
More information can be found here: 
https://docs.kubecost.com/install-and-configure/install/kubecostv2
If you have any questions or concerns, please reach out to us at product@kubecost.com

When ready to upgrade, add `--set upgrade.toV2=true`.
```

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Upgrading to 2.0 will be blocked when multi-cluster Prometheus is detected. 

## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
helm upgrades against various configs

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
