### PR TITLE
Cloud Integration Update

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,6 +1,6 @@
 --------------------------------------------------
 {{- include "kubecostV2-preconditions" . -}}
-{{- include "cloudIntegrationSecretMutualExclusivityCheck" . -}}
+{{- include "cloudIntegrationSourceCheck" . -}}
 {{- include "eksCheck" . -}}
 {{- include "cloudIntegrationSecretCheck" . -}}
 {{- $servicePort := .Values.service.port | default 9090 }}

--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,5 +1,6 @@
 --------------------------------------------------
 {{- include "kubecostV2-preconditions" . -}}
+{{- include "cloudIntegrationSecretMutualExclusivityCheck" . -}}
 {{- include "eksCheck" . -}}
 {{- $servicePort := .Values.service.port | default 9090 }}
 Kubecost {{ .Chart.Version }} has been successfully installed.

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -107,8 +107,6 @@ will result in failure. Users are asked to select one of the two presently-avail
   {{- end -}}
 {{- end -}}
 
-{{/*
-*/}}
 
 {{/*
 Print a warning if PV is enabled AND EKS is detected AND the EBS-CSI driver is not installed

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -94,6 +94,18 @@ Kubecost 2.0 preconditions
 {{- end -}}
 
 {{/*
+Cloud integration Secret mutual exclusivity check. Either the Secret must be specified or the JSON, not both.
+*/}}
+{{- define "cloudIntegrationSecretMutualExclusivityCheck" -}}
+  {{- if and .Values.kubecostProductConfigs.cloudIntegrationSecret .Values.kubecostProductConfigs.cloudIntegrationJSON -}}
+    {{- fail "cloudIntegrationSecret and cloudIntegrationJSON are mutually exclusive. Please specify only one." -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+*/}}
+
+{{/*
 Print a warning if PV is enabled AND EKS is detected AND the EBS-CSI driver is not installed
 */}}
 {{- define "eksCheck" }}
