### PR TITLE
provide reasonable default for db copy chunks

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -886,6 +886,10 @@ Begin Kubecost 2.0 templates
           name: {{ .Values.prometheus.server.clusterIDConfigmap }}
           key: CLUSTER_ID
     {{- end }}
+    {{- if (gt (int .Values.kubecostAggregator.numDBCopyPartitions) 0) }}
+    - name: NUM_DB_COPY_CHUNKS
+      value: {{ .Values.kubecostAggregator.numDBCopyPartitions | quote }}
+    {{- end }}
     {{- if .Values.kubecostAggregator.jaeger.enabled }}
     - name: TRACING_URL
       value: "http://localhost:14268/api/traces"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2333,6 +2333,14 @@ kubecostAggregator:
   # 2400Mi. In most environments, the default should suffice.
   stagingEmptyDirSizeLimit: 2Gi
 
+  # this is the number of partitions the datastore is split into for copying
+  # the higher this number, the lower the ram usage but the longer it takes for 
+  # new data to show in the kubecost UI 
+  # set to 0 for max partitioning (minimum possible ram usage, but the slowest)
+  # the default of 25 is sufficient for 95%+ of users. This should only be modified 
+  # after consulting with Kubecost's support team
+  numDBCopyPartitions: 25
+
   resources: {}
     # requests:
     #   cpu: 1000m

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2334,10 +2334,10 @@ kubecostAggregator:
   stagingEmptyDirSizeLimit: 2Gi
 
   # this is the number of partitions the datastore is split into for copying
-  # the higher this number, the lower the ram usage but the longer it takes for 
-  # new data to show in the kubecost UI 
+  # the higher this number, the lower the ram usage but the longer it takes for
+  # new data to show in the kubecost UI
   # set to 0 for max partitioning (minimum possible ram usage, but the slowest)
-  # the default of 25 is sufficient for 95%+ of users. This should only be modified 
+  # the default of 25 is sufficient for 95%+ of users. This should only be modified
   # after consulting with Kubecost's support team
   numDBCopyPartitions: 25
 


### PR DESCRIPTION
## What does this PR change?
Provides a 'middle ground' setting in the time vs resources tradeoff for the db copy operation 

## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
it will make new data show up in kubecost UI sooner, while keeping ram usage reasonable

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
tested via chart template rendering

## Have you made an update to documentation? If so, please provide the corresponding PR.

