### PR TITLE
Add carbon estimates config values

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -993,6 +993,10 @@ Begin Kubecost 2.0 templates
     - name: no_proxy
       value:  {{ .Values.systemProxy.noProxy }}
     {{- end }}
+    {{- if .Values.kubecostProductConfigs.carbonEstimates }}
+    - name: CARBON_ESTIMATES_ENABLED
+      value: "true"
+    {{- end }}
     {{- if .Values.kubecostAggregator.extraEnv -}}
     {{- toYaml .Values.kubecostAggregator.extraEnv | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -993,7 +993,7 @@ Begin Kubecost 2.0 templates
     - name: no_proxy
       value:  {{ .Values.systemProxy.noProxy }}
     {{- end }}
-    {{- if .Values.kubecostProductConfigs.carbonEstimates }}
+    {{- if ((.Values.kubecostProductConfigs).carbonEstimates) }}
     - name: CARBON_ESTIMATES_ENABLED
       value: "true"
     {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -428,6 +428,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/allocation/carbon {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/allocation/carbon;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/assets {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/assets;
@@ -464,6 +472,14 @@ data:
         location = /model/assets/autocomplete {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/assets/autocomplete;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/assets/carbon {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/assets/carbon;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
@@ -947,6 +963,14 @@ data:
         location = /model/diagnostic/nodeDuplicateNoId {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/diagnostic/nodeDuplicateNoId;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/enablements {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/enablements;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3228,6 +3228,7 @@ costEventsAudit:
 #     enabled: false
 #     secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }. If the secretname is specified, a configmap with the key will not be created
 #     mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
+#   carbonEstimates: false # Enables Kubecost beta carbon estimation endpoints /assets/carbon and /allocations/carbon 
 
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain
   ## a key with name `cloud-integration.json` and the contents must be in a specific format. It is expected

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3228,7 +3228,7 @@ costEventsAudit:
 #     enabled: false
 #     secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }. If the secretname is specified, a configmap with the key will not be created
 #     mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
-#   carbonEstimates: false # Enables Kubecost beta carbon estimation endpoints /assets/carbon and /allocations/carbon 
+#   carbonEstimates: false # Enables Kubecost beta carbon estimation endpoints /assets/carbon and /allocations/carbon
 
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain
   ## a key with name `cloud-integration.json` and the contents must be in a specific format. It is expected


### PR DESCRIPTION
## What does this PR change?
Adds supporting configs + nginx proxy values to helm chart to support carbon estimates functionality in Kubecost.

## Does this PR rely on any other PRs?
https://github.com/kubecost/kubecost-cost-model/pull/2312

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds ability to enable carbon emissions estimation endpoints in Kubecost.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Templated nginx configmap and aggregator deployment with new values.

## Have you made an update to documentation? If so, please provide the corresponding PR.

