### PR TITLE
bump modeling image 0.1.5

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -67,7 +67,7 @@ kubecostModel:
     #  memory: "256Mi"
 
 forecasting:
-  fullImageName: public.ecr.aws/kubecost/kubecost-modeling:v0.1.2
+  fullImageName: public.ecr.aws/kubecost/kubecost-modeling:v0.1.5
 
 networkCosts:
   enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2357,7 +2357,7 @@ forecasting:
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
   # Example: fullImageName: gcr.io/kubecost1/forecasting:v0.0.1
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.4
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.5
 
   # Resource specification block for the forecasting container.
   resources:


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
* Adds new modeling image with more stable and better predictions for allocations, assets, and cloudcosts

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Will improve the kubecost-forecasting pod stability as well as improve the predictions given for assets, allocations, and cloud costs.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Deployed to my development namespace for testing

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA - no functional changes here just stability and accuracy improvements
