### PR TITLE
disable configmapReloader by default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1443,7 +1443,7 @@ prometheus:
     prometheus:
       ## If false, the configmap-reload container will not be deployed
       ##
-      enabled: true
+      enabled: false
 
       ## configmap-reload container name
       ##


### PR DESCRIPTION
## What does this PR change?
Disable Prometheus configMap reloader by default

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Disable Prometheus configMap reloader by default to reduce containers/images. There is no impact to typical Kubecost installs

## What risks are associated with merging this PR? What is required to fully test this PR?
Users that don't see the release notes and utilize the functionality provided by the bundle prometheus server.

## How was this PR tested?
Helm installs on several environments.

## Have you made an update to documentation? If so, please provide the corresponding PR.
TBD
