### PR TITLE
Sensible error on /forecasting if forecasting is disabled (instead of index.html)

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -936,7 +936,7 @@ data:
         {{- else }}
         location /forecasting {
             default_type 'application/json';
-            return 404 '{"forecastingEnabled": "false"}';
+            return 405 '{"forecastingEnabled": "false"}';
         }
         {{- end }}
 

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -933,7 +933,12 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        {{ end }}
+        {{- else }}
+        location /forecasting {
+            default_type 'application/json';
+            return 404 '{"forecastingEnabled": "false"}';
+        }
+        {{- end }}
 
     }
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
Causes all `/forecasting` routes to 404 if forecasting is disabled. This means we shouldn't hit the fallback to index.html, which was odd behavior because it caused a 200 code response but with the default index.html, not the expected /forecasting/... JSON response.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A, unreleased

## How was this PR tested?
```
→ helm template kubecost ./cost-analyzer --set forecasting.enabled='false' -s 'templates/cost-analyzer-frontend-config-map-template.yaml' | yq '.data["nginx.conf"]' | grep -B 1 -A 5 'forecasting'
    }
    location /forecasting {
        default_type 'application/json';
        return 404 '{"forecastingEnabled": "false"}';
    }

}
```
```
→ helm template kubecost ./cost-analyzer --set forecasting.enabled='true' -s 'templates/cost-analyzer-frontend-config-map-template.yaml' | yq '.data["nginx.conf"]' | grep -B 1 -A 5 'forecasting'
}
upstream forecasting {
    server kubecost-forecasting.default:5000;
}
upstream aggregator {
    server kubecost-aggregator.default:9004;
}

--
    }
    location /forecasting {
        default_type 'application/json';
        add_header 'Access-Control-Allow-Origin' '*' always;
        add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
        proxy_read_timeout          300;
        proxy_pass http://forecasting/;
        proxy_redirect off;
        proxy_set_header Connection "";
        proxy_set_header  X-Real-IP  $remote_addr;
        proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
    }
```
