### PR TITLE
Aggregator license key

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -940,6 +940,10 @@ Begin Kubecost 2.0 templates
       # of the init container that gives everything under /var/configs 777.
       mountPath: /var/configs/waterfowl
     {{- end }}
+    {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname (eq (include "aggregator.deployMethod" .) "statefulset") }}
+    - name: productkey-secret
+      mountPath: /var/configs/productkey
+    {{- end }}
     {{- if .Values.saml }}
     {{- if .Values.saml.enabled }}
     {{- if .Values.saml.secretName }}
@@ -987,6 +991,10 @@ Begin Kubecost 2.0 templates
         configMapKeyRef:
           name: {{ .Values.prometheus.server.clusterIDConfigmap }}
           key: CLUSTER_ID
+    {{- end }}
+    {{- if and ((.Values.kubecostProductConfigs).productKey).mountPath (eq (include "aggregator.deployMethod" .) "statefulset") }}
+    - name: PRODUCT_KEY_MOUNT_PATH
+      value: {{ .Values.kubecostProductConfigs.productKey.mountPath }}
     {{- end }}
     {{- if (gt (int .Values.kubecostAggregator.numDBCopyPartitions) 0) }}
     - name: NUM_DB_COPY_CHUNKS

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -89,6 +89,14 @@ spec:
         {{- else }}
         {{- fail "\n\nKubecost Aggregator Enterprise Config requires .Values.kubecostModel.federatedStorageConfigSecret" }}
         {{- end }}
+        {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname }}
+        - name: productkey-secret
+          secret:
+            secretName: {{ .Values.kubecostProductConfigs.productKey.secretname }}
+            items:
+            - key: productkey.json
+              path: productkey.json
+        {{- end }}
         {{- if .Values.saml }}
         {{- if .Values.saml.enabled }}
         {{- if .Values.saml.secretName }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -112,8 +112,7 @@ spec:
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
         {{- end }}
         {{- if .Values.kubecostProductConfigs }}
-        {{- if .Values.kubecostProductConfigs.productKey }}
-        {{- if and .Values.kubecostProductConfigs.productKey.enabled .Values.kubecostProductConfigs.productKey.secretname }}
+        {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname }}
         - name: productkey-secret
           secret:
             secretName: {{ .Values.kubecostProductConfigs.productKey.secretname }}
@@ -121,7 +120,6 @@ spec:
             - key: productkey.json
               path: productkey.json
         {{- end }}
-        {{- end -}}
         {{- if .Values.kubecostProductConfigs }}
         {{- if .Values.kubecostProductConfigs.gcpSecretName }}
         - name: gcp-key-secret
@@ -593,11 +591,9 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs }}
-            {{- if .Values.kubecostProductConfigs.productKey }}
-            {{- if .Values.kubecostProductConfigs.productKey.secretname }}
+            {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname }}
             - name: productkey-secret
               mountPath: /var/configs/productkey
-            {{- end }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
             - name: gcp-key-secret
@@ -748,11 +744,9 @@ spec:
               value: production
             {{- end }}
             {{- if .Values.kubecostProductConfigs }}
-            {{- if .Values.kubecostProductConfigs.productKey }}
-            {{- if .Values.kubecostProductConfigs.productKey.mountPath }}
+            {{- if ((.Values.kubecostProductConfigs).productKey).mountPath }}
             - name: PRODUCT_KEY_MOUNT_PATH
               value: {{ .Values.kubecostProductConfigs.productKey.mountPath }}
-            {{- end }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs.ingestPodUID }}
             - name: INGEST_POD_UID

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3231,11 +3231,11 @@ costEventsAudit:
 #   shareTenancyCosts: true # enable or disable sharing costs such as cluster management fees (defaults to "true" on Settings page)
 #   metricsConfigs: # configuration for metrics emitted by Kubecost
 #     disabledMetrics: [] # list of metrics that Kubecost will not emit. Note that disabling metrics can lead to unexpected behavior in the cost-model.
-#   productKey: # apply business or enterprise product license
-#     key: ""
+#   productKey: # Apply enterprise product license
 #     enabled: false
-#     secretname: productkeysecret # create a secret out of a file named productkey.json of format { "key": "kc-b1325234" }. If the secretname is specified, a configmap with the key will not be created
-#     mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "kc-b1325234" }
+#     key: ""
+#     secretname: productkeysecret # Reference an existing k8s secret created from a file named productkey.json of format { "key": "enterprise-key-here" }. If the secretname is specified, a configmap with the key will not be created.
+#     mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) Declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "enterprise-key-here" }.
 #   carbonEstimates: false # Enables Kubecost beta carbon estimation endpoints /assets/carbon and /allocations/carbon
 
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain


### PR DESCRIPTION
## What does this PR change?

Instantiates product key in aggregator when run as a Statefulset.

## Does this PR rely on any other PRs?

Helm PR for https://github.com/kubecost/kubecost-cost-model/pull/2331

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A 

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

N/A

## How was this PR tested?

### Test 1 (secret + singlepod)

```yaml
kubecostProductConfigs:
  productKey:
    enabled: true
    secretname: "thomasn-product-key"
```

```sh
helm template ./cost-analyzer -f values.yaml
```

```sh
kubectl create secret generic thomasn-product-key --from-literal=productkey.json='{"key":"my-secret-here"}'
helm upgrade -i thomasn-agg-pkey cost-analyzer --repo https://kubecost.github.io/cost-analyzer/ -f values-agg-pkey.yaml
```

Validated that productkey-secret volume is created for `cost-analyzer`.

### Test 2 (secret + statefulset)

```yaml
kubecostProductConfigs:
  productKey:
    enabled: true
    secretname: "thomasn-product-key"
kubecostAggregator:
  deployMethod: "statefulset"
kubecostModel:
  federatedStorageConfigSecret: "federated-store"
```

```sh
helm template ./cost-analyzer -f values.yaml
```

```sh
kubectl create secret generic thomasn-product-key --from-literal=productkey.json='{"key":"my-secret-here"}'
kubectl create secret generic federated-store --from-literal=federated-store.yaml=test
helm upgrade -i thomasn-agg-pkey cost-analyzer --repo https://kubecost.github.io/cost-analyzer/ -f values-agg-pkey.yaml
```

Validated that productkey-secret volume is created for `cost-analyzer` deployment and `aggregator` statefulset.

### Test 3 (mountpath + singlepod)

```yaml
kubecostProductConfigs:
  productKey:
    enabled: true
    mountPath: "/etc/kubecost/productkey.json"
```

```sh
helm template ./cost-analyzer -f values.yaml

            - name: PRODUCT_KEY_MOUNT_PATH
              value: /etc/kubecost/productkey.json
```

Validated that env var is created in `cost-analyzer` deployment.

### Test 4 (mountpath + statefulset)

```yaml
kubecostProductConfigs:
  productKey:
    enabled: true
    mountPath: "/etc/kubecost/productkey.json"
kubecostAggregator:
  deployMethod: "statefulset"
kubecostModel:
  federatedStorageConfigSecret: "federated-store"
```

```sh
helm template ./cost-analyzer -f values.yaml
```

Validated that env var is created in `cost-analyzer` deployment. And also created in `aggregator` statefulset.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A
