### PR TITLE
Add filter-based config to the Helm ("YAML") Actions config

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2613,7 +2613,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.15.2
+    tag: v0.16.0
   imagePullPolicy: Always
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2661,14 +2661,47 @@ clusterController:
         #   allowSharedCore: false
         # allowCostIncrease: false
         # recommendationType: ''
-    # this configures the Kubecost Request Sizing action
-    # for more details, see documentation at https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/savings/savings-actions#automated-request-sizing
+    # This configures the Kubecost Continuous Request Sizing Action
+    #
+    # Using this configuration overrides annotation-based configuration of
+    # Continuous Request Sizing. Annotation configuration will be ignored while
+    # this configuration method is present in the cluster.
+    #
+    # For more details, see documentation at https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/savings/savings-actions#automated-request-sizing
     containerRightsize:
+      # Workloads can be selected by an _exact_ key (namespace, controllerKind,
+      # controllerName). This will only match a single controller. The cluster
+      # ID is current irrelevant because Cluster Controller can only modify
+      # workloads within the cluster it is running in.
       #  workloads:
       #   - clusterID: cluster-one
       #     namespace: my-namespace
       #     controllerKind: deployment
       #     controllerName: my-controller
+      # An alternative to exact key selection is filter selection. The filters
+      # are syntactically identical to Kubecost's "v2" filters [1] but only
+      # support a small set of filter fields, those being:
+      # - namespace
+      # - controllerKind
+      # - controllerName
+      # - label
+      # - annotation
+      #
+      # If multiple filters are listed, they will be ORed together at the top
+      # level.
+      #
+      # See the examples below.
+      #
+      # [1] https://docs.kubecost.com/apis/apis-overview/filters-api
+      # filterConfig:
+      #   - filter: |
+      #       namespace:"abc"+controllerKind:"deployment"
+      #   - filter: |
+      #       controllerName:"abc123"+controllerKind:"daemonset"
+      #   - filter: |
+      #       namespace:"foo"+controllerKind!:"statefulset"
+      #   - filter: |
+      #       namespace:"bar","baz"
       #  schedule:
       #   start: "2024-01-30T15:04:05Z"
       #   frequencyMinutes: 5


### PR DESCRIPTION
## What does this PR change?
Adds an example of the new filter-based Actions config and updates the CC image to one that supports this new feature. Updated Cluster Controller image with the functionality implementing this config.

## Does this PR rely on any other PRs?
Pairs with https://github.com/kubecost/cluster-controller/pull/71

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Added the ability to configure the Continuous Request Right-Sizing Action in the Helm chart by using filters. The exact workload key is still supported, but now it is also possible to express `namespace:"foo"+controllerKind:"deployment"` so that all Deployments in the `foo` namespace will be resized automatically.

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/SELFHOST-1274

## How was this PR tested?
Due to having a lot on my plate, we opted to defer this to QA.