### PR TITLE
Forward clusterSizing queries to aggregator _only_ if a specific environment variable is set.

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -586,6 +586,16 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        {{- if eq .Values.kubecostAggregator.env.MEMORY_INTENSIVE_CLUSTER_SIZING "enabled" }}
+        location = /model/savings/clusterSizingETL {
+            proxy_read_timeout          600;
+            proxy_pass http://aggregator/savings/clusterSizingETL;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        {{- end }}
         location = /model/reports/allocation {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/reports/allocation;


### PR DESCRIPTION
## What does this PR change?

Only forwards queries to Cluster Rightsizing if the following value is set:

```yaml
kubecostAggregator:
  env:
    "MEMORY_INTENSIVE_CLUSTER_SIZING": "enabled"
```

Makes the feature available for users that need it immediately. The env var is not set by default in the `values.yaml`. Future PRs have the option to make this config more visible, turn it into a proper config instead of an env var, or default enable the feature.

## Does this PR rely on any other PRs?

https://github.com/kubecost/kubecost-cost-model/pull/2233

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

N/A

## How was this PR tested?

```yaml
kubecostModel:
  federatedStorageConfigSecret: federated-store
kubecostAggregator:
  deployMethod: "statefulset"
  env:
    "LOG_LEVEL": "info"
    "DB_READ_THREADS": "1"
    "DB_WRITE_THREADS": "1"
    "DB_CONCURRENT_INGESTION_COUNT": "3"
    "MEMORY_INTENSIVE_CLUSTER_SIZING": "enabled"
prometheus:
  server:
    global:
      external_labels:
        cluster_id: thomasn-agg
```

```sh
$ helm template ./cost-analyzer -f values-agg.yml | grep "/savings/clusterSizingETL" -C 5
            proxy_redirect off;
            proxy_set_header Connection "";
            proxy_set_header  X-Real-IP  $remote_addr;
            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
        }
        location = /model/savings/clusterSizingETL {
            proxy_read_timeout          600;
            proxy_pass http://aggregator/savings/clusterSizingETL;
            proxy_redirect off;
            proxy_set_header Connection "";
            proxy_set_header  X-Real-IP  $remote_addr;
            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
        }
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

Not at this time, but will need to document as this feature matures.
