### PR TITLE
[CI] ignore missing schemas with kubeconform

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: docker://ghcr.io/yannh/kubeconform:latest
         with:
           entrypoint: /kubeconform
-          args: "-summary -output text full.yaml"
+          args: "-summary -ignore-missing-schemas -output text full.yaml"
 
 
   # Test cluster versions.


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Sets the `-ignore-missing-schemas` flag to Kubeconform to allow not checking of CRDs.

## Does this PR rely on any other PRs?

Outgoing dependency to #3075 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

CI only.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

We may actually need CRD schema checking at some point which won't happen by this change.

## How was this PR tested?

Tested in CI.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A