### PR TITLE
remove forecasting when agentOnly

### DIFF
--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.forecasting.enabled }}
+{{- if and .Values.forecasting.enabled (not .Values.federatedETL.agentOnly)  }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cost-analyzer/templates/forecasting-service.yaml
+++ b/cost-analyzer/templates/forecasting-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.forecasting.enabled }}
+{{- if and .Values.forecasting.enabled (not .Values.federatedETL.agentOnly)  }}
 kind: Service
 apiVersion: v1
 metadata:


### PR DESCRIPTION
## What does this PR change?
remove forecasting when agentOnly

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
remove forecasting pod when agentOnly is enabled


## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
helm upgrade of agent and "normal"

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
