### PR TITLE
FIX templating for non-existing nested values of frontend upstreams

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -54,7 +54,7 @@ data:
     upstream api {
 {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9001;
-{{- else if and .Values.kubecostFrontend.api .Values.kubecostFrontend.api.fqdn }}
+{{- else if ((.Values.kubecostFrontend.api).fqdn) }}
         server {{ .Values.kubecostFrontend.api.fqdn }};
 {{- else }}
         server {{ $serviceName }}.{{ .Release.Namespace }}:9001;
@@ -64,19 +64,19 @@ data:
     upstream model {
 {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9003;
-{{- else if and .Values.kubecostFrontend.model .Values.kubecostFrontend.model.fqdn }}
+{{- else if ((.Values.kubecostFrontend.model).fqdn) }}
         server {{ .Values.kubecostFrontend.model.fqdn }};
 {{- else }}
         server {{ $serviceName }}.{{ .Release.Namespace }}:9003;
 {{- end }}
     }
 
-{{- if and .Values.clusterController .Values.clusterController.enabled }}
+{{- if ((.Values.clusterController).enabled) }}
     upstream clustercontroller {
 {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "kubecost.clusterControllerName" . }}-service.{{ .Release.Namespace }}.svc.cluster.local:9731;
 {{- else }}
-{{- if and .Values.kubecostFrontend.clusterController .Values.kubecostFrontend.clusterController.fqdn }}
+{{- if ((.Values.kubecostFrontend.clusterController).fqdn) }}
         server {{ .Values.kubecostFrontend.clusterController.fqdn }};
 {{- else }}
         server {{ template "kubecost.clusterControllerName" . }}-service.{{ .Release.Namespace }}:9731;
@@ -108,7 +108,7 @@ data:
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ .Release.Name }}-forecasting.{{ .Release.Namespace }}.svc.cluster.local:5000;
         {{- else }}
-        {{- if and .Values.kubecostFrontend.forcasting .Values.kubecostFrontend.forcasting.fqdn }}
+        {{- if ((.Values.kubecostFrontend.forcasting).fqdn) }}
         server {{ .Values.kubecostFrontend.forcasting.fqdn }};
         {{- else }}
         server {{ .Release.Name }}-forecasting.{{ .Release.Namespace }}:5000;
@@ -122,7 +122,7 @@ data:
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
         {{- else }}
-        {{- if and .Values.kubecostFrontend.aggregator .Values.kubecostFrontend.aggregator.fqdn }}
+        {{- if ((.Values.kubecostFrontend.aggregator).fqdn) }}
         server {{ .Values.kubecostFrontend.aggregator.fqdn }};
         {{- else }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
@@ -133,7 +133,7 @@ data:
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:9005;
         {{- else }}
-        {{- if and .Values.kubecostFrontend.cloudCost .Values.kubecostFrontend.cloudCost.fqdn }}
+        {{- if ((.Values.kubecostFrontend.cloudCost).fqdn) }}
         server {{ .Values.kubecostFrontend.cloudCost.fqdn }};
         {{- else }}
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}:9005;
@@ -148,7 +148,7 @@ data:
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9007;
         {{- else}}
-        {{- if and .Values.kubecostFrontend.multiClusterDiagnostics .Values.kubecostFrontend.multiClusterDiagnostics.fqdn }}
+        {{- if ((.Values.kubecostFrontend.multiClusterDiagnostics).fqdn) }}
         server {{ .Values.kubecostFrontend.multiClusterDiagnostics.fqdn }};
         {{- else }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}:9007;


### PR DESCRIPTION
[this commit](https://github.com/kubecost/cost-analyzer-helm-chart/commit/133c886096a616a9fb33b48b3feb76223a490d7d) introduced a bug where helm fails on non-existing nested values.


## What does this PR change?
Correct handling of non-existing nested values introduced in [commit](https://github.com/kubecost/cost-analyzer-helm-chart/commit/133c886096a616a9fb33b48b3feb76223a490d7d)
Example of the error:
```
Error: Failed to render chart: exit status 1: Error: template: cost-analyzer/charts/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml:57:52: executing cost-analyzer/charts/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml at <.Values.kubecostFrontend.api.fqdn>: nil pointer evaluating interface {}.fqdn
```

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixes helm failure if value doesn't exist

## What risks are associated with merging this PR? What is required to fully test this PR?
I can't think of any risks.
To test just try to install version with the fix and values that worked before v2.1.0 release.

## How was this PR tested?
Helm release was updated from v2.0.2 to v2.1.0 (v2.1.0 was built from this branch)


## Have you made an update to documentation? If so, please provide the corresponding PR.
Not needed
