### PR TITLE
Add sanity check for cloudIntegrationSecret

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,6 +1,7 @@
 --------------------------------------------------
 {{- include "kubecostV2-preconditions" . -}}
 {{- include "eksCheck" . -}}
+{{- include "cloudIntegrationSecretCheck" . -}}
 {{- $servicePort := .Values.service.port | default 9090 }}
 Kubecost {{ .Chart.Version }} has been successfully installed.
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -115,7 +115,7 @@ Verify the cloud integration secret exists with the expected key when cloud inte
 {{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
   {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.kubecostProductConfigs.cloudIntegrationSecret }}
   {{- if or (not $secret) (not (index $secret.data "cloud-integration.json")) }}
-    {{- fail "The cloud integration secret does not exist or does not contain the expected key 'cloud-integration.json'" }}
+    {{- fail (printf "The cloud integration secret '%s' does not exist or does not contain the expected key 'cloud-integration.json'" .Values.kubecostProductConfigs.cloudIntegrationSecret) }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1004,7 +1004,7 @@ Begin Kubecost 2.0 templates
       readOnly: true
   {{- end }}
   {{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
-    - name: {{ .Values.kubecostProductConfigs.cloudIntegrationSecret }}
+    - name: cloud-integration
       mountPath: /var/configs/cloud-integration
   {{- end }}
   env:

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -109,6 +109,18 @@ ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTE
 {{- end -}}
 
 {{/*
+Verify the cloud integration secret exists with the expected key when cloud integration is enabled.
+*/}}
+{{- define "cloudIntegrationSecretCheck" -}}
+{{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.kubecostProductConfigs.cloudIntegrationSecret }}
+  {{- if or (not $secret) (not (index $secret.data "cloud-integration.json")) }}
+    {{- fail "The cloud integration secret does not exist or does not contain the expected key 'cloud-integration.json'" }}
+  {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "cost-analyzer.name" -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -113,10 +113,12 @@ Verify the cloud integration secret exists with the expected key when cloud inte
 */}}
 {{- define "cloudIntegrationSecretCheck" -}}
 {{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
+{{-  if .Capabilities.APIVersions.Has "v1/Secret" }}
   {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.kubecostProductConfigs.cloudIntegrationSecret }}
   {{- if or (not $secret) (not (index $secret.data "cloud-integration.json")) }}
     {{- fail (printf "The cloud integration secret '%s' does not exist or does not contain the expected key 'cloud-integration.json'" .Values.kubecostProductConfigs.cloudIntegrationSecret) }}
   {{- end }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Adds a sanity check that the cloudIntegrationSecret, when defined, both exists and has a key with the name `cloud-integration.json` or else fails the chart installation. This is done to prevent users from naming Secrets which don't yet exist and ensure that those Secrets have a key the chart expects. Without both, Kubecost will not be able to come into a healthy, running state.

This also fixes a bug with the name of the volume holding said cloudIntegration secret enabling secrets with a custom name to be properly mounted.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Provides a better user experience in that the chart fails and provides feedback to users rather than succeeding in installation only to fail when running.

## Links to Issues or tickets this PR addresses or fixes

Fixes #3046



## What risks are associated with merging this PR? What is required to fully test this PR?

The check could be wrong or it could somehow impact installations where the cloudIntegrationSecret was not specified. It could potentially impact users who use tools or generate manifests from `helm template` although this behavior was tested locally and in CI.

## How was this PR tested?

Various Helm templating and installation scenarios. This check should only be invoked when a "real" connection to a K8s cluster exists and not when using `helm template` with or without `--dry-run=server`.

### Attempting to install when the Secret does not exist

```sh
$ yq e .kubecostProductConfigs.cloudIntegrationSecret cost-analyzer/values.yaml 
mycustomsecret
```

```sh
$ k -n default get secret
No resources found in default namespace.
```

```sh
$ helm install kubecost -n default cost-analyzer/
Error: execution error at (cost-analyzer/templates/NOTES.txt:4:4): The cloud integration secret 'mycustomsecret' does not exist or does not contain the expected key 'cloud-integration.json'
```

### Attempting to install when the Secret exists but the cloud-integration.json key does not

```sh
$ yq e .kubecostProductConfigs.cloudIntegrationSecret cost-analyzer/values.yaml 
mycustomsecret
```

```sh
$ k -n default get secret mycustomsecret -o yaml | yq .data
foo: YmFy
```

```sh
$ helm install kubecost -n default cost-analyzer/
Error: execution error at (cost-analyzer/templates/NOTES.txt:4:4): The cloud integration secret 'mycustomsecret' does not exist or does not contain the expected key 'cloud-integration.json'
```

### Attempting to install when the Secret exists and does contain the key cloud-integration.json

```sh
$ yq e .kubecostProductConfigs.cloudIntegrationSecret cost-analyzer/values.yaml 
mycustomsecret
```

```sh
$ k -n default get secret mycustomsecret -o yaml | yq .data
cloud-integration.json: YmFy
```

```sh
$ helm install kubecost -n default cost-analyzer/
NAME: kubecost
LAST DEPLOYED: Thu Feb  1 10:28:03 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
--------------------------------------------------
Kubecost 2.0.0 has been successfully installed.

Welcome to Kubecost 2.0!

Kubecost 2.0 is a major upgrade from previous versions and includes major new features including a brand new API Backend. Please review the following documentation to ensure a smooth transition: https://docs.kubecost.com/install-and-configure/install/kubecostv2

For the full list of enhancements, please see our release notes: https://github.com/kubecost/cost-analyzer-helm-chart/releases/tag/v2.0.0

When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace default deployment/kubecost-cost-analyzer 9090

Then, navigate to http://localhost:9090 in a web browser.

Please allow 25 minutes for Kubecost to gather metrics. A progress indicator will appear at the top of the UI.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A