### PR TITLE
Bump forecasting image with latest improvements

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2244,7 +2244,7 @@ forecasting:
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
   # Example: fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.0.1
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:1603669
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:1904392
 
   # Resource specification block for the forecasting container.
   resources:


### PR DESCRIPTION
## What does this PR change?
Contains fixes from these PRs:
- https://github.com/kubecost/kubecost-modeling/pull/24
- https://github.com/kubecost/kubecost-modeling/pull/25
- https://github.com/kubecost/kubecost-modeling/pull/26
- https://github.com/kubecost/kubecost-modeling/pull/27
- https://github.com/kubecost/kubecost-modeling/pull/28
- https://github.com/kubecost/kubecost-modeling/pull/29

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A unreleased

## How was this PR tested?
Deployed in live env, tested with UI
