### PR TITLE
Add emptydir to Aggregator CloudCost deployment

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -979,6 +979,8 @@ Begin Kubecost 2.0 templates
   resources:
     {{- toYaml .Values.kubecostAggregator.cloudCost.resources | nindent 4 }}
   volumeMounts:
+    - name: persistent-configs
+      mountPath: /var/configs
   {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
     - name: federated-storage-config
       mountPath: /var/configs/etl/federated
@@ -988,16 +990,6 @@ Begin Kubecost 2.0 templates
     - name: etl-bucket-config
       mountPath: /var/configs/etl
       readOnly: true
-  {{- end }}
-  {{- if (eq (include "aggregator.deployMethod" .) "singlepod") }}
-  {{/*
-    persistent-configs is used to access cloud keys when configured via UI and
-    for storing CC data. In an enterprise config (aggregator statefulset) a CC
-    config secret is required and all data is uploaded to S3 rather than stored
-    in this PV, so it does not need to be mounted.
-  */}}
-    - name: persistent-configs
-      mountPath: /var/configs
   {{- end }}
   {{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
     - name: {{ .Values.kubecostProductConfigs.cloudIntegrationSecret }}

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -57,9 +57,12 @@ spec:
             items:
               - key: cloud-integration.json
                 path: cloud-integration.json
+        {{/* Titled persistent-configs to be compatible with single-pod install.
+        All data stored here is ephemeral, and does not require a PV. */}}
+        - name: persistent-configs
+          emptyDir: {}
       containers:
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
-
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}


### PR DESCRIPTION
## What does this PR change?

Add emptydir to Aggregator CloudCost deployment

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Fixed the following Azure Cloud Integration error. Expects to be able to write to `/var/configs` directory to cache downloaded billing data.

```
ERR CloudCost[0bd50fdf-c923-4e1e-850c-196dd3dcc5d3/costexport/export]: ingestor: build failed for window [2023-12-19T00:00:00+0000, 2023-12-26T00:00:00+0000): CloudCost: Azure: DownloadBlobToFile: failed to create directory mkdir /var/configs/db: permission denied
```

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

Minimal risk adding this `emptyDir`. Ran tests described below.

## How was this PR tested?

Deployed both Enterprise and Free architectures. Saw the following successful CloudCost log:

```
INF CloudCost: Azure: DownloadBlobToFile: retrieved export/thomasnExport/20240101-20240131/thomasnExport_5a2a755d-3cf1-4b18-8cd9-7ef732df31a8.csv of size 13MB
```

```yaml
# values.yaml
kubecostModel:
  federatedStorageConfigSecret: federated-store
kubecostAggregator:
  deployMethod: "statefulset"
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "thomasn-ent-agg-tmp"
kubecostProductConfigs:
  cloudIntegrationSecret: cloud-integration
  clusterName: "thomasn-ent-agg-tmp"
```

```yaml
# values-free.yaml
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "thomasn-free-agg-tmp"
kubecostProductConfigs:
  cloudIntegrationSecret: cloud-integration
  clusterName: "thomasn-free-agg-tmp"
```

```sh
# Successful logs
helm upgrade -i thomasn-ent-agg-tmp ~/kubecost/cost-analyzer-helm-chart/cost-analyzer \
    -n thomasn-ent-agg-tmp \
    -f values.yaml

# Successful logs
helm upgrade -i thomasn-free-agg-tmp ~/kubecost/cost-analyzer-helm-chart/cost-analyzer \
    -n thomasn-free-agg-tmp \
    -f values-free.yaml
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A