### PR TITLE
Enable forecasting by default, fix "early spike" forecast behavior

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2245,7 +2245,7 @@ kubecostDeployment:
 ## Kubecost Forecasting forecasts future cost patterns based on historical
 ## patterns observed by Kubecost.
 forecasting:
-  enabled: false
+  enabled: true
 
   # fullImageName overrides the default image construction logic. The exact
   # image provided (registry, image, tag) will be used for the forecasting

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2251,7 +2251,7 @@ forecasting:
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
   # Example: fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.0.1
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:d80ab74
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:3c46972
 
   # Resource specification block for the forecasting container.
   resources:


### PR DESCRIPTION
## What does this PR change?
- Enabled forecasting by default
- Bumped image with fix to bug where the first couple of days of prediction would spike due to training on unreconciled data: https://github.com/kubecost/kubecost-modeling/pull/31

## Does this PR rely on any other PRs?
- https://github.com/kubecost/kubecost-modeling/pull/31

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A unreleased

## How was this PR tested?
An equivalent of this image was deployed to a live env and the fix was observed to work