### PR TITLE
fix: nginx.conf for saml and oidc endpoints

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -280,6 +280,7 @@ data:
             return 404;
 {{- end }}
         }
+{{- if .Values.oidc.enabled }}
         location /oidc/ {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
@@ -291,6 +292,8 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+{{- end }}
+{{- if .Values.saml.enabled }}
         location /saml/ {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
@@ -302,6 +305,8 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+{{- end }}
+{{-if or .Values.saml.enabled .Values.oidc.enabled}}
         location /login {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
@@ -326,6 +331,7 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+{{- end }}
 
     {{- if .Values.global.grafana.proxy }}
         location /grafana/ {

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -165,7 +165,7 @@ data:
 
         add_header Cache-Control "must-revalidate";
 
-        {{- if.Values.kubecostFrontend.extraServerConfig }}
+        {{- if .Values.kubecostFrontend.extraServerConfig }}
         {{- .Values.kubecostFrontend.extraServerConfig | toString | nindent 8 -}}
         {{- else }}
         large_client_header_buffers 4 32k;
@@ -306,7 +306,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 {{- end }}
-{{-if or .Values.saml.enabled .Values.oidc.enabled}}
+{{- if or .Values.saml.enabled .Values.oidc.enabled}}
         location /login {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -280,7 +280,8 @@ data:
             return 404;
 {{- end }}
         }
-{{- if .Values.oidc.enabled }}
+{{- if and (or .Values.saml.enabled .Values.oidc.enabled) (not (eq (include "aggregator.deployMethod" .) "disabled")) }}
+    {{- if .Values.oidc.enabled }}
         location /oidc/ {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
@@ -292,8 +293,8 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-{{- end }}
-{{- if .Values.saml.enabled }}
+    {{- end }}
+    {{- if .Values.saml.enabled }}
         location /saml/ {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
@@ -305,8 +306,8 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-{{- end }}
-{{- if or .Values.saml.enabled .Values.oidc.enabled}}
+    {{- end }}
+    {{- if or .Values.saml.enabled .Values.oidc.enabled}}
         location /login {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
@@ -331,8 +332,8 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+    {{- end }}
 {{- end }}
-
     {{- if .Values.global.grafana.proxy }}
         location /grafana/ {
         {{- if .Values.saml.enabled }}


### PR DESCRIPTION
## What does this PR change?
This PR fixes the nginx.conf and includes the SAML, OIDC, login and logout endpoints conditional based on the required supplied values. This will help to fix #3172  as those nginx locations doesn't look for aggregator upstream hosts. The SAML, OIDC, Login and Logout endpoints are only supported for Federated Kubecost UI so technically this condition will help achieve those nginx locations.

## Does this PR rely on any other PRs?

Not at the moment.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

All the users using v2.x.x will be able to use Kubecost without enabling aggregator in the secondaries. This is same issue for v2.1.0 and gets fixed for that version as well.

## Links to Issues or tickets this PR addresses or fixes

#3172 

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

## What risks are associated with merging this PR? What is required to fully test this PR?

Tested using the `helm template` function by supplying the below values and saw the output template for nginx configmap if resolving correctly or not.

values supplied:

```
clusterController:
  enabled: true

federatedETL:
  agentOnly: false
  federatedCluster: true

kubecostAggregator:
  enabled: false
  deployMethod: 'disabled'

kubecostFrontend:
  enabled: true
```

The resolved templates looks like below:

```
---
# Source: cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: nginx-conf
  namespace: default
  labels:
    
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-2.0.0
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
data:
  nginx.conf: |
    gzip_static  on;

    # Enable gzip encoding for content of the provided types of 50kb and higher.
    gzip on;
    gzip_min_length 50000;
    gzip_proxied expired no-cache no-store private auth;
    gzip_types
        application/atom+xml
        application/geo+json
        application/javascript
        application/x-javascript
        application/json
        application/ld+json
        application/manifest+json
        application/rdf+xml
        application/rss+xml
        application/vnd.ms-fontobject
        application/wasm
        application/x-web-app-manifest+json
        application/xhtml+xml
        application/xml
        font/eot
        font/otf
        font/ttf
        image/bmp
        image/svg+xml
        text/cache-manifest
        text/calendar
        text/css
        text/javascript
        text/markdown
        text/plain
        text/xml
        text/x-component
        text/x-cross-domain-policy;

    upstream api {
        server release-name-cost-analyzer.default:9001;
    }

    upstream model {
        server release-name-cost-analyzer.default:9003;
    }
    upstream clustercontroller {
        server release-name-cluster-controller-service.default:9731;
    }
    upstream grafana {
        server release-name-grafana.default;
    }
    upstream forecasting {
        server release-name-forecasting.default:5000;
    }

    server {
        server_name _;
        root /var/www;
        index index.html;

        add_header Cache-Control "must-revalidate";
        large_client_header_buffers 4 32k;

        error_page 504 /custom_504.html;
        location = /custom_504.html {
            internal;
        }
        add_header Cache-Control "max-age=300";
        location / {
            try_files $uri $uri/ /index.html;
        }
        add_header ETag "2.0.0";
        listen 9090;
        listen [::]:9090;
        location /api/ {
            proxy_pass http://api/;
            proxy_redirect off;
            proxy_http_version 1.1;
            proxy_set_header Connection "";
            proxy_set_header  X-Real-IP  $remote_addr;
            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
        }
        location /model/ {
            proxy_connect_timeout       300;
            proxy_send_timeout          300;
            proxy_read_timeout          300;
            proxy_pass http://model/;
            proxy_redirect off;
            proxy_http_version 1.1;
            proxy_set_header Connection "";
            proxy_set_header  X-Real-IP  $remote_addr;
            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
        }

        location ~ ^/(turndown|cluster)/ {

            add_header 'Access-Control-Allow-Origin' '*' always;
            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;

            rewrite ^/(?:turndown|cluster)/(.*)$ /$1 break;
            proxy_pass http://clustercontroller;
            proxy_connect_timeout       180;
            proxy_send_timeout          180;
            proxy_read_timeout          180;
            proxy_redirect off;
            proxy_http_version 1.1;
            proxy_set_header Connection "";
            proxy_set_header X-Real-IP  $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        }
        location /grafana/ {
            proxy_pass http://grafana/;
            proxy_redirect off;
            proxy_http_version 1.1;
            proxy_set_header Connection "";
            proxy_set_header  X-Real-IP  $remote_addr;
            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header Host $http_host;
        }
    
        location = /model/hideOrphanedResources {
            default_type 'application/json';
            add_header 'Access-Control-Allow-Origin' '*' always;
            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
            return 200 '{"hideOrphanedResources": "false"}';
        }
        location = /model/hideDiagnostics {
            default_type 'application/json';
            add_header 'Access-Control-Allow-Origin' '*' always;
            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
            return 200 '{"hideDiagnostics": "false"}';
        }

        location /model/multi-cluster-diagnostics-enabled {
            default_type 'application/json';
            add_header 'Access-Control-Allow-Origin' '*' always;
            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
            return 200 '{"multiClusterDiagnosticsEnabled": false}';
        }

        location /model/aggregatorEnabled {
            default_type 'application/json';
            return 200 '{"aggregatorEnabled": "true"}';
        }
        location /forecasting {
            default_type 'application/json';
            add_header 'Access-Control-Allow-Origin' '*' always;
            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
            proxy_read_timeout          300;
            proxy_pass http://forecasting/;
            proxy_redirect off;
            proxy_set_header Connection "";
            proxy_set_header  X-Real-IP  $remote_addr;
            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
        }
        location /model/productConfigs {
            default_type 'application/json';
            add_header 'Access-Control-Allow-Origin' '*' always;
            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
            return 200 '\n
                {
                "ssoConfigured": "false",
                "dataBackupConfigured": "false"
                }
            ';
        }
    }

```

## How was this PR tested?

Using same process as above: `helm template cost-analyzer/ --values values.yaml` (values.yaml as shown above)

## Have you made an update to documentation? If so, please provide the corresponding PR.

No need for any documentation changes as far as i know.
