### PR TITLE
Add sanity/existence check for `kubecostModel.federatedStorageConfigSecret`

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -3,6 +3,7 @@
 {{- include "cloudIntegrationSourceCheck" . -}}
 {{- include "eksCheck" . -}}
 {{- include "cloudIntegrationSecretCheck" . -}}
+{{- include "federatedStorageConfigSecretCheck" . -}}
 {{- $servicePort := .Values.service.port | default 9090 }}
 Kubecost {{ .Chart.Version }} has been successfully installed.
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -173,12 +173,12 @@ Skip the check if CI/CD is enabled and skipSanityChecks is set. Argo CD, for exa
 support templating a chart which uses the lookup function.
 */}}
 {{- define "federatedStorageConfigSecretCheck" -}}
-{{- if (.Values.kubecostProductConfigs).federatedStorageConfigSecret }}
+{{- if (.Values.kubecostModel).federatedStorageConfigSecret }}
 {{- if not (and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks) }}
 {{-  if .Capabilities.APIVersions.Has "v1/Secret" }}
-  {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.kubecostProductConfigs.federatedStorageConfigSecret }}
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.kubecostModel.federatedStorageConfigSecret }}
   {{- if or (not $secret) (not (index $secret.data "federated-store.yaml")) }}
-    {{- fail (printf "The federated storage config secret '%s' does not exist or does not contain the expected key 'federated-store.yaml'" .Values.kubecostProductConfigs.federatedStorageConfigSecret) }}
+    {{- fail (printf "The federated storage config secret '%s' does not exist or does not contain the expected key 'federated-store.yaml'" .Values.kubecostModel.federatedStorageConfigSecret) }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -185,7 +185,6 @@ support templating a chart which uses the lookup function.
 {{- end -}}
 {{- end -}}
 
-
 {{/*
 Expand the name of the chart.
 */}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -168,6 +168,25 @@ support templating a chart which uses the lookup function.
 {{- end -}}
 
 {{/*
+Verify the federated storage config secret exists with the expected key when cloud integration is enabled.
+Skip the check if CI/CD is enabled and skipSanityChecks is set. Argo CD, for example, does not
+support templating a chart which uses the lookup function.
+*/}}
+{{- define "federatedStorageConfigSecretCheck" -}}
+{{- if (.Values.kubecostProductConfigs).federatedStorageConfigSecret }}
+{{- if not (and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks) }}
+{{-  if .Capabilities.APIVersions.Has "v1/Secret" }}
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.kubecostProductConfigs.federatedStorageConfigSecret }}
+  {{- if or (not $secret) (not (index $secret.data "federated-store.yaml")) }}
+    {{- fail (printf "The federated storage config secret '%s' does not exist or does not contain the expected key 'federated-store.yaml'" .Values.kubecostProductConfigs.federatedStorageConfigSecret) }}
+  {{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "cost-analyzer.name" -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -12,7 +12,7 @@ global:
     domainName: cost-analyzer-grafana.default.svc  # example grafana domain Ignored if enabled: true
     scheme: "http"  # http or https, for the domain name above.
     proxy: true  # If true, the kubecost frontend will route to your grafana through its service endpoint
-#    fqdn: cost-analyzer-grafana.default.svc
+    # fqdn: cost-analyzer-grafana.default.svc
 
   # Enable only when you are using GCP Marketplace ENT listing. Learn more at https://console.cloud.google.com/marketplace/product/kubecost-public/kubecost-ent
   gcpstore:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -512,7 +512,8 @@ kubecostModel:
 
   # The name of the Secret containing a bucket config for ETL backup.
   # etlBucketConfigSecret:
-  # The name of the Secret containing a bucket config for Federated storage.
+  # The name of the Secret containing a bucket config for Federated storage. The contents should be stored
+  # under a key named federated-store.yaml.
   # federatedStorageConfigSecret:
 
   ## Feature to view your out-of-cluster costs and their k8s utilization

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -514,7 +514,7 @@ kubecostModel:
   # etlBucketConfigSecret:
   # The name of the Secret containing a bucket config for Federated storage. The contents should be stored
   # under a key named federated-store.yaml.
-  federatedStorageConfigSecret: ""
+  # federatedStorageConfigSecret: ""
 
   ## Feature to view your out-of-cluster costs and their k8s utilization
   ## Ref: https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -514,7 +514,7 @@ kubecostModel:
   # etlBucketConfigSecret:
   # The name of the Secret containing a bucket config for Federated storage. The contents should be stored
   # under a key named federated-store.yaml.
-  # federatedStorageConfigSecret:
+  federatedStorageConfigSecret: ""
 
   ## Feature to view your out-of-cluster costs and their k8s utilization
   ## Ref: https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Adds a sanity/existence check for the Secret defined at `kubecostModel.federatedStorageConfigSecret` similar to what PR #3048 did for `kubecostProductConfigs.cloudIntegrationSecret`.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Provides a better UX in that the chart installation will fail if the Secret cannot be found.

## Links to Issues or tickets this PR addresses or fixes

Closes #3074

## What risks are associated with merging this PR? What is required to fully test this PR?

Secret check could be incorrect.

## How was this PR tested?

Tested locally with `helm install`.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A