### PR TITLE
Add log level to network costs

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -68,6 +68,8 @@ spec:
           value: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
         - name: TRAFFIC_LOGGING_ENABLED
           value: {{ (quote .Values.networkCosts.trafficLogging) | default (quote true) }}
+        - name: LOG_LEVEL
+          value: info
         {{- if .Values.networkCosts.softMemoryLimit }}
         - name: GOMEMLIMIT
           value: {{ .Values.networkCosts.softMemoryLimit }}

--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -73,7 +73,7 @@ networkCosts:
   enabled: false
   image:
     repository: public.ecr.aws/kubecost/kubecost-network-costs
-    tag: v0.17.2
+    tag: v0.17.3
 
 clusterController:
   enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2163,7 +2163,7 @@ networkCosts:
   enabled: false
   image:
     repository: gcr.io/kubecost1/kubecost-network-costs
-    tag: v0.17.2
+    tag: v0.17.3
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
## What does this PR change?
Bumps Network Costs image to 0.17.3 that changes noisier log entries to debug and allow for a better experience understanding successful pod state at INFO level.
Adds LOG_LEVEL to environment variable defaulted to info for network costs.

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds info log level as the default for network costs pod, and allows for setting the log level depending on desired level (ERROR|WARN|INFO|DEBUG). 

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

## How was this PR tested?
We have tested our deployments locally to see that INFO log level is in fact quieter while giving pod state and still showing warnings and errors in logs at the default INFO level.

## Have you made an update to documentation? If so, please provide the corresponding PR.

