### PR TITLE
Route /model/savings/clusterSizingETL to Aggregator

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -481,6 +481,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/savings/clusterSizingETL {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/savings/clusterSizingETL;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/cloudCost {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/cloudCost;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -601,16 +601,6 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        {{- if eq (default .Values.kubecostAggregator.env.MEMORY_INTENSIVE_CLUSTER_SIZING "disabled") "enabled" }}
-        location = /model/savings/clusterSizingETL {
-            proxy_read_timeout          600;
-            proxy_pass http://aggregator/savings/clusterSizingETL;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        {{- end }}
         location = /model/reports/allocation {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/reports/allocation;


### PR DESCRIPTION
## What does this PR change?
Title

## Does this PR rely on any other PRs?
- Requires https://github.com/kubecost/kubecost-cost-model/pull/2283

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Reintroduced multi-cluster support in the Cluster Sizing frontend and `/model/savings/clusterSizingETL` API

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/SELFHOST-313