### PR TITLE
Update MultiCluster Diagnostics endpoint to be `/model/diagnostics/multicluster`

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -993,14 +993,14 @@ data:
         }
 
         {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
-        # When the Multi-cluster Diagnostics Service is run within the
-        # cost-model container, its endpoint is available at
-        # `/model/diagnostics/multicluster`. No Nginx path forwarding needed.
-        # When the Multi-cluster Diagnostics Service is run as a K8s Deployment,
-        # we should forward that path to the K8s Service.
-
         {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
-        location /diagnostics/api {
+
+        # When the Multi-cluster Diagnostics Service is run within the
+        # cost-model container, its endpoint is available at the path
+        # `/model/diagnostics/multicluster`. No additional Nginx path forwarding
+        # needed. When the Multi-cluster Diagnostics Service is run as a K8s
+        # Deployment, we should forward that path to the K8s Service.
+        location /model/diagnostics/multicluster {
             default_type 'application/json';
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
@@ -1023,6 +1023,7 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+
         {{- end }}
         {{- end }}
 


### PR DESCRIPTION
## What does this PR change?

Updates MultiCluster Diagnostics endpoint from `/diagnostics/api` to `/model/diagnostics/multicluster`. This way regardless of whether this service is run within the `cost-model` container ([code ref](https://github.com/kubecost/kubecost-cost-model/blob/fa9ec60b1a33e45f568bac182d5cd65c3fafa007/pkg/cmd/costmodel/costmodel.go#L1694)) or as a separate `diagnostics` container, its API is always served at the same endpoint.

This abstracts away the need for the frontend/user to determine where the API is located based on how it's deployed.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

N/A

## How was this PR tested?

Templated using the following `values.yaml`. Correctly saw the `/model/diagnostics/multicluster` endpoint in the nginx conf.

```sh
helm template ./cost-analyzer -f values.yaml
```

```yaml
# values.yaml
diagnostics:
  enabled: true
  primary:
    enabled: true
  deployment:
    enabled: true
kubecostModel:
  federatedStorageConfigSecret: federated-store
prometheus:
  server:
    global:
      external_labels:
        cluster_id: thomasn-diagnostics
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A