### PR TITLE
Bump Grafana to 10.3.4

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2750,7 +2750,7 @@ grafana:
   ## Container image settings for the Grafana deployment
   image:
     repository: grafana/grafana
-    tag: 10.3.3
+    tag: 10.3.4
     pullPolicy: IfNotPresent
 
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

## What does this PR change?

Bumps Grafana to 10.3.4 to fix a vuln.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Grafana 10.3.4

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

Very low, it's a patch.

## How was this PR tested?

Test in nightly.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A