### PR TITLE
[CI] Add StatefulSet tests

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: docker://ghcr.io/yannh/kubeconform:latest
         with:
           entrypoint: /kubeconform
-          args: "-summary -output text full.yaml"
+          args: "-summary -ignore-missing-schemas -output text full.yaml"
 
 
   # Test cluster versions.

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: docker://ghcr.io/yannh/kubeconform:latest
         with:
           entrypoint: /kubeconform
-          args: "-summary -ignore-missing-schemas -output text full.yaml"
+          args: "-summary -output text full.yaml"
 
 
   # Test cluster versions.

--- a/cost-analyzer/ci/federatedetl-primary-netcosts-values.yaml
+++ b/cost-analyzer/ci/federatedetl-primary-netcosts-values.yaml
@@ -12,7 +12,6 @@ kubecostModel:
   federatedStorageConfigSecret: federated-store
 serviceAccount:  # this example uses AWS IRSA, which creates a service account with rights to the s3 bucket. If using keys+secrets in the federated-store, set create: true
   create: true
-kubecostDeployment:
 global:
   prometheus:
     enabled: true

--- a/cost-analyzer/ci/statefulsets-cc.yaml
+++ b/cost-analyzer/ci/statefulsets-cc.yaml
@@ -1,0 +1,40 @@
+### This test is to verify that Kubecost aggregator is deployed as a StatefulSet,
+### cluster controller is installed, and the various Prometheus components are installed.
+global:
+  podAnnotations:
+    kubecost.io/test1: value1
+    kubecost.io/test2: value2
+  additionalLabels:
+    kubecosttest1: value1
+    kubecosttest2: value2
+  prometheus:
+    enabled: true
+    # fqdn: http://prometheus-operated.monitoring:9090
+  grafana:  # prometheus metrics will be local cluster only, disable grafana to save resources
+    enabled: false
+    proxy: false
+kubecostProductConfigs:
+  clusterName: CLUSTER_NAME
+kubecostAggregator:
+  deployMethod: statefulset
+kubecostModel:
+  federatedStorageConfigSecret: federated-store
+clusterController:
+  enabled: true
+prometheus:
+  nodeExporter:
+    enabled: true
+  alertmanager:
+    enabled: true
+  configmapReload:
+    prometheus:
+      enabled: true
+  pushgateway:
+    enabled: true
+  server:
+    statefulSet:
+      enabled: true
+    global:
+      external_labels:
+        # cluster_id should be unique for all clusters and the same value as .kubecostProductConfigs.clusterName
+        cluster_id: CLUSTER_NAME


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Adds a new values file for CI testing only which installs Kubecost using the optional StatefulSet components (aggregator and Prometheus server) in addition to enabling some other disabled components (cluster controller, all other Prometheus components).

## Does this PR rely on any other PRs?

Depends on #3076 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

No user impact, CI only.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

CI may fail

## How was this PR tested?

Tested by installing locally and will be tested automatically as part of this PR.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A