### PR TITLE
Fix failed install/template with no values on older versions of Helm3

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -54,7 +54,7 @@ data:
     upstream api {
 {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9001;
-{{- else if and .Values.kubecostFrontend.api .Values.kubecostFrontend.api.fqdn }}
+{{- else if (.Values.kubecostFrontend.api).fqdn }}
         server {{ .Values.kubecostFrontend.api.fqdn }};
 {{- else }}
         server {{ $serviceName }}.{{ .Release.Namespace }}:9001;
@@ -64,7 +64,7 @@ data:
     upstream model {
 {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9003;
-{{- else if and .Values.kubecostFrontend.model .Values.kubecostFrontend.model.fqdn }}
+{{- else if (.Values.kubecostFrontend.model).fqdn }}
         server {{ .Values.kubecostFrontend.model.fqdn }};
 {{- else }}
         server {{ $serviceName }}.{{ .Release.Namespace }}:9003;
@@ -76,7 +76,7 @@ data:
 {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "kubecost.clusterControllerName" . }}-service.{{ .Release.Namespace }}.svc.cluster.local:9731;
 {{- else }}
-{{- if and .Values.kubecostFrontend.clusterController .Values.kubecostFrontend.clusterController.fqdn }}
+{{- if (.Values.kubecostFrontend.clusterController).fqdn }}
         server {{ .Values.kubecostFrontend.clusterController.fqdn }};
 {{- else }}
         server {{ template "kubecost.clusterControllerName" . }}-service.{{ .Release.Namespace }}:9731;
@@ -108,7 +108,7 @@ data:
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ .Release.Name }}-forecasting.{{ .Release.Namespace }}.svc.cluster.local:5000;
         {{- else }}
-        {{- if and .Values.kubecostFrontend.forcasting .Values.kubecostFrontend.forcasting.fqdn }}
+        {{- if (.Values.kubecostFrontend.forcasting).fqdn }}
         server {{ .Values.kubecostFrontend.forcasting.fqdn }};
         {{- else }}
         server {{ .Release.Name }}-forecasting.{{ .Release.Namespace }}:5000;
@@ -122,7 +122,7 @@ data:
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
         {{- else }}
-        {{- if and .Values.kubecostFrontend.aggregator .Values.kubecostFrontend.aggregator.fqdn }}
+        {{- if (.Values.kubecostFrontend.aggregator).fqdn }}
         server {{ .Values.kubecostFrontend.aggregator.fqdn }};
         {{- else }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
@@ -133,7 +133,7 @@ data:
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:9005;
         {{- else }}
-        {{- if and .Values.kubecostFrontend.cloudCost .Values.kubecostFrontend.cloudCost.fqdn }}
+        {{- if (.Values.kubecostFrontend.cloudCost).fqdn }}
         server {{ .Values.kubecostFrontend.cloudCost.fqdn }};
         {{- else }}
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}:9005;
@@ -148,7 +148,7 @@ data:
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9007;
         {{- else}}
-        {{- if and .Values.kubecostFrontend.multiClusterDiagnostics .Values.kubecostFrontend.multiClusterDiagnostics.fqdn }}
+        {{- if (.Values.kubecostFrontend.multiClusterDiagnostics).fqdn }}
         server {{ .Values.kubecostFrontend.multiClusterDiagnostics.fqdn }};
         {{- else }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}:9007;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -586,7 +586,7 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        {{- if eq .Values.kubecostAggregator.env.MEMORY_INTENSIVE_CLUSTER_SIZING "enabled" }}
+        {{- if eq (default .Values.kubecostAggregator.env.MEMORY_INTENSIVE_CLUSTER_SIZING "disabled") "enabled" }}
         location = /model/savings/clusterSizingETL {
             proxy_read_timeout          600;
             proxy_pass http://aggregator/savings/clusterSizingETL;


### PR DESCRIPTION
## What does this PR change?
`helm template kubecost ./cost-analyzer` (and thus also installing with no values) was failing with this error:

`Error: template: cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml:57:52: executing "cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml" at <.Values.kubecostFrontend.api.fqdn>: nil pointer evaluating interface {}.fqdn`
and also this error
`Error: template: cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml:589:15: executing "cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml" at <eq .Values.kubecostAggregator.env.MEMORY_INTENSIVE_CLUSTER_SIZING "enabled">: error calling eq: incompatible types for comparison`

This PR fixes both. See commit messages for the explanation of each fix.

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Fixed an install error when no values are provided -- one or both of the following errors: `nil pointer evaluating interface {}.fqdn` and `error calling eq: incompatible types for comparison`. This error occurred for users of older versions of Helm3. The current version of Helm3, `v3.14.0`, is unaffected.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
The new fqdn feature may not work (I expect this is fine, we use the same pattern elsewhere with parens). The intensive cluster sizing feature may not work.

## How was this PR tested?
`helm template kubecost ./cost-analyzer` failed before, succeeds after
