### PR TITLE
Route `/customCost` endpoints to Aggregator

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -976,6 +976,22 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/customCost/total {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/customCost/total;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/customCost/timeseries {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/customCost/timeseries;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
 
         #Cloud Cost Endpoints
         location = /model/cloudCost/status {


### PR DESCRIPTION
## What does this PR change?
* Routes `/customCost/total` and `/customCost/timeseries` to Aggregator.

## Does this PR rely on any other PRs?
* Nope.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Custom Cost queries will now be handled by Aggregator.

## What risks are associated with merging this PR? What is required to fully test this PR?
* Custom Cost queries will now be handled by Aggregator instead of cost-model. Both Aggregator and cost-model Custom Cost implementations are new and hardly-tested, so to me, the risk is minimal.

## How was this PR tested?
* Deployed to own namespace, verified queries are handled by Aggregator.