### PR TITLE
Fix duplicate labels key in metadata in aggregator StatefulSet

### DIFF
--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -45,12 +45,11 @@ spec:
         app.kubernetes.io/name: aggregator
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: aggregator
+        {{- with .Values.global.additionalLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.global.podAnnotations}}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.global.additionalLabels }}
-      labels:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Fixes a duplicate `labels` key in the aggregator StatefulSet when a user configures global additionalLabels

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows additional labels set globally to correctly apply.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Fixes #3050

## What risks are associated with merging this PR? What is required to fully test this PR?

Templating could be incorrect

## How was this PR tested?

Before

```sh
$ helm template kubecost cost-analyzer/ -s templates/aggregator-statefulset.yaml | yq .spec.template.metadata
labels:
  app.kubernetes.io/name: aggregator
  app.kubernetes.io/instance: kubecost
  app: aggregator
labels:
  foo: bar
```

After

```sh
$ helm template kubecost cost-analyzer/ -s templates/aggregator-statefulset.yaml | yq .spec.template.metadata
labels:
  app.kubernetes.io/name: aggregator
  app.kubernetes.io/instance: kubecost
  app: aggregator
  foo: bar
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

