### PR TITLE
federatedETL agent

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1054,3 +1054,11 @@ SSO enabled flag for nginx configmap
     {{- printf "false" -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "cost-analyzer.grafanaEnabled" -}}
+  {{- if and (.Values.global.grafana.enabled) (not .Values.federatedETL.agentOnly)  -}}
+    {{- printf "true" -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end -}}
+{{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -76,7 +76,7 @@ spec:
         {{- end }}
         - name: tmp
           emptyDir: {}
-        {{- if .Values.kubecostFrontend.enabled }}
+        {{- if and .Values.kubecostFrontend.enabled (not .Values.federatedETL.agentOnly) }}
         - name: nginx-conf
           configMap:
             name: nginx-conf
@@ -613,7 +613,7 @@ spec:
           env:
             {{- if .Values.global.grafana }}
             - name: GRAFANA_ENABLED
-              value: {{ (quote .Values.global.grafana.enabled) | default (quote false) }}
+              value: "{{ template "cost-analyzer.grafanaEnabled" . }}"
             {{- end}}
             {{- if .Values.kubecostModel.extraEnv -}}
             {{ toYaml .Values.kubecostModel.extraEnv | nindent 12 }}
@@ -1001,7 +1001,7 @@ spec:
                   key: kubecost-token
             - name: WATERFOWL_ENABLED
               value: "true"
-        {{- if .Values.kubecostFrontend.enabled }}
+        {{- if and .Values.kubecostFrontend.enabled (not .Values.federatedETL.agentOnly) }}
         {{- if .Values.kubecostFrontend }}
         {{- if .Values.kubecostFrontend.fullImageName }}
         - image: {{ .Values.kubecostFrontend.fullImageName }}
@@ -1077,14 +1077,11 @@ spec:
           {{- end }}
         {{ end }}
 
-        {{- if eq (include "aggregator.deployMethod" .) "singlepod" }}
+        {{- if and (eq (include "aggregator.deployMethod" .) "singlepod") (not .Values.federatedETL.agentOnly) }}
         {{- include "aggregator.containerTemplate" . | nindent 8 }}
         {{- if .Values.kubecostAggregator.jaeger.enabled }}
         {{- include "aggregator.jaeger.sidecarContainerTemplate" . | nindent 8 }}
         {{- end }}
-        {{- end }}
-
-        {{- if not (eq (include "aggregator.deployMethod" .) "statefulset") }}
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
         {{- end }}
 

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kubecostFrontend.enabled }}
-{{- if and (not .Values.agent) (not .Values.cloudAgent) }}
+{{- if and (not .Values.agent) (not .Values.cloudAgent) (not .Values.federatedETL.agentOnly) }}
 {{- $serviceName := include "cost-analyzer.serviceName" . -}}
 {{- if .Values.saml.enabled }}
 {{- if .Values.oidc.enabled }}

--- a/cost-analyzer/templates/grafana-attached-disk-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-attached-disk-metrics-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-clusterrole.yaml
+++ b/cost-analyzer/templates/grafana-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if .Values.grafana.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cost-analyzer/templates/grafana-clusterrolebinding.yaml
+++ b/cost-analyzer/templates/grafana-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if .Values.grafana.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cost-analyzer/templates/grafana-configmap-dashboard-provider.yaml
+++ b/cost-analyzer/templates/grafana-configmap-dashboard-provider.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if .Values.grafana.sidecar.dashboards.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/cost-analyzer/templates/grafana-configmap.yaml
+++ b/cost-analyzer/templates/grafana-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboards-json-configmap.yaml
+++ b/cost-analyzer/templates/grafana-dashboards-json-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true")  }}
 {{- if .Values.grafana.dashboards }}
   {{- range $provider, $dashboards := .Values.grafana.dashboards }}
 ---
@@ -21,4 +21,4 @@ data:
   {{- end }}
   {{- end }}
 {{- end }}
-{{ end }}
+{{- end }}

--- a/cost-analyzer/templates/grafana-deployment.yaml
+++ b/cost-analyzer/templates/grafana-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -160,7 +160,7 @@ spec:
               mountPath: "/var/lib/grafana/dashboards/{{ . }}"
   {{- end }}
 {{- end }}
-{{- if or .Values.grafana.datasources .Values.global.grafana.enabled }}
+{{- if or (.Values.grafana.datasources) (include "cost-analyzer.grafanaEnabled" .)  }}
             - name: config
               mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
               subPath: datasources.yaml

--- a/cost-analyzer/templates/grafana-ingress.yaml
+++ b/cost-analyzer/templates/grafana-ingress.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if .Values.grafana.ingress.enabled -}}
 {{- $fullName := include "grafana.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}

--- a/cost-analyzer/templates/grafana-networkcosts-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-networkcosts-metrics-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-pod-utilization-multi-cluster-template.yaml
+++ b/cost-analyzer/templates/grafana-pod-utilization-multi-cluster-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if .Values.grafana.sidecar.dashboards.enabled -}}
+{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-pvc.yaml
+++ b/cost-analyzer/templates/grafana-pvc.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if and .Values.grafana.persistence.enabled (not .Values.grafana.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/cost-analyzer/templates/grafana-secret.yaml
+++ b/cost-analyzer/templates/grafana-secret.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/cost-analyzer/templates/grafana-service.yaml
+++ b/cost-analyzer/templates/grafana-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/cost-analyzer/templates/grafana-serviceaccount.yaml
+++ b/cost-analyzer/templates/grafana-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.grafana.enabled }}
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -10,4 +10,4 @@ metadata:
   name: {{ template "grafana.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
-{{ end }}
+{{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2805,6 +2805,10 @@ awsstore:
 ## Ref: https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl
 ##
 federatedETL:
+
+  ## If true, installs the minimal set of components required for a Federated ETL cluster.
+  agentOnly: false
+
   ## If true, push ETL data to the federated storage bucket
   federatedCluster: false
 


### PR DESCRIPTION
## What does this PR change?
Create a simple helm flag for federated ETL agents

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Allow multi-cluster deployments with a simple arguement


## What risks are associated with merging this PR? What is required to fully test this PR?
Unknown configuratoins, bad logic blocks somewhere

## How was this PR tested?
new install and upgrade using local chart in many configurations

net result is 3 containers by default:
```
kgp
NAME                                                              READY   STATUS              RESTARTS   AGE
kubecost-fedetl-agent-qa-gcp1-cost-analyzer-ffd8bff89-wr5bf       0/1     ContainerCreating   0          8s
kubecost-fedetl-agent-qa-gcp1-diagnostics-7f4bc855df-hgls5        1/1     Running             0          8s
kubecost-fedetl-agent-qa-gcp1-prometheus-server-84795fb889xx49x   0/1     ContainerCreating   0          6s
```

## Have you made an update to documentation? If so, please provide the corresponding PR.
WIll need to update agent docs for 2.0
