### PR TITLE
Mount oidc secret when existingCustomSecret is used

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -941,7 +941,7 @@ Begin Kubecost 2.0 templates
     {{- if .Values.oidc.enabled }}
     - name: oidc-config
       mountPath: /var/configs/oidc
-    {{- if .Values.oidc.secretName }}
+    {{- if or .Values.oidc.existingCustomSecret.name .Values.oidc.secretName }}
     - name: oidc-client-secret
       mountPath: /var/configs/oidc-client-secret
     {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -647,7 +647,7 @@ spec:
             {{- if .Values.oidc.enabled }}
             - name: oidc-config
               mountPath: /var/configs/oidc
-            {{- if .Values.oidc.secretName }}
+            {{- if or .Values.oidc.existingCustomSecret.name .Values.oidc.secretName }}
             - name: oidc-client-secret
               mountPath: /var/configs/oidc-client-secret
             {{- end }}


### PR DESCRIPTION
## What does this PR change?
Currently, when users specify existingCustomSecret (and .Values.oidc.secretName is empty) in the OIDC config, the secret is not mounted. This PR addresses this issue by ensuring that the existingCustomSecret is mounted.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
This update allows users to utilize existingCustomSecret for OIDC configurations.

## Links to Issues or tickets this PR addresses or fixes
[ZD-5936](https://kubecost.zendesk.com/agent/tickets/5936)


## What risks are associated with merging this PR? What is required to fully test this PR?
The risks associated with this PR are minimal. To conduct thorough testing, it's advisable to test enabling OIDC with existingCustomSecret.

## How was this PR tested?

Manually by using the following files and commands

oidc-existingCustomSecret-enabled.yaml
```
oidc:
  enabled: true
  existingCustomSecret:
    enabled: true
    name: "my-secret-name-2"
```

oidc-existingCustomSecret-disabled.yaml
```
oidc:
  enabled: true
  secretName: "my-secret-name"
  existingCustomSecret:
    enabled: false
    name: "my-secret-name-2"

```
and generating template by running two commands:

`helm template kubecost   --repo https://kubecost.github.io/cost-analyzer/ cost-analyzer --namespace kubecost --create-namespace -f oidc-existingCustomSecret-enabled.yaml > kubecost-existingCustomSecret-enabled.yaml
`
`helm template kubecost   --repo https://kubecost.github.io/cost-analyzer/ cost-analyzer --namespace kubecost --create-namespace -f oidc-existingCustomSecret-enabled.yaml > kubecost-existingCustomSecret-disabled.yaml
`
Verifying:

BEFORE
```
grep "/var/configs/oidc-client-secret" kubecost-existingCustomSecret-disabled.yaml
              mountPath: /var/configs/oidc-client-secret
              mountPath: /var/configs/oidc-client-secret

```
`grep "/var/configs/oidc-client-secret" kubecost-existingCustomSecret-enabled.yaml
`
AFTER
`helm template chartmuseum  --repo  http://localhost:8080  cost-analyzer --namespace kubecost --create-namespace -f oidc-existingCustomSecret-enabled.yaml > kubecost-existingCustomSecret-enabled-AFTER.yaml
`
```
grep "/var/configs/oidc-client-secret" kubecost-existingCustomSecret-enabled-AFTER.yaml
              mountPath: /var/configs/oidc-client-secret
              mountPath: /var/configs/oidc-client-secret
```

`helm template chartmuseum  --repo  http://localhost:8080  cost-analyzer --namespace kubecost --create-namespace -f oidc-existingCustomSecret-disabled.yaml > kubecost-existingCustomSecret-disabled-AFTER.yaml
`
```
grep "/var/configs/oidc-client-secret" kubecost-existingCustomSecret-disabled-AFTER.yaml
              mountPath: /var/configs/oidc-client-secret
              mountPath: /var/configs/oidc-client-secret
```

## Have you made an update to documentation? If so, please provide the corresponding PR.
N/A
