### PR TITLE
correct image name in values-eks-cost-monitoring.yaml

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -72,7 +72,7 @@ forecasting:
 networkCosts:
   enabled: false
   image:
-    repository: public.ecr.aws/kubecost/kubecost-modeling
+    repository: public.ecr.aws/kubecost/kubecost-network-costs
     tag: v0.17.2
 
 clusterController:


### PR DESCRIPTION
## What does this PR change?
Default values used wrong image name for the networkCosts image.
This PR corrects the image name.
https://gallery.ecr.aws/kubecost/kubecost-network-costs


## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
nothing

## How was this PR tested?
By deploying the helm chart with the adjusted values-eks-cost-monitoring.yaml

## Have you made an update to documentation? If so, please provide the corresponding PR.
no
