### PR TITLE
Add CICD option to platforms with skipSanityChecks

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -143,12 +143,12 @@ ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTE
 
 {{/*
 Verify the cloud integration secret exists with the expected key when cloud integration is enabled.
-Skip the check if Argo CD is enabled and skipSanityChecks is set since Argo CD presently does not
+Skip the check if CI/CD is enabled and skipSanityChecks is set. Argo CD, for example, does not
 support templating a chart which uses the lookup function.
 */}}
 {{- define "cloudIntegrationSecretCheck" -}}
 {{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
-{{- if not (and .Values.global.platforms.argocd.enabled .Values.global.platforms.argocd.skipSanityChecks) }}
+{{- if not (and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks) }}
 {{-  if .Capabilities.APIVersions.Has "v1/Secret" }}
   {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.kubecostProductConfigs.cloudIntegrationSecret }}
   {{- if or (not $secret) (not (index $secret.data "cloud-integration.json")) }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -143,14 +143,18 @@ ERROR: MISSING EBS-CSI DRIVER WHICH IS REQUIRED ON EKS v1.23+ TO MANAGE PERSISTE
 
 {{/*
 Verify the cloud integration secret exists with the expected key when cloud integration is enabled.
+Skip the check if Argo CD is enabled and skipSanityChecks is set since Argo CD presently does not
+support templating a chart which uses the lookup function.
 */}}
 {{- define "cloudIntegrationSecretCheck" -}}
 {{- if (.Values.kubecostProductConfigs).cloudIntegrationSecret }}
+{{- if not (and .Values.global.platforms.argocd.enabled .Values.global.platforms.argocd.skipSanityChecks) }}
 {{-  if .Capabilities.APIVersions.Has "v1/Secret" }}
   {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.kubecostProductConfigs.cloudIntegrationSecret }}
   {{- if or (not $secret) (not (index $secret.data "cloud-integration.json")) }}
     {{- fail (printf "The cloud integration secret '%s' does not exist or does not contain the expected key 'cloud-integration.json'" .Values.kubecostProductConfigs.cloudIntegrationSecret) }}
   {{- end }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -244,9 +244,9 @@ global:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-    # When deploying the chart with Argo CD, enable for access to the below configuration options.
-    argocd:
-      enabled: false  # Set to true when using Argo CD for access to the below configuration options.
+    # Set options for deploying with CI/CD tools like Argo CD.
+    cicd:
+      enabled: false  # Set to true when using affected CI/CD tools for access to the below configuration options.
       skipSanityChecks: false  # If true, skip all sanity/existence checks for resources like Secrets.
 
 ## This flag is only required for users upgrading to a new version of Kubecost.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -244,6 +244,10 @@ global:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+    # When deploying the chart with Argo CD, enable for access to the below configuration options.
+    argocd:
+      enabled: false  # Set to true when using Argo CD for access to the below configuration options.
+      skipSanityChecks: false  # If true, skip all sanity/existence checks for resources like Secrets.
 
 ## This flag is only required for users upgrading to a new version of Kubecost.
 ## The flag is used to ensure users are aware of important


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Adds a new map under `global.platforms` called `cicd{}` which is largely a placeholder for future settings but presently contains a single option called `skipSanityChecks`. Enabling this option (along with `enabled: true`) will result in Helm (or a CD tool, mainly Argo CD) _not_ attempting to perform the sanity/existence check when a cloud integration Secret is used. This is needed because Argo CD does not presently support the Helm `lookup()` function and has been a well-known issue documented [here](https://github.com/argoproj/argo-cd/issues/5202).

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows users who are deploying the chart via Argo CD or some other affected CD tool to continue deploying by setting these new options with the understanding that no sanity/existence check will be performed.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Closes #3078

## What risks are associated with merging this PR? What is required to fully test this PR?

The sanity check could still be broken for Argo CD users although this was tested locally.

## How was this PR tested?

`helm install` using the necessary switches to disable sanity checks.

## Have you made an update to documentation? If so, please provide the corresponding PR.

No