### PR TITLE
[GTM-199] take global annotations setting into etlutils

### DIFF
--- a/cost-analyzer/templates/etl-utils-deployment.yaml
+++ b/cost-analyzer/templates/etl-utils-deployment.yaml
@@ -6,12 +6,16 @@ metadata:
   name: {{ template "etlUtils.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "etlUtils.commonLabels" . | nindent 4 }}
+    {{- include "etlUtils.commonLabels" . | nindent 4 }}
+  {{- with .Values.global.podAnnotations}}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{ include "etlUtils.selectorLabels" . | nindent 6 }}
+      {{- include "etlUtils.selectorLabels" . | nindent 6 }}
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
## What does this PR change?
allows user set annotations on etlutils

## Does this PR rely on any other PRs?
none 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
allows users to have their annotations appear on the etl-utils pod

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/GTM-199



## What risks are associated with merging this PR? What is required to fully test this PR?
low risk

## How was this PR tested?
tested with helm template

## Have you made an update to documentation? If so, please provide the corresponding PR.

