### PR TITLE
Fix Aggregator STS delete/recreate guard for nightly

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -39,7 +39,7 @@ Kubecost 2.0 preconditions
             {{- $chartNameAndVersion := split "-" $chartLabel -}}     {{/* _0:cost _1:analyzer _2:1.108.1 */}}
             {{- if gt (len $chartNameAndVersion) 2 -}}
               {{- $chartVersion := $chartNameAndVersion._2 -}}        {{/* 1.108.1 */}}
-              {{- if semverCompare "<2.0.0-0" $chartVersion -}}
+              {{- if (and (semverCompare ">=1.107.0-0" $chartVersion) (semverCompare "<2.0.0-0" $chartVersion)) -}}  {{/* Nightly charts are 0.0.X. The only released versions that need this guard are 1.107.X and 1.108.X */}}
                 {{- fail "\n\nAn existing Aggregator StatefulSet was found in your namespace.\nBefore upgrading to Kubecost 2.x, please `kubectl delete` this Statefulset.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2" -}}
               {{- end -}}
             {{- end -}}


### PR DESCRIPTION
## What does this PR change?
Nightly deploys to the `aggregator` namespace (which uses the separate StatefulSet configuration) are broken because of the new guard https://github.com/kubecost/integration-ci-cd/actions/runs/7699897566/job/20983046416. This guard is safe for production users, but nightly charts are special because they use v0.0.X as the version:
```
→ k describe sts -n aggregator
Name:               aggregator-aggregator
Namespace:          aggregator
CreationTimestamp:  Mon, 29 Jan 2024 08:52:15 -0800
Selector:           app=aggregator,app.kubernetes.io/instance=aggregator,app.kubernetes.io/name=aggregator
Labels:             app=aggregator
                    app.kubernetes.io/managed-by=Helm
                    helm.sh/chart=cost-analyzer-v0.0.1706546015
```

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A

## What risks are associated with merging this PR? What is required to fully test this PR?
Must be carefully tested to ensure the guarding functionality we need (see https://github.com/kubecost/cost-analyzer-helm-chart/pull/2964 for that testing) is retained by this change. Then we can rely on nightly deploy to test the fix itself.

## How was this PR tested?


