### PR TITLE
Update cluster controller image

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2447,7 +2447,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.15.0
+    tag: v0.15.1
   imagePullPolicy: Always
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2447,7 +2447,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.14.0
+    tag: v0.15.0
   imagePullPolicy: Always
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
## What does this PR change?
* Updates cluster controller image to v0.15.0
  * Requested as part of v2.0.3

## Does this PR rely on any other PRs?
Contains changes from https://github.com/kubecost/cluster-controller/pull/63

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Enables configuring of kc actions via yaml

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
part of https://kubecost.atlassian.net/browse/SELFHOST-1135


## What risks are associated with merging this PR? What is required to fully test this PR?
Should be low risk but this could impact continuous container right sizing. To test we should verify that passing in the kc actions via helm cause namespace turndown, continuous cluster right sizing, and continuous container right sizing to behave as expected.

## How was this PR tested?
Tested locally and on a kc actions test cluster, verified yaml configurations caused resizing

## Have you made an update to documentation? If so, please provide the corresponding PR.
No
