### PR TITLE
Fix Kubecost UI stuck at 'Oh No!' for SAML users after upgrade

### DIFF
--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -44,6 +44,8 @@ spec:
       labels:
         app.kubernetes.io/name: aggregator
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{/* Force pod restarts on upgrades to ensure the nginx config is current */}}
+        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
         app: aggregator
         {{- with .Values.global.additionalLabels }}
         {{- toYaml . | nindent 8 }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -37,6 +37,8 @@ spec:
     metadata:
       labels:
         {{- include "cost-analyzer.selectorLabels" . | nindent 8 }}
+        {{/* Force pod restarts on upgrades to ensure the nginx config is current */}}
+        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
         {{- if .Values.global.additionalLabels }}
         {{ toYaml .Values.global.additionalLabels | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## What does this PR change?
Force aggregator and cost model pods to restart during a helm upgrade

The problem I have been able to reproduce is caused by the following order of operations:
1) helm upgrade initiated
2) There is no update to cost analyzer
3) The saml secret gets regenerated and updated
4) aggregator is redeployed, with the updated secret mounted.

(The reverse is also possible, where aggregator is not updated, and cost analyzer is.)

The secret used to sign SAML tokens no longer match, therefore the cost analyzer can no longer decrypt tokens issued by aggregator. The easiest solution here is to force a restart of both pods to keep the secret synchronized.

If accepted, this will be cherry picked for 2.1 and 2.2.

## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Resolves issue for SAML users after upgrade where the UI is stuck on the 'Oh No!' page. 

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/GTM-236

## What risks are associated with merging this PR? What is required to fully test this PR?
Minimal

## How was this PR tested?
Manually

## Have you made an update to documentation? If so, please provide the corresponding PR.
None required
