### PR TITLE
Update which FQDN/port forecasting deployment points to depending on whether SSO is enabled in the environment.

### DIFF
--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -67,8 +67,13 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /var/configs/
+            {{- if or .Values.saml.enabled .Values.oidc.enabled }}
             - name: KCM_BASE_URL
-              value: http://{{ template "cost-analyzer.serviceName" . }}:9090/model
+              value: http://{{ template "aggregator.serviceName" . }}:9008
+            {{- else }}
+            - name: KCM_BASE_URL
+              value: http://{{ template "aggregator.serviceName" . }}:9004
+            {{- end }}
             - name: MODEL_STORAGE_PATH
               value: "/tmp/localrun/models"
             - name: PAGE_ITEM_LIMIT


### PR DESCRIPTION
## What does this PR change?

Update which FQDN/port forecasting deployment points to depending on whether SSO is enabled in the environment.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Previously, forecasting features did not work when user had SSO enabled

## Links to Issues or tickets this PR addresses or fixes

Closes https://kubecost.atlassian.net/browse/GTM-224

## What risks are associated with merging this PR? What is required to fully test this PR?

I've swapped the FQDN here from `cost-analyzer` to `aggregator`, because in theory the aggregator should be able to serve all queries Forecasting feature needs. This needs time under test in the nightly environment though because this was not the initial design. cc @jessegoodier 

## How was this PR tested?

### Default values

```sh
$ helm template ./cost-analyzer | grep -C 3 "KCM_BASE_URL"
          env:
            - name: CONFIG_PATH
              value: /var/configs/
            - name: KCM_BASE_URL
              value: http://release-name-aggregator:9004
            - name: MODEL_STORAGE_PATH
              value: "/tmp/localrun/models"
```

### With SSO enabled

```yaml
saml:
  enabled: true
```

```sh
$ helm template ./cost-analyzer -f values.yaml | grep -C 3 "KCM_BASE_URL"
          env:
            - name: CONFIG_PATH
              value: /var/configs/
            - name: KCM_BASE_URL
              value: http://release-name-aggregator:9008
            - name: MODEL_STORAGE_PATH
              value: "/tmp/localrun/models"
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A