### PR TITLE
feat: Allow templating fqdn for all frontend upstreams

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -52,7 +52,7 @@ data:
         text/x-cross-domain-policy;
 
     upstream api {
-{{- if .Values.kubecostFrontend.use_default_fqdn }}
+{{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9001;
 {{- else if and .Values.kubecostFrontend.api .Values.kubecostFrontend.api.fqdn }}    
         server {{ .Values.kubecostFrontend.api.fqdn }};
@@ -62,7 +62,7 @@ data:
     }
 
     upstream model {
-{{- if .Values.kubecostFrontend.use_default_fqdn }}
+{{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9003;
 {{- else if and .Values.kubecostFrontend.model .Values.kubecostFrontend.model.fqdn }}
         server {{ .Values.kubecostFrontend.model.fqdn }};
@@ -73,7 +73,7 @@ data:
 
 {{- if and .Values.clusterController .Values.clusterController.enabled }}
     upstream clustercontroller {
-{{- if .Values.kubecostFrontend.use_default_fqdn }}
+{{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "kubecost.clusterControllerName" . }}-service.{{ .Release.Namespace }}.svc.cluster.local:9731;
 {{- else }}
 {{- if and .Values.kubecostFrontend.clusterController .Values.kubecostFrontend.clusterController.fqdn }}
@@ -88,7 +88,7 @@ data:
 {{- if .Values.global.grafana.proxy }}
     upstream grafana {
 {{- if .Values.global.grafana.enabled }}
-{{- if .Values.kubecostFrontend.use_default_fqdn }}
+{{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ .Release.Name }}-grafana.{{ .Release.Namespace }}.svc.cluster.local;
 {{- else }}
 {{- if .Values.global.grafana.fqdn }}
@@ -105,7 +105,7 @@ data:
 
   {{- if .Values.forecasting.enabled }}
     upstream forecasting {
-        {{- if .Values.kubecostFrontend.use_default_fqdn }}
+        {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ .Release.Name }}-forecasting.{{ .Release.Namespace }}.svc.cluster.local:5000;
         {{- else }}
         {{- if and .Values.kubecostFrontend.forcasting .Values.kubecostFrontend.forcasting.fqdn }}
@@ -119,7 +119,7 @@ data:
 
   {{- if and (not .Values.agent) (not .Values.cloudAgent) (not (eq (include "aggregator.deployMethod" .) "disabled")) }}
     upstream aggregator {
-        {{- if .Values.kubecostFrontend.use_default_fqdn }}
+        {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
         {{- else }}
         {{- if and .Values.kubecostFrontend.aggregator .Values.kubecostFrontend.aggregator.fqdn }}
@@ -130,7 +130,7 @@ data:
         {{- end }}
     }
     upstream cloudCost {
-        {{- if .Values.kubecostFrontend.use_default_fqdn }}
+        {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:9005;
         {{- else }}
         {{- if and .Values.kubecostFrontend.cloudCost .Values.kubecostFrontend.cloudCost.fqdn }}
@@ -144,7 +144,7 @@ data:
     {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
     {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
     upstream multi-cluster-diagnostics {
-        {{- if .Values.kubecostFrontend.use_default_fqdn }}
+        {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9007;
         {{- else}}
         {{- if and .Values.kubecostFrontend.multiClusterDiagnostics .Values.kubecostFrontend.multiClusterDiagnostics.fqdn }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -147,8 +147,8 @@ data:
         {{- if .Values.kubecostFrontend.use_default_fqdn }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9007;
         {{- else}}
-        {{- if and .Values.kubecostFrontend.multi_cluster_diagnostics .Values.kubecostFrontend.multi_cluster_diagnostics.fqdn }}
-        server {{ .Values.kubecostFrontend.multi_cluster_diagnostics.fqdn }};
+        {{- if and .Values.kubecostFrontend.multiClusterDiagnostics .Values.kubecostFrontend.multiClusterDiagnostics.fqdn }}
+        server {{ .Values.kubecostFrontend.multiClusterDiagnostics.fqdn }};
         {{- else }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}:9007;
         {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -106,9 +106,9 @@ data:
         {{- if .Values.kubecostFrontend.forcasting }}
         {{- if .Values.kubecostFrontend.forcasting.fqdn }}
         server {{ .Values.kubecostFrontend.forcasting.fqdn }};
+        {{- end }}
         {{- else }}
         server {{ .Release.Name }}-forecasting.{{ .Release.Namespace }}:5000;
-        {{- end }}
         {{- end }}
     }
   {{- end }}
@@ -118,18 +118,18 @@ data:
         {{- if .Values.kubecostFrontend.aggregator }}
         {{- if .Values.kubecostFrontend.aggregator.fqdn }}
         server {{ .Values.kubecostFrontend.aggregator.fqdn }};
+        {{- end }}
         {{- else }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
-        {{- end }}
         {{- end }}
     }
     upstream cloudCost {
         {{- if .Values.kubecostFrontend.cloudCost }}
         {{- if .Values.kubecostFrontend.cloudCost.fqdn }}
         server {{ .Values.kubecostFrontend.cloudCost.fqdn }};
+        {{- end }}
         {{- else }}
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}:9005;
-        {{- end }}
         {{- end }}
     }
   {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -103,22 +103,46 @@ data:
 
   {{- if .Values.forecasting.enabled }}
     upstream forecasting {
+        {{- if .Values.kubecostFrontend.forcasting }}
+        {{- if .Values.kubecostFrontend.forcasting.fqdn }}
+        server {{ .Values.kubecostFrontend.forcasting.fqdn }};
+        {{- else }}
         server {{ .Release.Name }}-forecasting.{{ .Release.Namespace }}:5000;
+        {{- end }}
+        {{- end }}
     }
   {{- end }}
 
   {{- if and (not .Values.agent) (not .Values.cloudAgent) (not (eq (include "aggregator.deployMethod" .) "disabled")) }}
     upstream aggregator {
+        {{- if .Values.kubecostFrontend.aggregator }}
+        {{- if .Values.kubecostFrontend.aggregator.fqdn }}
+        server {{ .Values.kubecostFrontend.aggregator.fqdn }};
+        {{- else }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
+        {{- end }}
+        {{- end }}
     }
     upstream cloudCost {
+        {{- if .Values.kubecostFrontend.cloudCost }}
+        {{- if .Values.kubecostFrontend.cloudCost.fqdn }}
+        server {{ .Values.kubecostFrontend.cloudCost.fqdn }};
+        {{- else }}
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}:9005;
+        {{- end }}
+        {{- end }}
     }
   {{- end }}
     {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
     {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
     upstream multi-cluster-diagnostics {
+        {{- if .Values.kubecostFrontend.multi_cluster_diagnostics }}
+        {{- if .Values.kubecostFrontend.multi_cluster_diagnostics.fqdn }}
+        server {{ .Values.kubecostFrontend.multi_cluster_diagnostics.fqdn }};
+        {{- else }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}:9007;
+        {{- end }}
+        {{- end }}
     }
     {{- end }}
     {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -52,48 +52,50 @@ data:
         text/x-cross-domain-policy;
 
     upstream api {
-{{- if.Values.kubecostFrontend.api }}
-{{- if.Values.kubecostFrontend.api.fqdn }}
+{{- if .Values.kubecostFrontend.use_default_fqdn }}
+        server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9001;
+{{- else if and .Values.kubecostFrontend.api .Values.kubecostFrontend.api.fqdn }}    
         server {{ .Values.kubecostFrontend.api.fqdn }};
-{{- else }}
-        server {{ $serviceName }}.{{ .Release.Namespace }}:9001;
-{{- end }}
 {{- else }}
         server {{ $serviceName }}.{{ .Release.Namespace }}:9001;
 {{- end }}
     }
 
     upstream model {
-{{- if.Values.kubecostFrontend.model }}
-{{- if.Values.kubecostFrontend.model.fqdn }}
+{{- if .Values.kubecostFrontend.use_default_fqdn }}
+        server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9003;
+{{- else if and .Values.kubecostFrontend.model .Values.kubecostFrontend.model.fqdn }}
         server {{ .Values.kubecostFrontend.model.fqdn }};
-{{- else }}
-        server {{ $serviceName }}.{{ .Release.Namespace }}:9003;
-{{- end }}
 {{- else }}
         server {{ $serviceName }}.{{ .Release.Namespace }}:9003;
 {{- end }}
     }
 
-{{- if .Values.clusterController }}
-{{- if .Values.clusterController.enabled }}
+{{- if and .Values.clusterController .Values.clusterController.enabled }}
     upstream clustercontroller {
-{{- if .Values.clusterController.fqdn }}
-        server {{ .Values.clusterController.fqdn }};
+{{- if .Values.kubecostFrontend.use_default_fqdn }}
+        server {{ template "kubecost.clusterControllerName" . }}-service.{{ .Release.Namespace }}.svc.cluster.local:9731;
+{{- else }}
+{{- if and .Values.kubecostFrontend.clusterController .Values.kubecostFrontend.clusterController.fqdn }}
+        server {{ .Values.kubecostFrontend.clusterController.fqdn }};
 {{- else }}
         server {{ template "kubecost.clusterControllerName" . }}-service.{{ .Release.Namespace }}:9731;
 {{- end }}
-    }
 {{- end }}
+    }
 {{- end }}
 
 {{- if .Values.global.grafana.proxy }}
     upstream grafana {
 {{- if .Values.global.grafana.enabled }}
+{{- if .Values.kubecostFrontend.use_default_fqdn }}
+        server {{ .Release.Name }}-grafana.{{ .Release.Namespace }}.svc.cluster.local;
+{{- else }}
 {{- if .Values.global.grafana.fqdn }}
         server {{ .Values.global.grafana.fqdn }};
 {{- else }}
         server {{ .Release.Name }}-grafana.{{ .Release.Namespace }};
+{{- end }}
 {{- end }}
 {{- else }}
         server {{.Values.global.grafana.domainName}};
@@ -103,41 +105,49 @@ data:
 
   {{- if .Values.forecasting.enabled }}
     upstream forecasting {
-        {{- if .Values.kubecostFrontend.forcasting }}
-        {{- if .Values.kubecostFrontend.forcasting.fqdn }}
+        {{- if .Values.kubecostFrontend.use_default_fqdn }}
+        server {{ .Release.Name }}-forecasting.{{ .Release.Namespace }}.svc.cluster.local:5000;
+        {{- else }}
+        {{- if and .Values.kubecostFrontend.forcasting .Values.kubecostFrontend.forcasting.fqdn }}
         server {{ .Values.kubecostFrontend.forcasting.fqdn }};
-        {{- end }}
         {{- else }}
         server {{ .Release.Name }}-forecasting.{{ .Release.Namespace }}:5000;
+        {{- end }}
         {{- end }}
     }
   {{- end }}
 
   {{- if and (not .Values.agent) (not .Values.cloudAgent) (not (eq (include "aggregator.deployMethod" .) "disabled")) }}
     upstream aggregator {
-        {{- if .Values.kubecostFrontend.aggregator }}
-        {{- if .Values.kubecostFrontend.aggregator.fqdn }}
+        {{- if .Values.kubecostFrontend.use_default_fqdn }}
+        server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
+        {{- else }}
+        {{- if and .Values.kubecostFrontend.aggregator .Values.kubecostFrontend.aggregator.fqdn }}
         server {{ .Values.kubecostFrontend.aggregator.fqdn }};
-        {{- end }}
         {{- else }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
         {{- end }}
+        {{- end }}
     }
     upstream cloudCost {
-        {{- if .Values.kubecostFrontend.cloudCost }}
-        {{- if .Values.kubecostFrontend.cloudCost.fqdn }}
+        {{- if .Values.kubecostFrontend.use_default_fqdn }}
+        server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:9005;
+        {{- else }}
+        {{- if and .Values.kubecostFrontend.cloudCost .Values.kubecostFrontend.cloudCost.fqdn }}
         server {{ .Values.kubecostFrontend.cloudCost.fqdn }};
-        {{- end }}
         {{- else }}
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}:9005;
+        {{- end }}
         {{- end }}
     }
   {{- end }}
     {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
     {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
     upstream multi-cluster-diagnostics {
-        {{- if .Values.kubecostFrontend.multi_cluster_diagnostics }}
-        {{- if .Values.kubecostFrontend.multi_cluster_diagnostics.fqdn }}
+        {{- if .Values.kubecostFrontend.use_default_fqdn }}
+        server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9007;
+        {{- else}}
+        {{- if and .Values.kubecostFrontend.multi_cluster_diagnostics .Values.kubecostFrontend.multi_cluster_diagnostics.fqdn }}
         server {{ .Values.kubecostFrontend.multi_cluster_diagnostics.fqdn }};
         {{- else }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}:9007;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -54,7 +54,7 @@ data:
     upstream api {
 {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9001;
-{{- else if and .Values.kubecostFrontend.api .Values.kubecostFrontend.api.fqdn }}    
+{{- else if and .Values.kubecostFrontend.api .Values.kubecostFrontend.api.fqdn }}
         server {{ .Values.kubecostFrontend.api.fqdn }};
 {{- else }}
         server {{ $serviceName }}.{{ .Release.Namespace }}:9001;
@@ -141,7 +141,8 @@ data:
         {{- end }}
     }
   {{- end }}
-    {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
+
+    {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
     {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
     upstream multi-cluster-diagnostics {
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
@@ -918,7 +919,7 @@ data:
             default_type 'application/json';
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
-            {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
+            {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled }}
             {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
             return 200 '{"multi-cluster-diagnostics-enabled": "true"}';
             {{- end }}
@@ -926,9 +927,16 @@ data:
             return 200 '{"multi-cluster-diagnostics-enabled": "false"}';
             {{- end }}
         }
-        {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
+
+        {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
+        # When the Multi-cluster Diagnostics Service is run within the
+        # cost-model container, its endpoint is available at
+        # `/model/diagnostics/multicluster`. No Nginx path forwarding needed.
+        # When the Multi-cluster Diagnostics Service is run as a K8s Deployment,
+        # we should forward that path to the K8s Service.
+
         {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
-        location /model/multi-cluster-diagnostics {
+        location /diagnostics/api {
             default_type 'application/json';
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
@@ -940,7 +948,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         # simple alias for support
-        location /model/mcd {
+        location /mcd {
             default_type 'application/json';
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -401,6 +401,9 @@ kubecostFrontend:
   #   large_client_header_buffers 4 64k;
   # hideDiagnostics: false  # useful if the primary is not monitored. Supported in limited environments.
   # hideOrphanedResources: false  # OrphanedResources works on the primary-cluster's cloud-provider only.
+  
+  # set to true to set all upstreams to use <service>.<namespace>.svc.cluster.local instead of just <service>.<namespace>
+  use_default_fqdn: false
 #  api:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -403,7 +403,7 @@ kubecostFrontend:
   # hideOrphanedResources: false  # OrphanedResources works on the primary-cluster's cloud-provider only.
 
   # set to true to set all upstreams to use <service>.<namespace>.svc.cluster.local instead of just <service>.<namespace>
-  use_default_fqdn: false
+  useDefaultFqdn: false
 #  api:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -405,6 +405,15 @@ kubecostFrontend:
 #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:
 #    fqdn: kubecost-model.kubecost.svc.cluster.local:9003
+#  forecasting:
+#    fqdn: kubecost-forcasting.kubecost.svc.cluster.local:5000
+#  aggregator:
+#    fqdn: kubecost-aggregator.kubecost.svc.cluster.local:9004
+#  cloudCost:
+#    fqdn: kubecost-cloud-cost.kubecost.svc.cluster.local:9005
+#  multi_cluster_diagnostics:
+#    fqdn: kubecost-multi-diag.kubecost.svc.cluster.local:9007
+
 
 # Kubecost Metrics deploys a separate pod which will emit kubernetes specific metrics required
 # by the cost-model. This pod is designed to remain active and decoupled from the cost-model itself.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -416,6 +416,8 @@ kubecostFrontend:
 #    fqdn: kubecost-cloud-cost.kubecost.svc.cluster.local:9005
 #  multi_cluster_diagnostics:
 #    fqdn: kubecost-multi-diag.kubecost.svc.cluster.local:9007
+#  clusterController:
+#    fqdn: cluster-controller.kubecost.svc.cluster.local:9731
 
 
 # Kubecost Metrics deploys a separate pod which will emit kubernetes specific metrics required

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -414,7 +414,7 @@ kubecostFrontend:
 #    fqdn: kubecost-aggregator.kubecost.svc.cluster.local:9004
 #  cloudCost:
 #    fqdn: kubecost-cloud-cost.kubecost.svc.cluster.local:9005
-#  multi_cluster_diagnostics:
+#  multiClusterDiagnostics:
 #    fqdn: kubecost-multi-diag.kubecost.svc.cluster.local:9007
 #  clusterController:
 #    fqdn: cluster-controller.kubecost.svc.cluster.local:9731

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -401,7 +401,7 @@ kubecostFrontend:
   #   large_client_header_buffers 4 64k;
   # hideDiagnostics: false  # useful if the primary is not monitored. Supported in limited environments.
   # hideOrphanedResources: false  # OrphanedResources works on the primary-cluster's cloud-provider only.
-  
+
   # set to true to set all upstreams to use <service>.<namespace>.svc.cluster.local instead of just <service>.<namespace>
   use_default_fqdn: false
 #  api:


### PR DESCRIPTION
## What does this PR change?
Currently only 3 upstreams in the nginx configuration for the tcp-frontend are template-able via the `fqdn` setting. This adds templating for `forecasting`, `aggregator`, and `cloudCost` upstreams.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds ability to template all upstream hosts for K8s clusters that require FQDNs.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
The defaults are untouched, so this is not a breaking change. It should fix issues some may have with shorthand upstream servers.

## How was this PR tested?
Deployed to our local cluster

## Have you made an update to documentation? If so, please provide the corresponding PR.
Added to the relevant commented-out pieces in the `values.yaml` file.
