### PR TITLE
allow future carbonEstimates configuration

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1020,7 +1020,7 @@ Begin Kubecost 2.0 templates
     - name: no_proxy
       value:  {{ .Values.systemProxy.noProxy }}
     {{- end }}
-    {{- if ((.Values.kubecostProductConfigs).carbonEstimates) }}
+    {{- if (((.Values.kubecostProductConfigs).carbonEstimates).enabled) }}
     - name: CARBON_ESTIMATES_ENABLED
       value: "true"
     {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3236,7 +3236,8 @@ costEventsAudit:
 #     enabled: false
 #     secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }. If the secretname is specified, a configmap with the key will not be created
 #     mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
-#   carbonEstimates: false # Enables Kubecost beta carbon estimation endpoints /assets/carbon and /allocations/carbon
+#   carbonEstimates:
+#     enabled: false  # Beta- enables Kubecost carbon estimation
 
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain
   ## a key with name `cloud-integration.json` and the contents must be in a specific format. It is expected


### PR DESCRIPTION
## What does this PR change?
Allows for future options on carbonEstimates

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
NA, unpublished feature

## What risks are associated with merging this PR? What is required to fully test this PR?
NA, unpublished feature

## How was this PR tested?
upgraded nightly with:

```yaml
kubecostProductConfigs:
  carbonEstimates:
    enabled: true
```

## Have you made an update to documentation? If so, please provide the corresponding PR.
@bstuder99 FYI on helm value change.
