### PR TITLE
Reduce Prom retention to 97h for stability

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -6,6 +6,7 @@
 {{- include "gcpCloudIntegrationCheck" . -}}
 {{- include "azureCloudIntegrationCheck" . -}}
 {{- include "federatedStorageConfigSecretCheck" . -}}
+{{- include "prometheusRetentionCheck" . -}}
 
 {{- $servicePort := .Values.service.port | default 9090 }}
 Kubecost {{ .Chart.Version }} has been successfully installed.

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -201,6 +201,38 @@ support templating a chart which uses the lookup function.
 {{- end -}}
 
 {{/*
+ Ensure that the Prometheus retention is not set too low
+*/}}
+{{- define "prometheusRetentionCheck" }}
+{{- if ((.Values.prometheus).server).enabled }}
+
+  {{- $retention := .Values.prometheus.server.retention }}
+  {{- $etlHourlyDurationHours := (int .Values.kubecostModel.etlHourlyStoreDurationHours) }}
+
+  {{- if (hasSuffix "d" $retention) }}
+    {{- $retentionDays := (int (trimSuffix "d" $retention)) }}
+    {{- if lt $retentionDays 3 }}
+      {{- fail (printf "With a daily resolution, Prometheus retention must be set >= 3 days. Provided retention is %s" $retention) }}
+    {{- else if le (mul $retentionDays 24) $etlHourlyDurationHours }}
+      {{- fail (printf "Prometheus retention (%s) must be greater than .Values.kubecostModel.etlHourlyStoreDurationHours (%d)" $retention $etlHourlyDurationHours) }}
+    {{- end }}
+
+  {{- else if (hasSuffix "h" $retention) }}
+    {{- $retentionHours := (int (trimSuffix "h" $retention)) }}
+    {{- if lt $retentionHours 50 }}
+      {{- fail (printf "With an hourly resolution, Prometheus retention must be set >= 50 hours. Provided retention is %s" $retention) }}
+    {{- else if le $retentionHours $etlHourlyDurationHours }}
+      {{- fail (printf "Prometheus retention (%s) must be greater than .Values.kubecostModel.etlHourlyStoreDurationHours (%d)" $retention $etlHourlyDurationHours) }}
+    {{- end }}
+
+  {{- else }}
+    {{- fail "prometheus.server.retention must be set in days (e.g. 5d) or hours (e.g. 97h)"}}
+
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "cost-analyzer.name" -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -521,6 +521,8 @@ kubecostModel:
   etlDailyStoreDurationDays: 91
   # The total number of hours the ETL pipelines will build
   # Set to 0 to disable hourly ETL (not recommended)
+  # Must be < prometheus server retention, otherwise empty data may overwrite
+  # known-good data
   etlHourlyStoreDurationHours: 49
   # The total number of weeks the ETL pipelines will build
   # Set to 0 to disable weekly ETL (not recommended)
@@ -1178,9 +1180,32 @@ prometheus:
     ##
     terminationGracePeriodSeconds: 300
 
-    ## Prometheus data retention period (default if not specified is 15 days)
+    ## Prometheus data retention period (default if not specified is 97 hours)
     ##
-    retention: 15d  # 50h. This must be greater than or equal to etlHourlyStoreDurationHours
+    ## Kubecost builds up its own persistent store of metric data on the
+    ## filesystem (usually a PV) and, when using ETL Backup and/or Federated
+    ## ETL, in more durable object storage like S3 or GCS. Kubecost's data
+    ## retention is _not_ tied to the configured Prometheus retention.
+    ##
+    ## For data durability, we recommend using ETL Backup instead of relying on
+    ## Prometheus retention.
+    ##
+    ## Lower retention values will affect Prometheus by reducing resource
+    ## consumption and increasing stability. It _must not_ be set below or equal
+    ## to kubecostModel.etlHourlyStoreDurationHours, otherwise empty data sets
+    ## may overwrite good data sets. For now, it must also be >= 49h for Daily
+    ## ETL stability.
+    ##
+    ## "ETL Rebuild" and "ETL Repair" is only possible on data available within
+    ## this retention window. This is an extremely rare operation.
+    ##
+    ## If you want maximum security in the event of a Kubecost agent
+    ## (cost-model) outage, increase this value. The current default of 97h is
+    ## intended to balance Prometheus stability and resource consumption
+    ## against the event of an outage in Kubecost which would necessitate a
+    ## version change. 4 days should provide enough time for most users to
+    ## notice a problem and initiate corrective action.
+    retention: 97h
     # retentionSize: should be significantly greater than the storage used in the number of hours set in etlHourlyStoreDurationHours
 
   # Install Prometheus Alert Manager


### PR DESCRIPTION
## What does this PR change?
As noted in the new comment, Kubecost has a fairly reliable data store at this time which we rely upon for long-running metrics storage. Prometheus has major problems with stability and resource consumption, particularly at high scale, and we only need it to be queryable long enough for ETL to build data. Once that data is built, and assuming a rebuild is not necessary, we no longer need Prometheus to hold that data. We are wasting a lot of user resources for near-zero gain.

We have performed changes like this (as aggressive as 50h) in user environments with great success. This is a more conservative 97h to provide some grace room for agent crashes while still reaping most of the benefits (from 15d to 4d).

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Reduced the default retention of the Prometheus in the Kubecost Helm chart from 15d to 97h, increasing stability and reducing resource consumption. See the comment attached to the `prometheus.retention.server` value for more information.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
- https://kubecost.atlassian.net/browse/SELFHOST-1178


## What risks are associated with merging this PR? What is required to fully test this PR?
- As noted in the comment, crashing agents (or crashing KC, in a default single-pod deployment) would have to be remedied within this window otherwise data will be lost. I think this is a worthwhile trade, as a retention value which is too high has caused similar unrecoverable data loss due to Prometheus outages in high-scale environments
- ~For testing, I'm hoping we can get a multi-week smoke test going in our nightly environments after I do a basic test of leaving this PR up for a day or two in a dev environment.~ We have tested this change in several live user environments with success. I think having it also spend some time in our nightly environments will be to our benefit.

## How was this PR tested?
See above

## Have you made an update to documentation? If so, please provide the corresponding PR.

