### PR TITLE
Update to check if saml is enabled, not just if the object exists.

### DIFF
--- a/cost-analyzer/templates/kubecost-saml-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-saml-secret-template.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.saml }}
+{{- if .Values.saml.enabled }}
 apiVersion: v1
 kind: Secret
 type: Opaque


### PR DESCRIPTION
## What does this PR change?

Update to check if saml is enabled, not just if the object exists.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

For non-SAML users, an unnecessary secret will not be created

## Links to Issues or tickets this PR addresses or fixes

None

## What risks are associated with merging this PR? What is required to fully test this PR?

I observed that the `kubecost-saml` secret was being created even in the default nightly install:

```
helm upgrade -i thomasn-nightly  cost-analyzer --repo https://kubecost.github.io/nightly-helm-chart
```

I have not yet tested an install on a SAML setup, or a standard Kubecost Enterprise which may have a hidden dependency on this secret. @saweber Do you have any insight here?

## How was this PR tested?

TODO?

## Have you made an update to documentation? If so, please provide the corresponding PR.

Not needed