### PR TITLE
Move 2.0 precondition checks into a function

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Kubecost 2.0 preconditions
   {{/* Aggregator config reconciliation and common config */}}
   {{- if eq (include "aggregator.deployMethod" .) "statefulset" -}}
     {{- if .Values.kubecostAggregator -}}
-      {{- if (not .values.kubecostAggregator.aggregatorDbStorage) -}}
+      {{- if (not .Values.kubecostAggregator.aggregatorDbStorage) -}}
         {{- fail "In Enterprise configuration, Aggregator DB storage is required" -}}
       {{- end -}}
     {{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -61,6 +61,19 @@ Kubecost 2.0 preconditions
   {{- if not .Values.kubecostModel.etlFileStoreEnabled -}}
     {{- fail "Kubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." -}}
   {{- end -}}
+
+  {{- if .Values.kubecostModel.openSourceOnly -}}
+    {{- fail "In Kubecost 2.0, kubecostModel.openSourceOnly is not supported" -}}
+  {{- end -}}
+
+  {{/* Aggregator config reconciliation and common config */}}
+  {{- if eq (include "aggregator.deployMethod" .) "statefulset" -}}
+    {{- if .Values.kubecostAggregator -}}
+      {{- if (not .values.kubecostAggregator.aggregatorDbStorage) -}}
+        {{- fail "In Enterprise configuration, Aggregator DB storage is required" -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 
@@ -657,39 +670,11 @@ Create the name of the service account
 {{- end -}}
 {{- end -}}
 
-
-
 {{/*
 ==============================================================
 Begin Kubecost 2.0 templates
 ==============================================================
 */}}
-{{/*
-Check KC 2.0 values requirements that may differ
-*/}}
-{{ if .Values.federatedETL }}
-  {{ if .Values.federatedETL.primaryCluster }}
-    {{ fail "In Kubecost 2.0, all federated configurations must be set up as secondary" }}
-  {{ end }}
-{{ end }}
-
-{{ if .Values.kubecostModel }}
-  {{ if .Values.kubecostModel.openSourceOnly }}
-    {{ fail "In Kubecost 2.0, kubecostModel.openSourceOnly is not supported" }}
-  {{ end }}
-{{ end }}
-
-{{/*
-Aggregator config reconciliation and common config
-*/}}
-{{ if eq (include "aggregator.deployMethod" .) "statefulset" }}
-  {{ if .Values.kubecostAggregator }}
-    {{ if (not .values.kubecostAggregator.aggregatorDbStorage) }}
-      {{ fail "In Enterprise configuration, Aggregator DB storage is required" }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-
 
 {{- define "aggregator.containerTemplate" }}
 - name: aggregator


### PR DESCRIPTION
## What does this PR change?

Moves 2.0 precondition checks into a function. I don't believe anything in the `_helpers.tpl` gets executed unless its in a function and the function is called.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Additional 2.0 checks to ensure users are upgrading using a valid configuration.

## Links to Issues or tickets this PR addresses or fixes

None

## What risks are associated with merging this PR? What is required to fully test this PR?

Should be minimal. Just relocating code in `_helpers.tpl`

## How was this PR tested?

```
$ helm template thomasn-agg-upgrade ./cost-analyzer --dry-run=server --set kubecostModel.openSourceOnly=true
Error: execution error at (cost-analyzer/templates/NOTES.txt:4:4): In Kubecost 2.0, kubecostModel.openSourceOnly is not supported
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

Not needed