### PR TITLE
add athenaWorkgroup and masterPayerARN

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -102,6 +102,14 @@ Kubecost 2.0 preconditions
           "athenaDatabase": "{{ .Values.kubecostProductConfigs.athenaDatabase }}",
           "athenaTable": "{{ .Values.kubecostProductConfigs.athenaTable }}",
           "projectID": "{{ .Values.kubecostProductConfigs.athenaProjectID }}"
+          {{ if (.Values.kubecostProductConfigs).athenaWorkgroup }}
+          , "athenaWorkgroup": "{{ .Values.kubecostProductConfigs.athenaWorkgroup }}"
+          {{ else }}
+          , "athenaWorkgroup": "primary"
+          {{ end }}
+          {{ if (.Values.kubecostProductConfigs).masterPayerARN }}
+          , "masterPayerARN": "{{ .Values.kubecostProductConfigs.masterPayerARN }}"
+          {{ end }}
           {{- if and ((.Values.kubecostProductConfigs).awsServiceKeyName) ((.Values.kubecostProductConfigs).awsServiceKeyPassword) }},
           "serviceKeyName": "{{ .Values.kubecostProductConfigs.awsServiceKeyName }}",
           "serviceKeySecret": "{{ .Values.kubecostProductConfigs.awsServiceKeyPassword }}"


### PR DESCRIPTION
## What does this PR change?
adds athenaWorkgroup and masterPayerARN to cloud-integration.json

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Bug:  cloud-integration.json did not include athenaWorkgroup and masterPayerARN


## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
Helm installs with added values and without new values.

## Have you made an update to documentation? If so, please provide the corresponding PR.

