### PR TITLE
Fix 2.0 precondition for nightly environment

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -39,7 +39,7 @@ Kubecost 2.0 preconditions
             {{- $chartNameAndVersion := split "-" $chartLabel -}}     {{/* _0:cost _1:analyzer _2:1.108.1 */}}
             {{- if gt (len $chartNameAndVersion) 2 -}}
               {{- $chartVersion := $chartNameAndVersion._2 -}}        {{/* 1.108.1 */}}
-              {{- if semverCompare "<2.0.0-0" $chartVersion -}}
+              {{- if semverCompare ">=1.0.0-0 <2.0.0-0" $chartVersion -}}
                 {{- fail "\n\nAn existing Aggregator StatefulSet was found in your namespace.\nBefore upgrading to Kubecost 2.x, please `kubectl delete` this Statefulset.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2" -}}
               {{- end -}}
             {{- end -}}


### PR DESCRIPTION
## What does this PR change?

- Fixes the 2.0 Helm precondition for those installing the nightly release.
- The nightly environment is consistently tagged with `helm.sh/chart=cost-analyzer-v0.0.1706547567`. Specifically, this is an epoch timestamp prefixed with `v0.0.`.
- Update the `if` statement to only apply to users who are on 1.x

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Fixes an error being thrown for users on the nightly release.

## Links to Issues or tickets this PR addresses or fixes

None

## What risks are associated with merging this PR? What is required to fully test this PR?

After my testing, no further risk comes to mind. Let me know if you think otherwise.

## How was this PR tested?

I performed all tests described in https://github.com/kubecost/cost-analyzer-helm-chart/pull/2964 and correctly saw the same errors thrown.

I also tested against a nightly release:

```yaml
# values-nightly.yaml
kubecostModel:
  federatedStorageConfigSecret: federated-store
kubecostAggregator:
  deployMethod: "statefulset"
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "thomasn-agg-upgrade-nightly"
```

```sh
# Initial install of a nightly environment
$ helm upgrade -i thomasn-nightly cost-analyzer --repo https://kubecost.github.io/nightly-helm-chart -f values-nightly.yaml

# Try upgrading with the same values, see a failure
$ helm upgrade -i thomasn-nightly cost-analyzer --repo https://kubecost.github.io/nightly-helm-chart -f values-nightly.yaml

Error: UPGRADE FAILED: execution error at (cost-analyzer/templates/NOTES.txt:4:4):

An existing Aggregator StatefulSet was found in your namespace.
Before upgrading to Kubecost 2.x, please `kubectl delete` this Statefulset.
Refer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2

# Try upgrading with my local chart, no longer see an error
$ helm upgrade -i thomasn-nightly ~/kubecost/cost-analyzer-helm-chart/cost-analyzer -f values-nightly.yaml
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

Not needed.