@@ -993,6 +1005,9 @@ Begin Kubecost 2.0 templates
   {{- end }}
   {{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
     - name: {{ .Values.kubecostProductConfigs.cloudIntegrationSecret }}
+      mountPath: /var/configs/cloud-integration
+  {{- else if (.Values.kubecostProductConfigs).cloudIntegrationJSON }}
+    - name: cloud-integration
       mountPath: /var/configs/cloud-integration
   {{- end }}
   env:

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1017,10 +1017,7 @@ Begin Kubecost 2.0 templates
       mountPath: /var/configs/etl
       readOnly: true
   {{- end }}
-  {{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
-    - name: cloud-integration
-      mountPath: /var/configs/cloud-integration
-  {{- else if (.Values.kubecostProductConfigs).cloudIntegrationJSON }}
+  {{- if or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON }}
     - name: cloud-integration
       mountPath: /var/configs/cloud-integration
   {{- end }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -94,11 +94,16 @@ Kubecost 2.0 preconditions
 {{- end -}}
 
 {{/*
-Cloud integration Secret mutual exclusivity check. Either the Secret must be specified or the JSON, not both.
+Cloud integration source contents check. Either the Secret must be specified or the JSON, not both.
+Additionally, for upgrade protection, certain individual values populated under the kubecostProductConfigs map, if found,
+will result in failure. Users are asked to select one of the two presently-available sources for cloud integration information.
 */}}
-{{- define "cloudIntegrationSecretMutualExclusivityCheck" -}}
+{{- define "cloudIntegrationSourceCheck" -}}
   {{- if and (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON -}}
     {{- fail "cloudIntegrationSecret and cloudIntegrationJSON are mutually exclusive. Please specify only one." -}}
+  {{- end -}}
+  {{- if or ((.Values.kubecostProductConfigs).athenaProjectID) ((.Values.kubecostProductConfigs).bigQueryBillingDataDataset) ((.Values.kubecostProductConfigs).azureSubscriptionID) }}
+    {{- fail "Specifying cloud integration details as individual keys has been removed. Please use either cloudIntegrationSecret or cloudIntegrationJSON depending on your requirements and unset individual cloud-specific fields." -}}
   {{- end -}}
 {{- end -}}
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -97,7 +97,7 @@ Kubecost 2.0 preconditions
 Cloud integration Secret mutual exclusivity check. Either the Secret must be specified or the JSON, not both.
 */}}
 {{- define "cloudIntegrationSecretMutualExclusivityCheck" -}}
-  {{- if and .Values.kubecostProductConfigs.cloudIntegrationSecret .Values.kubecostProductConfigs.cloudIntegrationJSON -}}
+  {{- if and (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON -}}
     {{- fail "cloudIntegrationSecret and cloudIntegrationJSON are mutually exclusive. Please specify only one." -}}
   {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -3,7 +3,7 @@
 {{/*
   A cloud integration secret is required for cloud cost to function as a dedicated pod.
 */}}
-{{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
+{{- if or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -3,7 +3,7 @@
 {{/*
   A cloud integration secret is required for cloud cost to function as a dedicated pod.
 */}}
-{{- if or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON }}
+{{- if or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaProjectID) }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -58,7 +58,7 @@ spec:
             items:
               - key: cloud-integration.json
                 path: cloud-integration.json
-        {{- else if .Values.kubecostProductConfigs.cloudIntegrationJSON }}
+        {{- else if or .Values.kubecostProductConfigs.cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaProjectID) }}
         - name: cloud-integration
           secret:
             secretName: cloud-integration

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             secretName: {{ .Values.kubecostProductConfigs.cloudIntegrationSecret }}
             items:
               - key: cloud-integration.json
-                path: cloud-integration.
+                path: cloud-integration.json
         {{- else if .Values.kubecostProductConfigs.cloudIntegrationJSON }}
         - name: cloud-integration
           secret:

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -51,12 +51,21 @@ spec:
             defaultMode: 420
             secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
         {{- end }}
+        {{- if .Values.kubecostProductConfigs.cloudIntegrationSecret }}
         - name: cloud-integration
           secret:
             secretName: {{ .Values.kubecostProductConfigs.cloudIntegrationSecret }}
             items:
               - key: cloud-integration.json
+                path: cloud-integration.
+        {{- else if .Values.kubecostProductConfigs.cloudIntegrationJSON }}
+        - name: cloud-integration
+          secret:
+            secretName: cloud-integration
+            items:
+              - key: cloud-integration.json
                 path: cloud-integration.json
+        {{- end }}
         {{/* Titled persistent-configs to be compatible with single-pod install.
         All data stored here is ephemeral, and does not require a PV. */}}
         - name: persistent-configs

--- a/cost-analyzer/templates/cloud-integration-secret.yaml
+++ b/cost-analyzer/templates/cloud-integration-secret.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.kubecostProductConfigs).cloudIntegrationJSON }}
+{{- if or ((.Values.kubecostProductConfigs).cloudIntegrationJSON) ((.Values.kubecostProductConfigs).athenaProjectID) }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -6,7 +6,11 @@ metadata:
   name: cloud-integration
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
+  {{- if (.Values.kubecostProductConfigs).cloudIntegrationJSON }}
   cloud-integration.json: {{ .Values.kubecostProductConfigs.cloudIntegrationJSON | replace "\n" "" | b64enc }}
+    {{- else }}
+  cloud-integration.json: {{ include "cloudIntegrationFromProductConfigs" . |nindent 4| replace "\n" "" | b64enc }}
+  {{- end }}
 {{- end -}}

--- a/cost-analyzer/templates/cloud-integration-secret.yaml
+++ b/cost-analyzer/templates/cloud-integration-secret.yaml
@@ -1,0 +1,12 @@
+{{- if (.Values.kubecostProductConfigs).cloudIntegrationJSON }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cloud-integration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  cloud-integration.json: {{ .Values.kubecostProductConfigs.cloudIntegrationJSON | replace "\n" "" | b64enc }}
+{{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -158,7 +158,7 @@ spec:
             items:
               - key: cloud-integration.json
                 path: cloud-integration.json
-        {{- else if .Values.kubecostProductConfigs.cloudIntegrationJSON }}
+        {{- else if or .Values.kubecostProductConfigs.cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaProjectID) }}
         - name: cloud-integration
           secret:
             secretName: cloud-integration

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -158,6 +158,13 @@ spec:
             items:
               - key: cloud-integration.json
                 path: cloud-integration.json
+        {{- else if .Values.kubecostProductConfigs.cloudIntegrationJSON }}
+        - name: cloud-integration
+          secret:
+            secretName: cloud-integration
+            items:
+              - key: cloud-integration.json
+                path: cloud-integration.json
         {{- end }}
         {{- if .Values.kubecostProductConfigs.clusters }}
         - name: kubecost-clusters
@@ -553,7 +560,7 @@ spec:
             - name: azure-storage-config
               mountPath: /var/azure-storage-config
             {{- end }}
-            {{- if .Values.kubecostProductConfigs.cloudIntegrationSecret }}
+            {{- if or (.Values.kubecostProductConfigs.cloudIntegrationSecret) (.Values.kubecostProductConfigs.cloudIntegrationJSON) }}
             - name: cloud-integration
               mountPath: /var/configs/cloud-integration
             {{- end }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -106,6 +106,13 @@ spec:
             items:
               - key: cloud-integration.json
                 path: cloud-integration.json
+        {{- else if .Values.kubecostProductConfigs.cloudIntegrationJSON }}
+        - name: cloud-integration
+          secret:
+            secretName: cloud-integration
+            items:
+              - key: cloud-integration.json
+                path: cloud-integration.json
         {{- end }}
         {{- end }}
         - name: persistent-configs
@@ -190,7 +197,7 @@ spec:
             - name: azure-storage-config
               mountPath: /var/azure-storage-config
             {{- end }}
-            {{- if .Values.kubecostProductConfigs.cloudIntegrationSecret }}
+            {{- if or (.Values.kubecostProductConfigs.cloudIntegrationSecret) (.Values.kubecostProductConfigs.cloudIntegrationJSON) }}
             - name: cloud-integration
               mountPath: /var/configs/cloud-integration
             {{- end }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -106,7 +106,7 @@ spec:
             items:
               - key: cloud-integration.json
                 path: cloud-integration.json
-        {{- else if .Values.kubecostProductConfigs.cloudIntegrationJSON }}
+        {{- else if or .Values.kubecostProductConfigs.cloudIntegrationJSON  ((.Values.kubecostProductConfigs).athenaProjectID) }}
         - name: cloud-integration
           secret:
             secretName: cloud-integration
@@ -197,7 +197,7 @@ spec:
             - name: azure-storage-config
               mountPath: /var/azure-storage-config
             {{- end }}
-            {{- if or (.Values.kubecostProductConfigs.cloudIntegrationSecret) (.Values.kubecostProductConfigs.cloudIntegrationJSON) }}
+            {{- if or (.Values.kubecostProductConfigs.cloudIntegrationSecret) (.Values.kubecostProductConfigs.cloudIntegrationJSON) ((.Values.kubecostProductConfigs).athenaProjectID) }}
             - name: cloud-integration
               mountPath: /var/configs/cloud-integration
             {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2892,109 +2892,131 @@ costEventsAudit:
 # An optional list of cluster definitions that can be added for frontend access. The local
 # cluster is *always* included by default, so this list is for non-local clusters.
 # Ref: https://github.com/kubecost/docs/blob/main/multi-cluster.md
-#  clusters:
-#   - name: "Cluster A"
-#     address: http://cluster-a.kubecost.com:9090
-#     # Optional authentication credentials - only basic auth is currently supported.
-#     auth:
-#       type: basic
-#       # Secret name should be a secret formatted based on: https://github.com/kubecost/docs/blob/main/ingress-examples.md
-#       secretName: cluster-a-auth
-#       # Or pass auth directly as base64 encoded user:pass
-#       data: YWRtaW46YWRtaW4=
-#       # Or user and pass directly
-#       user: admin
-#       pass: admin
-#   - name: "Cluster B"
-#     address: http://cluster-b.kubecost.com:9090
-#  defaultModelPricing: # default monthly resource prices, used predominately for on-prem clusters. Use quotes if setting "0.00" for any item.
-#    CPU: 28.0
-#    spotCPU: 4.86
-#    RAM: 3.09
-#    spotRAM: 0.65
-#    GPU: 693.50
-#    spotGPU: 225.0
-#    storage: 0.04
-#    zoneNetworkEgress: 0.01
-#    regionNetworkEgress: 0.01
-#    internetNetworkEgress: 0.12
-#    enabled: true
-#  # The cluster profile represents a predefined set of parameters to use when calculating savings.
-#  # Possible values are: [ development, production, high-availability ]
-#  clusterProfile: production
-#  customPricesEnabled: false # This makes the default view custom prices-- generally used for on-premises clusters
-#  spotLabel: lifecycle
-#  spotLabelValue: Ec2Spot
-#  gpuLabel: gpu
-#  gpuLabelValue: true
-#  awsServiceKeyName: ACCESSKEYID
-#  awsServiceKeyPassword:  fakepassword # Only use if your values.yaml are stored encrypted. Otherwise provide an existing secret via serviceKeySecretName
-#  awsSpotDataRegion: us-east-1
-#  awsSpotDataBucket: spot-data-feed-s3-bucket
-#  awsSpotDataPrefix: dev
-#  athenaProjectID: "530337586277" # The AWS AccountID where the Athena CUR is. Generally your masterpayer account
-#  athenaBucketName: "s3://aws-athena-query-results-530337586277-us-east-1"
-#  athenaRegion: us-east-1
-#  athenaDatabase: athenacurcfn_athena_test1
-#  athenaTable: "athena_test1"
-#  athenaWorkgroup: "primary" # The default workgroup in AWS is 'primary'
-#  masterPayerARN: ""
-#  projectID: "123456789"  # Also known as AccountID on AWS -- the current account/project that this instance of Kubecost is deployed on.
-#  gcpSecretName: gcp-secret # Name of a secret representing the gcp service key
-#  gcpSecretKeyName: compute-viewer-kubecost-key.json # Name of the secret's key containing the gcp service key
-#  bigQueryBillingDataDataset: billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2
-#  labelMappingConfigs:  # names of k8s labels or annotations used to designate different allocation concepts
-#    enabled: true
-#    owner_label: "owner"
-#    team_label: "team"
-#    department_label: "dept"
-#    product_label: "product"
-#    environment_label: "env"
-#    namespace_external_label: "kubernetes_namespace" # external labels/tags are used to map external cloud costs to kubernetes concepts
-#    cluster_external_label: "kubernetes_cluster"
-#    controller_external_label: "kubernetes_controller"
-#    product_external_label: "kubernetes_label_app"
-#    service_external_label: "kubernetes_service"
-#    deployment_external_label: "kubernetes_deployment"
-#    owner_external_label: "kubernetes_label_owner"
-#    team_external_label: "kubernetes_label_team"
-#    environment_external_label: "kubernetes_label_env"
-#    department_external_label: "kubernetes_label_department"
-#    statefulset_external_label: "kubernetes_statefulset"
-#    daemonset_external_label: "kubernetes_daemonset"
-#    pod_external_label: "kubernetes_pod"
-#  grafanaURL: ""
-#  # Provide a mapping from Account ID to a readable Account Name in a key/value object. Provide Account IDs as they are displayed in CloudCost
-#  # as the 'key' and the Account Name associated with it as the 'value'
-#  cloudAccountMapping:
-#    EXAMPLE_ACCOUNT_ID: EXAMPLE_ACCOUNT_NAME
-#  clusterName: "" # clusterName is the default context name in settings.
-#  clusterAccountID: "" # Manually set Account property for assets
-#  currencyCode: "USD" # official support for USD, AUD, BRL, CAD, CHF, CNY, DKK, EUR, GBP, IDR, INR, JPY, NOK, PLN, SEK
-#  azureBillingRegion: US # Represents 2-letter region code, e.g. West Europe = NL, Canada = CA. ref: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-#  azureSubscriptionID: 0bd50fdf-c923-4e1e-850c-196dd3dcc5d3
-#  azureClientID: f2ef6f7d-71fb-47c8-b766-8d63a19db017
-#  azureTenantID: 72faf3ff-7a3f-4597-b0d9-7b0b201bb23a
-#  azureClientPassword: fake key # Only use if your values.yaml are stored encrypted. Otherwise provide an existing secret via serviceKeySecretName
-#  azureOfferDurableID: "MS-AZR-0003p"
-#  discount: "" # percentage discount applied to compute
-#  negotiatedDiscount: "" # custom negotiated cloud provider discount
-#  defaultIdle: false
-#  serviceKeySecretName: "" # Use an existing AWS or Azure secret with format as in aws-service-key-secret.yaml or azure-service-key-secret.yaml. Leave blank if using createServiceKeySecret
-#  createServiceKeySecret: true # Creates a secret representing your cloud service key based on data in values.yaml. If you are storing unencrypted values, add a secret manually
-#  sharedNamespaces: "" # namespaces with shared workloads, example value: "kube-system\,ingress-nginx\,kubecost\,monitoring"
-#  sharedOverhead: "" # value representing a fixed external cost per month to be distributed among aggregations.
-#  shareTenancyCosts: true # enable or disable sharing costs such as cluster management fees (defaults to "true" on Settings page)
-#  metricsConfigs: # configuration for metrics emitted by Kubecost
-#    disabledMetrics: [] # list of metrics that Kubecost will not emit. Note that disabling metrics can lead to unexpected behavior in the cost-model.
-#  productKey: # apply business or enterprise product license
-#    key: ""
-#    enabled: false
-#    secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }. If the secretname is specified, a configmap with the key will not be created
-#    mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
-#  cloudIntegrationSecret: "cloud-integration"
-#  ingestPodUID: false # Enables using UIDs to uniquely ID pods. This requires either Kubecost's replicated KSM metrics, or KSM v2.1.0+. This may impact performance, and changes the default cost-model allocation behavior.
-#  regionOverrides: "region1,region2,region3" # list of regions which will override default costmodel provider regions
+  # clusters:
+  #   - name: "Cluster A"
+  #     address: http://cluster-a.kubecost.com:9090
+  #     # Optional authentication credentials - only basic auth is currently supported.
+  #     auth:
+  #       type: basic
+  #       # Secret name should be a secret formatted based on: https://github.com/kubecost/docs/blob/main/ingress-examples.md
+  #       secretName: cluster-a-auth
+  #       # Or pass auth directly as base64 encoded user:pass
+  #       data: YWRtaW46YWRtaW4=
+  #       # Or user and pass directly
+  #       user: admin
+  #       pass: admin
+  #   - name: "Cluster B"
+  #     address: http://cluster-b.kubecost.com:9090
+  # defaultModelPricing: # default monthly resource prices, used predominately for on-prem clusters. Use quotes if setting "0.00" for any item.
+  #   CPU: 28.0
+  #   spotCPU: 4.86
+  #   RAM: 3.09
+  #   spotRAM: 0.65
+  #   GPU: 693.50
+  #   spotGPU: 225.0
+  #   storage: 0.04
+  #   zoneNetworkEgress: 0.01
+  #   regionNetworkEgress: 0.01
+  #   internetNetworkEgress: 0.12
+  #   enabled: true
+  # # The cluster profile represents a predefined set of parameters to use when calculating savings.
+  # # Possible values are: [ development, production, high-availability ]
+  # clusterProfile: production
+  # customPricesEnabled: false # This makes the default view custom prices-- generally used for on-premises clusters
+  # spotLabel: lifecycle
+  # spotLabelValue: Ec2Spot
+  # gpuLabel: gpu
+  # gpuLabelValue: true
+  # awsServiceKeyName: ACCESSKEYID
+  # awsServiceKeyPassword:  fakepassword # Only use if your values.yaml are stored encrypted. Otherwise provide an existing secret via serviceKeySecretName
+  # awsSpotDataRegion: us-east-1
+  # awsSpotDataBucket: spot-data-feed-s3-bucket
+  # awsSpotDataPrefix: dev
+  # athenaProjectID: "530337586277" # The AWS AccountID where the Athena CUR is. Generally your masterpayer account
+  # athenaBucketName: "s3://aws-athena-query-results-530337586277-us-east-1"
+  # athenaRegion: us-east-1
+  # athenaDatabase: athenacurcfn_athena_test1
+  # athenaTable: "athena_test1"
+  # athenaWorkgroup: "primary" # The default workgroup in AWS is 'primary'
+  # masterPayerARN: ""
+  # projectID: "123456789"  # Also known as AccountID on AWS -- the current account/project that this instance of Kubecost is deployed on.
+  # gcpSecretName: gcp-secret # Name of a secret representing the gcp service key
+  # gcpSecretKeyName: compute-viewer-kubecost-key.json # Name of the secret's key containing the gcp service key
+  # bigQueryBillingDataDataset: billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2
+  # labelMappingConfigs:  # names of k8s labels or annotations used to designate different allocation concepts
+  #   enabled: true
+  #   owner_label: "owner"
+  #   team_label: "team"
+  #   department_label: "dept"
+  #   product_label: "product"
+  #   environment_label: "env"
+  #   namespace_external_label: "kubernetes_namespace" # external labels/tags are used to map external cloud costs to kubernetes concepts
+  #   cluster_external_label: "kubernetes_cluster"
+  #   controller_external_label: "kubernetes_controller"
+  #   product_external_label: "kubernetes_label_app"
+  #   service_external_label: "kubernetes_service"
+  #   deployment_external_label: "kubernetes_deployment"
+  #   owner_external_label: "kubernetes_label_owner"
+  #   team_external_label: "kubernetes_label_team"
+  #   environment_external_label: "kubernetes_label_env"
+  #   department_external_label: "kubernetes_label_department"
+  #   statefulset_external_label: "kubernetes_statefulset"
+  #   daemonset_external_label: "kubernetes_daemonset"
+  #   pod_external_label: "kubernetes_pod"
+  # grafanaURL: ""
+  # # Provide a mapping from Account ID to a readable Account Name in a key/value object. Provide Account IDs as they are displayed in CloudCost
+  # # as the 'key' and the Account Name associated with it as the 'value'
+  # cloudAccountMapping:
+  #   EXAMPLE_ACCOUNT_ID: EXAMPLE_ACCOUNT_NAME
+  # clusterName: "" # clusterName is the default context name in settings.
+  # clusterAccountID: "" # Manually set Account property for assets
+  # currencyCode: "USD" # official support for USD, AUD, BRL, CAD, CHF, CNY, DKK, EUR, GBP, IDR, INR, JPY, NOK, PLN, SEK
+  # azureBillingRegion: US # Represents 2-letter region code, e.g. West Europe = NL, Canada = CA. ref: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+  # azureSubscriptionID: 0bd50fdf-c923-4e1e-850c-196dd3dcc5d3
+  # azureClientID: f2ef6f7d-71fb-47c8-b766-8d63a19db017
+  # azureTenantID: 72faf3ff-7a3f-4597-b0d9-7b0b201bb23a
+  # azureClientPassword: fake key # Only use if your values.yaml are stored encrypted. Otherwise provide an existing secret via serviceKeySecretName
+  # azureOfferDurableID: "MS-AZR-0003p"
+  # discount: "" # percentage discount applied to compute
+  # negotiatedDiscount: "" # custom negotiated cloud provider discount
+  # defaultIdle: false
+  # serviceKeySecretName: "" # Use an existing AWS or Azure secret with format as in aws-service-key-secret.yaml or azure-service-key-secret.yaml. Leave blank if using createServiceKeySecret
+  # createServiceKeySecret: true # Creates a secret representing your cloud service key based on data in values.yaml. If you are storing unencrypted values, add a secret manually
+  # sharedNamespaces: "" # namespaces with shared workloads, example value: "kube-system\,ingress-nginx\,kubecost\,monitoring"
+  # sharedOverhead: "" # value representing a fixed external cost per month to be distributed among aggregations.
+  # shareTenancyCosts: true # enable or disable sharing costs such as cluster management fees (defaults to "true" on Settings page)
+  # metricsConfigs: # configuration for metrics emitted by Kubecost
+  #   disabledMetrics: [] # list of metrics that Kubecost will not emit. Note that disabling metrics can lead to unexpected behavior in the cost-model.
+  # productKey: # apply business or enterprise product license
+  #   key: ""
+  #   enabled: false
+  #   secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }. If the secretname is specified, a configmap with the key will not be created
+  #   mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
+
+  ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain
+  ## a key with name `cloud-integration.json` and the contents must be in a specific format. It is expected
+  ## to exist in the release Namespace. This is mutually exclusive with cloudIntegrationJSON where only one must be defined.
+  # cloudIntegrationSecret: "cloud-integration"
+
+  ## Specify the cloud integration information in JSON form if pointing to an existing Secret is not desired or you'd rather
+  ## define the cloud integration information directly in the values file. This will result in a new Secret being created
+  ## named `cloud-integration` in the release Namespace. It is mutually exclusive with the cloudIntegrationSecret where only one must be defined.
+  # cloudIntegrationJSON: |-
+  #   {
+  #     "aws": [
+  #       {
+  #         "athenaBucketName": "s3://AWS_cloud_integration_athenaBucketName",
+  #         "athenaRegion": "AWS_cloud_integration_athenaRegion",
+  #         "athenaDatabase": "AWS_cloud_integration_athenaDatabase",
+  #         "athenaTable": "AWS_cloud_integration_athenaBucketName",
+  #         "projectID": "AWS_cloud_integration_athena_projectID",
+  #         "serviceKeyName": "AWS_cloud_integration_athena_serviceKeyName",
+  #         "serviceKeySecret": "AWS_cloud_integration_athena_serviceKeySecret"
+  #       }
+  #     ]
+  #   }
+  # ingestPodUID: false # Enables using UIDs to uniquely ID pods. This requires either Kubecost's replicated KSM metrics, or KSM v2.1.0+. This may impact performance, and changes the default cost-model allocation behavior.
+  # regionOverrides: "region1,region2,region3" # list of regions which will override default costmodel provider regions
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3013,8 +3013,35 @@ costEventsAudit:
   #         "serviceKeyName": "AWS_cloud_integration_athena_serviceKeyName",
   #         "serviceKeySecret": "AWS_cloud_integration_athena_serviceKeySecret"
   #       }
+  #     ],
+  #     "azure": [
+  #       {
+  #         "azureSubscriptionID": "my-subscription-id",
+  #         "azureStorageAccount": "my-storage-account",
+  #         "azureStorageAccessKey": "my-storage-access-key",
+  #         "azureStorageContainer": "my-storage-container"
+  #       }
+  #     ],
+  #     "gcp": [
+  #       {
+  #         "projectID": "my-project-id",
+  #         "billingDataDataset": "detailedbilling.my-billing-dataset",
+  #         "key": {
+  #           "type": "service_account",
+  #           "project_id": "my-project-id",
+  #           "private_key_id": "my-private-key-id",
+  #           "private_key": "my-pem-encoded-private-key",
+  #           "client_email": "my-service-account-name@my-project-id.iam.gserviceaccount.com",
+  #           "client_id": "my-client-id",
+  #           "auth_uri": "auth-uri",
+  #           "token_uri": "token-uri",
+  #           "auth_provider_x509_cert_url": "my-x509-provider-cert",
+  #           "client_x509_cert_url": "my-x509-cert-url"
+  #         }
+  #       }
   #     ]
   #   }
+
   # ingestPodUID: false # Enables using UIDs to uniquely ID pods. This requires either Kubecost's replicated KSM metrics, or KSM v2.1.0+. This may impact performance, and changes the default cost-model allocation behavior.
   # regionOverrides: "region1,region2,region3" # list of regions which will override default costmodel provider regions
 


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?
Two fixes here:
1. Fixes a bug where cloud billing via KubecostProductConfigs was not honored.
2. 
Adds a new key under `kubecostProductConfigs` called `cloudIntegrationJSON`, the value of which is a block scalar in JSON form with the cloud integration contents. This is provided as an alternative for users who would rather define the cloud integration contents in-line to the values file rather than precreating a Secret with similar contents. This new value is mutually exclusive with the existing `cloudIntegrationSecret` and only one may be specified. If both are specified, installation will fail.

This PR also adds a second check for upgrade protection which will also produce a failure if users have set individual fields under kubecostProductConfigs with cloud-specific information previously used to create cloud integration info.

## Does this PR rely on any other PRs?

No but is related to #3048

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows users to define the cloud integration contents in their values file rather than being forced to precreate a Secret and provide that value to this chart's installation process.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Closes #3047

## What risks are associated with merging this PR? What is required to fully test this PR?

There could be issues when using either when templating, or the encoded value could trip up Kubecost.

## How was this PR tested?

Helm templating in both combinations and comparing results.

### Specifying both cloudIntegrationSecret and cloudIntegrationJSON

```sh
$ helm template kubecost cost-analyzer/
Error: execution error at (cost-analyzer/templates/NOTES.txt:3:4): cloudIntegrationSecret and cloudIntegrationJSON are mutually exclusive. Please specify only one.
```

### Rendered Secret named cloud-integration

```yaml
apiVersion: v1
kind: Secret
type: Opaque
metadata:
  name: cloud-integration
  namespace: default
  labels:
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-2.0.0
    app.kubernetes.io/instance: kubecost
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
data:
  cloud-integration.json: eyAgImF3cyI6IFsgICAgeyAgICAgICJhdGhlbmFCdWNrZXROYW1lIjogInMzOi8vQVdTX2Nsb3VkX2ludGVncmF0aW9uX2F0aGVuYUJ1Y2tldE5hbWUiLCAgICAgICJhdGhlbmFSZWdpb24iOiAiQVdTX2Nsb3VkX2ludGVncmF0aW9uX2F0aGVuYVJlZ2lvbiIsICAgICAgImF0aGVuYURhdGFiYXNlIjogIkFXU19jbG91ZF9pbnRlZ3JhdGlvbl9hdGhlbmFEYXRhYmFzZSIsICAgICAgImF0aGVuYVRhYmxlIjogIkFXU19jbG91ZF9pbnRlZ3JhdGlvbl9hdGhlbmFCdWNrZXROYW1lIiwgICAgICAicHJvamVjdElEIjogIkFXU19jbG91ZF9pbnRlZ3JhdGlvbl9hdGhlbmFfcHJvamVjdElEIiwgICAgICAic2VydmljZUtleU5hbWUiOiAiQVdTX2Nsb3VkX2ludGVncmF0aW9uX2F0aGVuYV9zZXJ2aWNlS2V5TmFtZSIsICAgICAgInNlcnZpY2VLZXlTZWNyZXQiOiAiQVdTX2Nsb3VkX2ludGVncmF0aW9uX2F0aGVuYV9zZXJ2aWNlS2V5U2VjcmV0IiAgICB9ICBdfQ==
```

### Contents of Secret

Input values file

```sh
$ yq e .kubecostProductConfigs.cloudIntegrationJSON cost-analyzer/values.yaml | jq
{
  "aws": [
    {
      "athenaBucketName": "s3://AWS_cloud_integration_athenaBucketName",
      "athenaRegion": "AWS_cloud_integration_athenaRegion",
      "athenaDatabase": "AWS_cloud_integration_athenaDatabase",
      "athenaTable": "AWS_cloud_integration_athenaBucketName",
      "projectID": "AWS_cloud_integration_athena_projectID",
      "serviceKeyName": "AWS_cloud_integration_athena_serviceKeyName",
      "serviceKeySecret": "AWS_cloud_integration_athena_serviceKeySecret"
    }
  ]
}
```

Decoded contents of the templatized Secret

```sh
$ helm template kubecost cost-analyzer/ -s templates/cloud-integration-secret.yaml | yq .data.\"cloud-integration.json\" | base64 -d | jq
{
  "aws": [
    {
      "athenaBucketName": "s3://AWS_cloud_integration_athenaBucketName",
      "athenaRegion": "AWS_cloud_integration_athenaRegion",
      "athenaDatabase": "AWS_cloud_integration_athenaDatabase",
      "athenaTable": "AWS_cloud_integration_athenaBucketName",
      "projectID": "AWS_cloud_integration_athena_projectID",
      "serviceKeyName": "AWS_cloud_integration_athena_serviceKeyName",
      "serviceKeySecret": "AWS_cloud_integration_athena_serviceKeySecret"
    }
  ]
}
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

No