### PR TITLE
Multi-cluster Diagnostics runs in the cost-model by default

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -684,7 +684,6 @@ spec:
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API key.This GCP api key is expected to be here and is limited to accessing google's billing API.
             {{- if .Values.kubecostProductConfigs }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
-
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/configs/key.json
             {{- end }}
@@ -1008,6 +1007,33 @@ spec:
                   key: kubecost-token
             - name: WATERFOWL_ENABLED
               value: "true"
+            {{- /*A pre-requisite for running MultiClusterDiagnostics in the cost-model container is a configured federated-store secret and cluster_id*/}}
+            {{- if or (empty .Values.kubecostModel.federatedStorageConfigSecret) (eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one") }}
+            - name: DIAGNOSTICS_RUN_IN_COST_MODEL
+              value: "false"
+            {{- else if .Values.diagnostics.deployment.enabled }}
+            - name: DIAGNOSTICS_RUN_IN_COST_MODEL
+              value: "false"
+            {{- else }}
+            - name: DIAGNOSTICS_RUN_IN_COST_MODEL
+              value: "true"
+            - name: DIAGNOSTICS_KUBECOST_FQDN
+              value: "localhost"
+            - name: DIAGNOSTICS_KUBECOST_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DIAGNOSTICS_PRIMARY
+              value: {{ quote .Values.diagnostics.primary.enabled }}
+            - name: DIAGNOSTICS_RETENTION
+              value: {{ .Values.diagnostics.primary.retention }}
+            - name: DIAGNOSTICS_PRIMARY_READONLY
+              value: {{ quote .Values.diagnostics.primary.readonly }}
+            - name: DIAGNOSTICS_POLLING_INTERVAL
+              value: {{ .Values.diagnostics.pollingInterval }}
+            - name: DIAGNOSTICS_KEEP_HISTORY
+              value: {{ quote .Values.diagnostics.keepDiagnosticHistory }}
+            - name: DIAGNOSTICS_COLLECT_HELM_VALUES
+              value: {{ quote .Values.diagnostics.collectHelmValues }}
+            {{- end }}
         {{- if and .Values.kubecostFrontend.enabled (not .Values.federatedETL.agentOnly) }}
         {{- if .Values.kubecostFrontend }}
         {{- if .Values.kubecostFrontend.fullImageName }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -115,7 +115,7 @@ data:
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}:9005;
     }
   {{- end }}
-  
+
     {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
     {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
     upstream multi-cluster-diagnostics {
@@ -894,15 +894,15 @@ data:
             {{- end }}
         }
 
+        {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
         # When the Multi-cluster Diagnostics Service is run within the
         # cost-model container, its endpoint is available at
         # `/model/diagnostics/multicluster`. No Nginx path forwarding needed.
         # When the Multi-cluster Diagnostics Service is run as a K8s Deployment,
         # we should forward that path to the K8s Service.
 
-        {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
         {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
-        location /model/diagnostics/multicluster {
+        location /diagnostics/api {
             default_type 'application/json';
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
@@ -914,7 +914,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         # simple alias for support
-        location /model/mcd {
+        location /mcd {
             default_type 'application/json';
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -115,7 +115,8 @@ data:
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}:9005;
     }
   {{- end }}
-    {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled }}
+  
+    {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
     {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
     upstream multi-cluster-diagnostics {
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}:9007;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -115,7 +115,7 @@ data:
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}:9005;
     }
   {{- end }}
-    {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
+    {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled }}
     {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
     upstream multi-cluster-diagnostics {
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}:9007;
@@ -884,7 +884,7 @@ data:
             default_type 'application/json';
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
-            {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
+            {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled }}
             {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
             return 200 '{"multi-cluster-diagnostics-enabled": "true"}';
             {{- end }}
@@ -892,9 +892,16 @@ data:
             return 200 '{"multi-cluster-diagnostics-enabled": "false"}';
             {{- end }}
         }
-        {{- if and .Values.diagnostics.enabled .Values.diagnostics.isDiagnosticsPrimary.enabled }}
+
+        # When the Multi-cluster Diagnostics Service is run within the
+        # cost-model container, its endpoint is available at
+        # `/model/diagnostics/multicluster`. No Nginx path forwarding needed.
+        # When the Multi-cluster Diagnostics Service is run as a K8s Deployment,
+        # we should forward that path to the K8s Service.
+
+        {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
         {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
-        location /model/multi-cluster-diagnostics {
+        location /model/diagnostics/multicluster {
             default_type 'application/json';
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.diagnostics.enabled }}
+{{- if and .Values.diagnostics.enabled .Values.diagnostics.deployment.enabled }}
 {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) -}}
 
 {{- if eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one" }}
@@ -12,8 +12,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "diagnostics.selectorLabels" . | nindent 4 }}
-    {{- if and .Values.diagnostics .Values.diagnostics.labels }}
-    {{- toYaml .Values.diagnostics.labels | nindent 4 }}
+    {{- if .Values.diagnostics.deployment.labels }}
+    {{- toYaml .Values.diagnostics.deployment.labels | nindent 4 }}
     {{- end }}
 spec:
   replicas: 1
@@ -32,9 +32,9 @@ spec:
         {{- end }}
     spec:
       restartPolicy: Always
-      {{- if .Values.diagnostics.securityContext }}
+      {{- if .Values.diagnostics.deployment.securityContext }}
       securityContext:
-        {{- toYaml .Values.diagnostics.securityContext | nindent 8 }}
+        {{- toYaml .Values.diagnostics.deployment.securityContext | nindent 8 }}
       {{- else if .Values.global.securityContext }}
       securityContext:
         {{- toYaml .Values.global.securityContext | nindent 8 }}
@@ -75,9 +75,9 @@ spec:
           imagePullSecrets:
           {{ toYaml .Values.imagePullSecrets | indent 2 }}
           {{- end }}
-          {{- if .Values.diagnostics.containerSecurityContext }}
+          {{- if .Values.diagnostics.deployment.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.diagnostics.containerSecurityContext | nindent 12 }}
+            {{- toYaml .Values.diagnostics.deployment.containerSecurityContext | nindent 12 }}
           {{- else if .Values.global.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
@@ -103,30 +103,24 @@ spec:
             {{- end }}
             - name: FEDERATED_STORE_CONFIG
               value: /var/configs/etl/federated-store.yaml
+            - name: DIAGNOSTICS_RUN_IN_COST_MODEL
+              value: "false"
             - name: DIAGNOSTICS_KUBECOST_FQDN
               value: {{ template "cost-analyzer.serviceName" . }}
             - name: DIAGNOSTICS_KUBECOST_NAMESPACE
               value: {{ .Release.Namespace }}
-            - name: DIAGNOSTICS_POLLING_INTERVAL
-              value: {{ .Values.diagnostics.pollingInterval | default "300s" }}
             - name: DIAGNOSTICS_PRIMARY
-            {{- if .Values.diagnostics.isDiagnosticsPrimary.enabled }}
-              value: "true"
-            {{- else }}
-              value: "false"
-            {{- end }}
-            - name: DIAGNOSTICS_COLLECT_HELM_VALUES
-            {{- if and .Values.reporting.valuesReporting .Values.diagnostics.collectHelmValues }}
-              value: "true"
-            {{- else }}
-              value: "false"
-            {{- end }}
+              value: {{ quote .Values.diagnostics.primary.enabled }}
+            - name: DIAGNOSTICS_RETENTION
+              value: {{ .Values.diagnostics.primary.retention }}
+            - name: DIAGNOSTICS_PRIMARY_READONLY
+              value: {{ quote .Values.diagnostics.primary.readonly }}
+            - name: DIAGNOSTICS_POLLING_INTERVAL
+              value: {{ .Values.diagnostics.pollingInterval }}
             - name: DIAGNOSTICS_KEEP_HISTORY
-            {{- if .Values.diagnostics.keepDiagnosticHistory }}
-              value: "true"
-            {{- else }}
-              value: "false"
-            {{- end }}
+              value: {{ quote .Values.diagnostics.keepDiagnosticHistory }}
+            - name: DIAGNOSTICS_COLLECT_HELM_VALUES
+              value: {{ quote .Values.diagnostics.collectHelmValues }}
             {{- if .Values.systemProxy.enabled }}
             - name: HTTP_PROXY
               value: {{ .Values.systemProxy.httpProxyUrl }}
@@ -141,12 +135,12 @@ spec:
             - name: no_proxy
               value:  {{ .Values.systemProxy.noProxy }}
             {{- end }}
-            {{- range $key, $value := .Values.diagnostics.env }}
+            {{- range $key, $value := .Values.diagnostics.deployment.env }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
             {{- end }}
           {{- /* TODO: heatlhcheck that validates the diagnotics pod is healthy */}}
-          {{- if .Values.diagnostics.isDiagnosticsPrimary.enabled}}
+          {{- if .Values.diagnostics.primary.enabled}}
           readinessProbe:
             httpGet:
               path: /healthz
@@ -157,18 +151,19 @@ spec:
               protocol: TCP
           {{- end }}
           resources:
-            {{- toYaml .Values.diagnostics.resources | nindent 12 }}
-      {{- with .Values.diagnostics.nodeSelector }}
+            {{- toYaml .Values.diagnostics.deployment.resources | nindent 12 }}
+      {{- with .Values.diagnostics.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.diagnostics.tolerations }}
+      {{- with .Values.diagnostics.deployment.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.diagnostics.affinity }}
+      {{- with .Values.diagnostics.deployment.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/diagnostics-service.yaml
+++ b/cost-analyzer/templates/diagnostics-service.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.diagnostics.enabled .Values.diagnostics.deployment.enabled }}
-{{- if .Values.diagnostics.primary.enabled }}
+{{- if and .Values.diagnostics.enabled .Values.diagnostics.deployment.enabled .Values.diagnostics.primary.enabled }}
 {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) -}}
 apiVersion: v1
 kind: Service
@@ -17,6 +16,5 @@ spec:
   selector:
     {{- include "diagnostics.selectorLabels" . | nindent 4 }}
   type: ClusterIP
-{{- end }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/diagnostics-service.yaml
+++ b/cost-analyzer/templates/diagnostics-service.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.diagnostics.isDiagnosticsPrimary.enabled }}
-{{- if .Values.diagnostics.enabled }}
+{{- if and .Values.diagnostics.enabled .Values.diagnostics.deployment.enabled }}
+{{- if .Values.diagnostics.primary.enabled }}
 {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) -}}
 apiVersion: v1
 kind: Service

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2426,21 +2426,42 @@ kubecostAggregator:
 ##
 diagnostics:
   enabled: true
+
+  ## The primary aggregates all diagnostic data and handles API requests. It's
+  ## also responsible for deleting diagnostic data (on disk & bucket) beyond
+  ## retention. When in readonly mode it does not push its own diagnostic data
+  ## to the bucket.
+  primary:
+    enabled: false
+    retention: "7d"
+    readonly: false
+
   ## How frequently to run & push diagnostics. Defaults to 5 minutes.
   pollingInterval: "300s"
+
   ## Creates a new Diagnostic file in the bucket for every run.
   keepDiagnosticHistory: false
+
   ## Pushes the cluster's Kubecost Helm Values to the bucket once upon startup.
   ## This may contain sensitive information and is roughly 30kb per cluster.
   collectHelmValues: false
-  ## The primary aggregates all diagnostic data and serves HTTP queries.
-  isDiagnosticsPrimary:
+
+  ## By default, the Multi-cluster Diagnostics service runs within the
+  ## cost-model container in the cost-analyzer pod. For higher availability, it
+  ## can be run as a separate deployment.
+  deployment:
     enabled: false
-  resources:
-    requests:
-      cpu: "10m"
-      memory: "20Mi"
-  securityContext: {}
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "20Mi"
+    env: {}
+    labels: {}
+    securityContext: {}
+    containerSecurityContext: {}
+    nodeSelector: {}
+    tolerations: {}
+    affinity: {}
 
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:


### PR DESCRIPTION
## What does this PR change?

- Do not create the `diagnostics-deployment` by default, unless the user explicitly enables it
- Add environment variables for new features (`DIAGNOSTICS_RUN_IN_COST_MODEL`, `DIAGNOSTICS_RETENTION `, `DIAGNOSTICS_PRIMARY_READONLY`)
- Update nginx-conf to perform path forwarding when the `diagnostics-deployment` is enabled.

## Does this PR rely on any other PRs?

- Creates Helm configs for https://github.com/kubecost/kubecost-cost-model/pull/2163
- Supersedes https://github.com/kubecost/cost-analyzer-helm-chart/pull/2942

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Previously, users who had configured a `federated-store` secret would automatically have a Deployment created running Multi-cluster Diagnostics.

Now, those users will see the Multi-cluster Diagnostics process run in the `cost-model` container by default (in the `cost-analyzer` Deployment). The option is still available for users who prefer to run it as a separate Deployment.

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

- Breaking changes to the Helm config names (e.g. `isDiagnosticsPrimary` is now `primary`). There is no backwards compatibility built-in. Accepting that risk since the feature itself is still in beta and currently has limited interaction with the frontend
- Need to check with frontend team to ensure they are aware of path change from `/model/multi-cluster-diagnostics` to `/model/diagnostics/multicluster`

## How was this PR tested?

<details>
<summary> Test 1 (run Multi-Cluster Diagnostics in `cost-model`) </summary>

```yaml
# values.yaml
kubecostModel:
  federatedStorageConfigSecret: federated-store
  fullImageName: thomasvn/cost-model:diagnostics-in-costmodel
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "thomasn-nightly-dev"
```

Successfully see logs that the diagnostics are running:

```
2024-02-09T02:45:22.33617863Z INF RunDiagnostic: getKubecostCostModelVersion: dev (20919ef7)
2024-02-09T02:45:22.397249225Z INF RunDiagnostic: checkKubecostCostModelEmittingMetrics: successful query to http://localhost:9003/metrics
2024-02-09T02:45:22.40280726Z INF RunDiagnostic: checkPrometheusHasKubecostMetric: kubecost metric exists: absent_over_time(node_total_hourly_cost[5m])
2024-02-09T02:45:22.406701815Z INF RunDiagnostic: checkPrometheusHasCadvisorMetric: cAdvisor metric exists: absent_over_time(container_memory_working_set_bytes{container='cost-model', container!='POD', instance!=''}[5m])
2024-02-09T02:45:22.421743051Z INF RunDiagnostic: checkPrometheusHasKSMMetric: ksm metric exists: absent_over_time(kube_pod_container_resource_requests{resource='memory', unit='byte'}[5m])
2024-02-09T02:45:22.443129619Z INF RunDiagnostic: checkDailyAllocationEtlHealth: all daily allocation ETL are healthy: kubecost_allocation_data_status{resolution='daily', status='error'} > 0
2024-02-09T02:45:22.449804997Z INF RunDiagnostic: checkDailyAssetEtlHealth: all asset ETL are healthy: kubecost_asset_data_status{resolution='daily', status='error'} > 0
2024-02-09T02:45:22.456709575Z INF RunDiagnostic: checkKubecostPodsNotOOMKilled: all pods in thomasn-nightly-dev namespace sufficient memory
2024-02-09T02:45:22.471867741Z INF RunDiagnostic: checkKubecostPodsNotPending: all pods in thomasn-nightly-dev namespace running
```
</details>

<details>
<summary> Test 2 (run Multi-Cluster Diagnostics Primary in `cost-model`) </summary>

```yaml
# values.yaml
kubecostModel:
  federatedStorageConfigSecret: federated-store
  fullImageName: thomasvn/cost-model:diagnostics-in-costmodel
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "thomasn-nightly-dev"
diagnostics:
  enabled: true
  primary:
    enabled: true
```

Multi-cluster Diagnostics successfully running in the `cost-model` container with the following logs:

```
2024-02-09T02:59:41.895135308Z INF DownloadDiagnostics: downloading diagnostic files from bucket to local filesystem /var/configs//db/diagnostics/
```

Additionally, hitting the following API endpoint properly works, and is being handled by the `cost-model` container. `http://localhost:9090/model/diagnostics/multicluster?window=1d`

</details>

<details>
<summary> Test 3 (run Multi-Cluster Diagnostics Primary as a separate K8s deployment) </summary>

```yaml
# values.yaml
kubecostModel:
  federatedStorageConfigSecret: federated-store
  fullImageName: thomasvn/cost-model:diagnostics-in-costmodel
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "thomasn-nightly-dev"
diagnostics:
  enabled: true
  primary:
    enabled: true
  deployment:
    enabled: true
```

Successfully see the Diagnostics Deployment. And the following query to Kubecost successfully returns a response from the Multi-cluster Diagnostics API. `http://localhost:9090/model/diagnostics/multicluster?window=1d`

</details>

## Have you made an update to documentation? If so, please provide the corresponding PR.

TODO