### PR TITLE
implementation of plugin delivery mechanism

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -708,7 +708,7 @@ spec:
               value: {{ .Values.metricsConfigmapName }}
             {{- end }}
             - name: CUSTOM_COST_ENABLED
-              value: {{ .Values.plugins.enabled | quote }}
+              value: {{ .Values.kubecostModel.plugins.enabled | quote }}
             - name: READ_ONLY
               value: {{ (quote .Values.readonly) | default (quote false) }}
             - name: PROMETHEUS_SERVER_ENDPOINT

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -256,6 +256,18 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if .Values.kubecostModel.plugins.enabled  }}
+        {{- if .Values.kubecostModel.plugins.install.enabled}}
+        - name: install-script
+          configMap:
+            name: {{ template "cost-analyzer.fullname" . }}-install-plugins
+        {{- end }}
+        - name: plugins-dir
+          emptyDir: {}
+        - name: plugins-config
+          secret:
+            secretName:  {{ template "cost-analyzer.fullname" . }}-plugins-config
+        {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
         {{- toYaml .Values.extraVolumes | nindent 8 }}
@@ -296,6 +308,19 @@ spec:
 {{- end }}
 {{- if .Values.supportNFS }}
       initContainers:
+      {{- if (and .Values.kubecostModel.plugins.enabled .Values.kubecostModel.plugins.install.enabled )}}
+        - name: plugin-installer
+          image: {{ .Values.kubecostModel.plugins.install.fullImageName }}
+          command: ["sh", "/install/install_plugins.sh"]
+      {{- with .Values.kubecostModel.plugins.install.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+      {{- end }}
+          volumeMounts:
+            - name: install-script
+              mountPath: /install
+            - name: plugins-dir
+              mountPath: {{ .Values.kubecostModel.plugins.folder }}
+      {{- end }}
         - name: config-db-perms-fix
         {{- if .Values.initChownDataImage }}
           image: {{ .Values.initChownDataImage }}
@@ -518,6 +543,17 @@ spec:
               mountPath: /var/secrets
               readOnly: true
             {{- end }}
+            {{- if .Values.kubecostModel.plugins.enabled }} 
+            - mountPath: /opt/opencost/plugin
+              name: plugins-dir
+              readOnly: false
+            {{- range $key, $config := .Values.kubecostModel.plugins.configs }}
+            - mountPath: /opt/opencost/plugin/config/{{$key}}_config.json
+              subPath: {{$key}}_config.json
+              name: plugins-config
+              readOnly: true
+            {{- end }}
+            {{- end }}
             - name: persistent-configs
               mountPath: /var/configs
             {{- if .Values.extraVolumeMounts }}
@@ -671,6 +707,8 @@ spec:
             - name: METRICS_CONFIGMAP_NAME
               value: {{ .Values.metricsConfigmapName }}
             {{- end }}
+            - name: CUSTOM_COST_ENABLED
+              value: {{ .Values.plugins.enabled | quote }}
             - name: READ_ONLY
               value: {{ (quote .Values.readonly) | default (quote false) }}
             - name: PROMETHEUS_SERVER_ENDPOINT

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -306,8 +306,7 @@ spec:
             claimName: {{ template "cost-analyzer.fullname" . }}-db
 {{- end }}
 {{- end }}
-{{- if .Values.supportNFS }}
-      initContainers:
+      initContainers:   
       {{- if (and .Values.kubecostModel.plugins.enabled .Values.kubecostModel.plugins.install.enabled )}}
         - name: plugin-installer
           image: {{ .Values.kubecostModel.plugins.install.fullImageName }}
@@ -321,6 +320,7 @@ spec:
             - name: plugins-dir
               mountPath: {{ .Values.kubecostModel.plugins.folder }}
       {{- end }}
+      {{- if .Values.supportNFS }}   
         - name: config-db-perms-fix
         {{- if .Values.initChownDataImage }}
           image: {{ .Values.initChownDataImage }}

--- a/cost-analyzer/templates/install-plugins.yaml
+++ b/cost-analyzer/templates/install-plugins.yaml
@@ -34,10 +34,10 @@ data:
       {{- else }}
       VER=$(curl --silent https://api.github.com/repos/opencost/opencost-plugins/releases/latest | grep ".tag_name" | awk -F\" '{print $4}')
       {{- end }}
-
+      
       {{- range $pluginName := .Values.kubecostModel.plugins.configs }}
-      curl -fsSLO "https://github.com/opencost/opencost-plugins/releases/download/$VER/datadog.ocplugin.$OS.$ARCH"
-      chmod a+rx "datadog.ocplugin.$OS.$ARCH"
+      curl -fsSLO "https://github.com/opencost/opencost-plugins/releases/download/$VER/$pluginName.ocplugin.$OS.$ARCH"
+      chmod a+rx "$pluginName.ocplugin.$OS.$ARCH"
       {{- end }}
     {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/install-plugins.yaml
+++ b/cost-analyzer/templates/install-plugins.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.kubecostModel.plugins.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cost-analyzer.fullname" . }}-install-plugins
+  labels:
+   {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  install_plugins.sh: |-
+    {{- if .Values.kubecostModel.plugins.install.enabled }}
+      set -ex
+      rm -f {{ .Values.kubecostModel.plugins.folder }}/bin/*
+      mkdir -p {{ .Values.kubecostModel.plugins.folder }}/bin
+      cd {{ .Values.kubecostModel.plugins.folder }}/bin
+      OSTYPE=$(cat /etc/os-release)
+      OS=''
+      case "$OSTYPE" in
+        *Linux*) OS='linux';;
+        *)         echo "$OSTYPE is unsupported" && exit 1 ;;
+      esac
+
+      UNAME_OUTPUT=$(uname -m)
+      ARCH=''
+      case "$UNAME_OUTPUT" in
+        *x86_64*) ARCH='amd64';;
+        *amd64*) ARCH='amd64';;
+        *aarch64*) ARCH='arm64';;
+        *arm64*) ARCH='arm64';;
+        *)         echo "$UNAME_OUTPUT is unsupported" && exit 1 ;;
+      esac
+
+      {{- if .Values.kubecostModel.plugins.version  }}
+      VER={{ .Values.kubecostModel.plugins.version | quote}}
+      {{- else }}
+      VER=$(curl --silent https://api.github.com/repos/opencost/opencost-plugins/releases/latest | grep ".tag_name" | awk -F\" '{print $4}')
+      {{- end }}
+
+      {{- range $pluginName := .Values.kubecostModel.plugins.configs }}
+      curl -fsSLO "https://github.com/opencost/opencost-plugins/releases/download/$VER/datadog.ocplugin.$OS.$ARCH"
+      chmod a+rx "datadog.ocplugin.$OS.$ARCH"
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/cost-analyzer/templates/install-plugins.yaml
+++ b/cost-analyzer/templates/install-plugins.yaml
@@ -35,9 +35,9 @@ data:
       VER=$(curl --silent https://api.github.com/repos/opencost/opencost-plugins/releases/latest | grep ".tag_name" | awk -F\" '{print $4}')
       {{- end }}
       
-      {{- range $pluginName := .Values.kubecostModel.plugins.configs }}
-      curl -fsSLO "https://github.com/opencost/opencost-plugins/releases/download/$VER/$pluginName.ocplugin.$OS.$ARCH"
-      chmod a+rx "$pluginName.ocplugin.$OS.$ARCH"
+      {{- range $pluginName, $config := .Values.plugins.configs }}
+      curl -fsSLO "https://github.com/opencost/opencost-plugins/releases/download/$VER/{{ $pluginName }}.ocplugin.$OS.$ARCH"
+      chmod a+rx "{{ $pluginName }}.ocplugin.$OS.$ARCH"
       {{- end }}
     {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/install-plugins.yaml
+++ b/cost-analyzer/templates/install-plugins.yaml
@@ -35,7 +35,7 @@ data:
       VER=$(curl --silent https://api.github.com/repos/opencost/opencost-plugins/releases/latest | grep ".tag_name" | awk -F\" '{print $4}')
       {{- end }}
       
-      {{- range $pluginName, $config := .Values.plugins.configs }}
+      {{- range $pluginName, $config := .Values.kubecostModel.plugins.configs }}
       curl -fsSLO "https://github.com/opencost/opencost-plugins/releases/download/$VER/{{ $pluginName }}.ocplugin.$OS.$ARCH"
       chmod a+rx "{{ $pluginName }}.ocplugin.$OS.$ARCH"
       {{- end }}

--- a/cost-analyzer/templates/plugins-config.yaml
+++ b/cost-analyzer/templates/plugins-config.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.kubecostModel.plugins.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "cost-analyzer.fullname" . }}-plugins-config
+  labels:
+     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  {{- range $key, $config := .Values.kubecostModel.plugins.configs }}
+  {{ $key }}_config.json:
+    {{ $config | b64enc | indent 4}}
+  {{- end }}
+{{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -536,7 +536,31 @@ kubecostModel:
   # The name of the Secret containing a bucket config for Federated storage. The contents should be stored
   # under a key named federated-store.yaml.
   # federatedStorageConfigSecret: ""
-
+  plugins:
+    enabled: false
+    install:
+      enabled: true
+      fullImageName: curlimages/curl:latest
+      securityContext:
+        allowPrivilegeEscalation: false
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+    folder: /opt/opencost/plugin
+    # leave this commented to always download most recent version of plugins
+    # version: <INSERT_SPECIFIC_PLUGINS_VERSION>
+    configs:
+      # datadog: |
+      #   {
+      #   "datadog_site": "<INSERT_DATADOG_SITE>",
+      #   "datadog_api_key": "<INSERT_DATADOG_API_KEY>",
+      #   "datadog_app_key": "<INSERT_DATADOG_APP_KEY>"
+      #   }
   ## Feature to view your out-of-cluster costs and their k8s utilization
   ## Ref: https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer
   cloudCost:


### PR DESCRIPTION
## What does this PR change?
adds the plugin delivery mechanism for OC plugins

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Allows users to leverage opencost plugins in kubecost

## Links to Issues or tickets this PR addresses or fixes
related to https://github.com/opencost/opencost-helm-chart/pull/180

https://kubecost.atlassian.net/browse/SELFHOST-1235
https://kubecost.atlassian.net/browse/SELFHOST-1229

## What risks are associated with merging this PR? What is required to fully test this PR?
no risks - disabled by default. even if it is enabled and plugins are downloaded, this is additive and so will be ignored by incompatible versions of KCM 

## How was this PR tested?
test via install into cluster

## Have you made an update to documentation? If so, please provide the corresponding PR.
no, this needs documentation. internal setup docs can serve as a basis for this and are restricted to kubecost staff here: https://docs.google.com/document/d/1JHg0EdVY9CrQhU2RVwuvav9rL1kvKqw4FVz-Hv3x3J0/edit
