### PR TITLE
containerStats on by default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -605,7 +605,7 @@ kubecostModel:
   # please monitor Kubecost logs, Thanos query logs, and Thanos load closely.
   # We hope to make major improvements at scale here soon!
   #
-  # containerStatsEnabled: false
+  containerStatsEnabled: true  # enabled by default as of v2.2.0
 
   # max number of concurrent Prometheus queries
   maxQueryConcurrency: 5


### PR DESCRIPTION
## What does this PR change?
Turn on containerStats by default

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
containerStats pipeline is now enabled by default, can be manually disabled. See more detail:  <https://docs.kubecost.com/architecture/containerstats-pipeline>

## What risks are associated with merging this PR? What is required to fully test this PR?
None, long-term value that is already frequently enabled. Just need to communicate change in release notes.

## How was this PR tested?
Countless environments have this one for many versions

## Have you made an update to documentation? If so, please provide the corresponding PR.

Brett, can you quickly update this to refelct the fact that it is now on by default? <https://docs.kubecost.com/architecture/containerstats-pipeline>