### PR TITLE
provide mechanism to use pre-existing secret

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -264,9 +264,14 @@ spec:
         {{- end }}
         - name: plugins-dir
           emptyDir: {}
+        
         - name: plugins-config
           secret:
-            secretName:  {{ template "cost-analyzer.fullname" . }}-plugins-config
+            {{- if (eq .Values.kubecostModel.plugins.configSecret "") }}
+            secretName: {{ template "cost-analyzer.fullname" . }}-plugins-config
+            {{- else }}
+            secretName: {{  .Values.kubecostModel.plugins.configSecret }}
+            {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
@@ -547,7 +552,7 @@ spec:
             - mountPath: /opt/opencost/plugin
               name: plugins-dir
               readOnly: false
-            {{- range $key, $config := .Values.kubecostModel.plugins.configs }}
+            {{- range $key := .Values.kubecostModel.plugins.enabledPlugins }}
             - mountPath: /opt/opencost/plugin/config/{{$key}}_config.json
               subPath: {{$key}}_config.json
               name: plugins-config

--- a/cost-analyzer/templates/install-plugins.yaml
+++ b/cost-analyzer/templates/install-plugins.yaml
@@ -35,7 +35,7 @@ data:
       VER=$(curl --silent https://api.github.com/repos/opencost/opencost-plugins/releases/latest | grep ".tag_name" | awk -F\" '{print $4}')
       {{- end }}
       
-      {{- range $pluginName, $config := .Values.kubecostModel.plugins.configs }}
+      {{- range $pluginName := .Values.kubecostModel.plugins.enabledPlugins }}
       curl -fsSLO "https://github.com/opencost/opencost-plugins/releases/download/$VER/{{ $pluginName }}.ocplugin.$OS.$ARCH"
       chmod a+rx "{{ $pluginName }}.ocplugin.$OS.$ARCH"
       {{- end }}

--- a/cost-analyzer/templates/plugins-config.yaml
+++ b/cost-analyzer/templates/plugins-config.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.kubecostModel.plugins.enabled }}
+{{- if (eq .Values.kubecostModel.plugins.configSecret "") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,4 +11,5 @@ data:
   {{ $key }}_config.json:
     {{ $config | b64enc | indent 4}}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -554,7 +554,15 @@ kubecostModel:
     folder: /opt/opencost/plugin
     # leave this commented to always download most recent version of plugins
     # version: <INSERT_SPECIFIC_PLUGINS_VERSION>
-    configs:
+    # the list of enabled plugins
+    enabledPlugins: []
+      # - datadog
+
+    # pre-existing secret for plugin configuration
+    configSecret: ""
+
+    # uncomment this to define plugin configuration via the values file
+    # configs:
       # datadog: |
       #   {
       #   "datadog_site": "<INSERT_DATADOG_SITE>",


### PR DESCRIPTION
## What does this PR change?
adds config to allow pre-existing secrets to be used for plugin config

## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
allows users to define their own secrets containing plugin config 

## What risks are associated with merging this PR? What is required to fully test this PR?
disabled by default

## How was this PR tested?
used helm template, manually inspected result

## Have you made an update to documentation? If so, please provide the corresponding PR.

