### PR TITLE
block thanos agent upgrades and suggest fedetl

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -69,6 +69,10 @@ Kubecost 2.0 preconditions
   {{- if not .Values.kubecostModel.etlFileStoreEnabled -}}
     {{- fail "\n\nKubecost 2.0 does not support running fully in-memory. Some file system must be available to store cost data." -}}
   {{- end -}}
+
+  {{- if (.Values.agent) -}}
+    {{- fail "\n\nKubecost 2.0 Does not support Thanos based agents. For Thanos, please continue to use 1.108.x.\nConsider moving to Kubecost Federated ETL based agents.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\nSupport for Thanos agents is under consideration.\nIf you have any questions or concerns, please reach out to us at product@kubecost.com" -}}
+  {{- end -}}
 {{- end -}}
 
 

--- a/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secretprovider-template.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.agent }}
-{{- if .Values.agentCsi.enabled }}
+{{- if ((.Values.agentCsi).enabled) }}
 {{- if .Capabilities.APIVersions.Has "secrets-store.csi.x-k8s.io/v1" }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 {{- else }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -58,7 +58,7 @@ spec:
       volumes:
         {{- if .Values.agent }}
         - name: config-store
-          {{- if .Values.agentCsi.enabled }}
+          {{- if ((.Values.agentCsi).enabled) }}
           csi:
             driver: secrets-store.csi.k8s.io
             readOnly: true
@@ -274,7 +274,7 @@ spec:
               value: {{ (quote .Values.global.prometheus.insecureSkipVerify) }}
             {{- end }}
             {{- if .Values.cloudAgentClusterId }}
-            - name: CLUSTER_ID 
+            - name: CLUSTER_ID
               value: {{ .Values.cloudAgentClusterId }}
             {{- else if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.clusterIDConfigmap) }}
             - name: CLUSTER_ID


### PR DESCRIPTION
## What does this PR change?
Blocking thanos agents until 2.x supports multi-cluster prometheus.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Thanos based agents should remain on 1.x versions until 2.x supports multi-cluster prometheus.

## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
--set agent=true
```
Error: UPGRADE FAILED: execution error at (cost-analyzer/templates/NOTES.txt:4:4): 

Kubecost 2.0 Does not support Thanos based agents. For Thanos, please continue to use 1.108.x.
Consider moving to Kubecost Federated ETL based agents.
Refer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2
Support for Thanos agents is under consideration.
If you have any questions or concerns, please reach out to us at product@kubecost.com
```


## Have you made an update to documentation? If so, please provide the corresponding PR.
Need to add statement in v2 doc.
