### PR TITLE
use badger with jaeger

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1040,6 +1040,15 @@ Begin Kubecost 2.0 templates
 
 {{- define "aggregator.jaeger.sidecarContainerTemplate" }}
 - name: embedded-jaeger
+  env: 
+  - name: SPAN_STORAGE_TYPE
+    value: badger
+  - name: BADGER_EPHEMERAL
+    value: "true"
+  - name: BADGER_DIRECTORY_VALUE
+    value: /tmp/badger/data
+  - name: BADGER_DIRECTORY_KEY
+    value: /tmp/badger/key
   securityContext:
     {{- toYaml .Values.kubecostAggregator.jaeger.containerSecurityContext | nindent 4 }}
   image: {{ .Values.kubecostAggregator.jaeger.image }}:{{ .Values.kubecostAggregator.jaeger.imageVersion }}


### PR DESCRIPTION
## What does this PR change?
Enables Jaeger to use badger, an embedded local storage

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Moved Jaeger to use embedded local storage

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
https://kubecost.atlassian.net/browse/SELFHOST-1168


## What risks are associated with merging this PR? What is required to fully test this PR?
Low to no risk, we may want to keep an eye on deployments running badger, just to ensure jaeger is still tracing properly.

## How was this PR tested?
Ran on gke-dev-1 cluster, observed existence of a badger directory in the file system. Pod logs also reference badger. This was let run for ~12 hours and there are no issues

## Have you made an update to documentation? If so, please provide the corresponding PR.

