### PR TITLE
Add loadBalancerSourceRanges for Cost Analyser service

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -25,6 +25,15 @@ spec:
 {{- else }}
   type: ClusterIP
 {{- end }}
+{{- if (eq .Values.service.type "LoadBalancer") }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- end }} 
   ports:
     - name: tcp-model
       port: 9003

--- a/cost-analyzer/templates/cost-analyzer-service-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-template.yaml
@@ -26,9 +26,6 @@ spec:
   type: ClusterIP
 {{- end }}
 {{- if (eq .Values.service.type "LoadBalancer") }}
-  {{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
-  {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
 {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -731,6 +731,8 @@ service:
   # nodePort:
   labels: {}
   annotations: {}
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
   sessionAffinity:
     enabled: false  # Makes sure that connections from a client are passed to the same Pod each time, when set to `true`. You should set it when you enabled authentication through OIDC or SAML integration.
     timeoutSeconds: 10800

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -731,8 +731,8 @@ service:
   # nodePort:
   labels: {}
   annotations: {}
-  loadBalancerIP: ""
-  loadBalancerSourceRanges: []
+  # loadBalancerIP: ""
+  # loadBalancerSourceRanges: []
   sessionAffinity:
     enabled: false  # Makes sure that connections from a client are passed to the same Pod each time, when set to `true`. You should set it when you enabled authentication through OIDC or SAML integration.
     timeoutSeconds: 10800

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -731,7 +731,6 @@ service:
   # nodePort:
   labels: {}
   annotations: {}
-  # loadBalancerIP: ""
   # loadBalancerSourceRanges: []
   sessionAffinity:
     enabled: false  # Makes sure that connections from a client are passed to the same Pod each time, when set to `true`. You should set it when you enabled authentication through OIDC or SAML integration.


### PR DESCRIPTION
## What does this PR change?
This is to support `loadBalancerSourceRanges` for Cost Analyzer service template

## Does this PR rely on any other PRs?

No
## How does this PR impact users? (This is the kind of thing that goes in release notes!)
To provide explicit access to the subnets that are communicating with your load balancer

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

Check if, Cost Analyser can be accessed  only with the IP's specified in the load balancer range
## How was this PR tested?
This was tested locally

## Have you made an update to documentation? If so, please provide the corresponding PR.
Not made
