### PR TITLE
rbac upgrade check

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -40,7 +40,7 @@ Kubecost 2.0 preconditions
             {{- if gt (len $chartNameAndVersion) 2 -}}
               {{- $chartVersion := $chartNameAndVersion._2 -}}        {{/* 1.108.1 */}}
               {{- if semverCompare "<2.0.0-0" $chartVersion -}}
-                {{- fail "Detected an existing Aggregator StatefulSet in your namespace. Before upgrading to Kubecost 2.0, please `kubectl delete` this Statefulset. Refer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2" -}}
+                {{- fail "\n\nAn existing Aggregator StatefulSet was found in your namespace.\nBefore upgrading to Kubecost 2.x, please `kubectl delete` this Statefulset.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2" -}}
               {{- end -}}
             {{- end -}}
           {{- end -}}
@@ -51,21 +51,21 @@ Kubecost 2.0 preconditions
 
   {{/*https://github.com/helm/helm/issues/8026#issuecomment-881216078*/}}
   {{- if ((.Values.thanos).store).enabled -}}
-  {{- fail "Kubecost no longer includes Thanos by default. Please see https://docs.kubecost.com/install-and-configure/install/thanos for more information." -}}
+  {{- fail "\n\nKubecost no longer includes Thanos by default. Please see https://docs.kubecost.com/install-and-configure/install/thanos for more information." -}}
   {{- end -}}
 
   {{- if (.Values.federatedETL).primaryCluster -}}
-    {{- fail "In Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." -}}
+    {{- fail "\n\nIn Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." -}}
   {{- end -}}
 
   {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
     {{- if (not (.Values.upgrade).toV2) -}}
-      {{- fail "Kubecost 2.x has significant architectural changes that may impact RBAC.\nThis should be tested before giving end-users access to the UI.\nKubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
+      {{- fail "\n\nKubecost 2.x has significant architectural changes that may impact RBAC.\nThis should be tested before giving end-users access to the UI.\nKubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
     {{- end -}}
   {{- end -}}
 
   {{- if not .Values.kubecostModel.etlFileStoreEnabled -}}
-    {{- fail "Kubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." -}}
+    {{- fail "\n\nKubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." -}}
   {{- end -}}
 {{- end -}}
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1041,3 +1041,14 @@ Aggregator config reconciliation and common config
       value: {{ .Values.systemProxy.noProxy }}
     {{- end }}
 {{- end }}
+
+{{/*
+SSO enabled flag for nginx configmap
+*/}}
+{{- define "ssoEnabled" -}}
+  {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
+    {{- printf "true" -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end -}}
+{{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -58,6 +58,12 @@ Kubecost 2.0 preconditions
     {{- fail "In Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." -}}
   {{- end -}}
 
+  {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
+    {{- if (not (.Values.upgrade).toV2) -}}
+      {{- fail "Kubecost 2.x has significant architectural changes that may impact RBAC.\nThis should be tested before giving end-users access to the UI.\nKubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
+    {{- end -}}
+  {{- end -}}
+
   {{- if not .Values.kubecostModel.etlFileStoreEnabled -}}
     {{- fail "Kubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." -}}
   {{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -58,9 +58,9 @@ Kubecost 2.0 preconditions
     {{- fail "\n\nIn Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." -}}
   {{- end -}}
 
-  {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
+  {{- if or (.Values.saml.rbac).enabled (.Values.oidc.rbac).enabled -}}
     {{- if (not (.Values.upgrade).toV2) -}}
-      {{- fail "\n\nSSO is enabled.\nNote that Kubecost 2.x has significant architectural changes that may impact RBAC.\nThis should be tested before giving end-users access to the UI.\nKubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
+      {{- fail "\n\nSSO with RBAC is enabled.\nNote that Kubecost 2.x has significant architectural changes that may impact RBAC.\nThis should be tested before giving end-users access to the UI.\nKubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
     {{- end -}}
   {{- end -}}
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -58,7 +58,7 @@ Kubecost 2.0 preconditions
     {{- fail "\n\nIn Kubecost 2.0, there is no such thing as a federated primary. If you are a Federated ETL user, this setting has been removed. Make sure you have kubecostAggregator.deployMethod set to 'statefulset' and federatedETL.federatedCluster set to 'true'." -}}
   {{- end -}}
 
-  {{- if or (.Values.saml.rbac).enabled (.Values.oidc.rbac).enabled -}}
+  {{- if or ((.Values.saml).rbac).enabled ((.Values.oidc).rbac).enabled -}}
     {{- if (not (.Values.upgrade).toV2) -}}
       {{- fail "\n\nSSO with RBAC is enabled.\nNote that Kubecost 2.x has significant architectural changes that may impact RBAC.\nThis should be tested before giving end-users access to the UI.\nKubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
     {{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -60,7 +60,7 @@ Kubecost 2.0 preconditions
 
   {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
     {{- if (not (.Values.upgrade).toV2) -}}
-      {{- fail "\n\nKubecost 2.x has significant architectural changes that may impact RBAC.\nThis should be tested before giving end-users access to the UI.\nKubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
+      {{- fail "\n\nSSO is enabled.\nNote that Kubecost 2.x has significant architectural changes that may impact RBAC.\nThis should be tested before giving end-users access to the UI.\nKubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
     {{- end -}}
   {{- end -}}
 

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -939,7 +939,14 @@ data:
             return 405 '{"forecastingEnabled": "false"}';
         }
         {{- end }}
-
+        location /model/productConfigs {
+            default_type 'application/json';
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            return 200 '\n
+                {"ssoConfigured": "{{ template "ssoEnabled" . }}"}\n
+            ';
+        }
     }
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
Force RBAC users to accept risk before upgrading. 

Message:
```
Error: UPGRADE FAILED: execution error at (cost-analyzer/templates/NOTES.txt:4:4): Kubecost 2.x has significant architectural changes that may impact RBAC.
This should be tested before giving end-users access to the UI.
Kubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.
Refer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2

When ready to upgrade, add `--set upgrade.toV2=true`.
```

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
RBAC users: Kubecost 2.x has significant architectural changes that may impact RBAC. Please test the configuration before allowing end-user access to Kubecost. 


## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
Tested against a 1.x SAML environment. 

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
