### PR TITLE
Expose /heatlhz check for cost-analyzer-frontend, if OIDC is enabled.

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -188,6 +188,10 @@ data:
             error_page 401 = /login;
             try_files $uri $uri/ /index.html;
         }
+        location /healthz {
+            add_header 'Content-Type' 'text/plain';
+            return 200 "healthy\n";
+        }
 {{- else }}
         add_header Cache-Control "max-age=300";
         location / {


### PR DESCRIPTION
## What does this PR change?
This exposes the /heatlhz check for the cost-analyzer-frontend, if OIDC is enabled.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Expose /heatlhz check for cost-analyzer-frontend, if OIDC is enabled.

This issue is being reported on behalf of our customer, who utilizes network endpoint groups (NEGs) to distribute traffic to the load balancer's backends. In certain scenarios, when OIDC is enabled, it has been identified that regular health checks appear to go unauthenticated. This situation is causing disruptions for users attempting to connect to the Kubecost UI.

## Links to Issues or tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/3231

- https://kubecost.slack.com/archives/C06C05DGY6M/p1709851817934499



## What risks are associated with merging this PR? What is required to fully test this PR?
We need to sanity check if exposing /heatlhz without auth is a good security practice, opening this PR for discussion


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

