### PR TITLE
fix logic

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -55,8 +55,10 @@ Kubecost 2.0 preconditions
   {{- end -}}
 
   {{- if or (((.Values.global).amp).enabled) (((.Values.global).gmp).enabled) (((.Values.global).thanos).queryService) (((.Values.global).mimirProxy).enabled) -}}
-    {{- if or (not (.Values.federatedETL).federatedCluster) (not (.Values.upgrade).toV2) -}}
+    {{- if (not (.Values.federatedETL).federatedCluster)  -}}
+      {{- if (not (.Values.upgrade).toV2) -}}
       {{- fail "\n\nMulti-Cluster-Prometheus Error:\nYou are attempting to upgrade to Kubecost 2.x\nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2\nIf you have any questions or concerns, please reach out to us at product@kubecost.com\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 


### PR DESCRIPTION
## What does this PR change?
fix logic for v2=true

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fix logic for upgrade checks to v2.

## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
Couple environment tests. when it fails, this is the message:

```
Multi-Cluster-Prometheus Error:
You are attempting to upgrade to Kubecost 2.x
Support for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. 
If this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.
More information can be found here: 
https://docs.kubecost.com/install-and-configure/install/kubecostv2
If you have any questions or concerns, please reach out to us at product@kubecost.com

When ready to upgrade, add `--set upgrade.toV2=true`.
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

