### PR TITLE
Use array instead of object as tolerations default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -665,7 +665,7 @@ etlUtils:
   resources: {}
   env: {}
   nodeSelector: {}
-  tolerations: {}
+  tolerations: []
   affinity: {}
 
 # Basic Kubecost ingress, more examples available at https://github.com/kubecost/docs/blob/main/ingress-examples.md
@@ -2375,7 +2375,7 @@ forecasting:
   nodeSelector: {}
 
   # Define tolerations for the forecasting Deployment.
-  tolerations: {}
+  tolerations: []
 
   # Define Pod affinity for the forecasting Deployment.
   affinity: {}
@@ -2535,7 +2535,7 @@ kubecostAggregator:
     # nodeSelector: {}
 
     ## Tolerations for the aggregator cloud costs
-    # tolerations: {}
+    # tolerations: []
 
     ## Affinity for the aggregator cloud costs
     # affinity: {}
@@ -2602,7 +2602,7 @@ diagnostics:
     securityContext: {}
     containerSecurityContext: {}
     nodeSelector: {}
-    tolerations: {}
+    tolerations: []
     affinity: {}
 
 ## Provide a full name override for the diagnostics Deployment.


### PR DESCRIPTION
## What does this PR change?

Changes `values.yaml` `tolerations` properties from `{}` to `[]`

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Fixes warnings when trying to define tolerations:

```
coalesce.go:286: warning: cannot overwrite table with non table for kubecost.cost-analyzer.forecasting.tolerations (map[])
```

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Not that I'm aware of


## What risks are associated with merging this PR? What is required to fully test this PR?

Shouldn't be any risks

## How was this PR tested?

Created `values-test.yaml` with content:

```
forecasting:
  tolerations:
    - key: "test"
      operator: "Equal"
      value: "true"
      effect: "NoSchedule"
```

and ran:

```
> helm template . -f values.yaml -f values-test.yaml > output.yaml                                                            
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

I don't think there is anything to update?