### PR TITLE
Route Custom Cost endpoints and default-enable plugins

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1193,8 +1193,7 @@ Begin Kubecost 2.0 templates
     - name: tmp
       mountPath: /tmp
     {{- range $key := .Values.kubecostModel.plugins.enabledPlugins }}
-    - mountPath: {{ $.Values.kubecostModel.plugins.folder }}/config/{{$key}}_config.json
-      subPath: {{$key}}_config.json
+    - mountPath: {{ $.Values.kubecostModel.plugins.folder }}/config
       name: plugins-config
       readOnly: true
     {{- end }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1186,6 +1186,19 @@ Begin Kubecost 2.0 templates
     - name: cloud-integration
       mountPath: /var/configs/cloud-integration
   {{- end }}
+    {{- if .Values.kubecostModel.plugins.enabled }}
+    - mountPath: {{ .Values.kubecostModel.plugins.folder }}
+      name: plugins-dir
+      readOnly: false
+    - name: tmp
+      mountPath: /tmp
+    {{- range $key := .Values.kubecostModel.plugins.enabledPlugins }}
+    - mountPath: /opt/opencost/plugin/config/{{$key}}_config.json
+      subPath: {{$key}}_config.json
+      name: plugins-config
+      readOnly: true
+    {{- end }}
+    {{- end }}
   env:
     - name: CONFIG_PATH
       value: /var/configs/

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1193,7 +1193,7 @@ Begin Kubecost 2.0 templates
     - name: tmp
       mountPath: /tmp
     {{- range $key := .Values.kubecostModel.plugins.enabledPlugins }}
-    - mountPath: /opt/opencost/plugin/config/{{$key}}_config.json
+    - mountPath: {{ $.Values.kubecostModel.plugins.folder }}/config/{{$key}}_config.json
       subPath: {{$key}}_config.json
       name: plugins-config
       readOnly: true

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1032,6 +1032,8 @@ Begin Kubecost 2.0 templates
     - name: CARBON_ESTIMATES_ENABLED
       value: "true"
     {{- end }}
+    - name: CUSTOM_COST_ENABLED
+      value: {{ .Values.kubecostModel.plugins.enabled | quote }}
     {{- if .Values.kubecostAggregator.extraEnv -}}
     {{- toYaml .Values.kubecostAggregator.extraEnv | nindent 4 }}
     {{- end }}
@@ -1203,6 +1205,8 @@ Begin Kubecost 2.0 templates
       value: {{ .Values.kubecostAggregator.cloudCost.queryWindowDays | default 7 | quote }}
     - name: CLOUD_COST_RUN_WINDOW_DAYS
       value: {{ .Values.kubecostAggregator.cloudCost.runWindowDays | default 3 | quote }}
+    - name: CUSTOM_COST_ENABLED
+      value: {{ .Values.kubecostModel.plugins.enabled | quote }}
     {{- with .Values.kubecostModel.cloudCost }}
     {{- with .labelList }}
     - name: CLOUD_COST_IS_INCLUDE_LIST

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -29,6 +29,10 @@ spec:
   template:
     metadata:
       labels:
+        {{/*
+        Force pod restarts on upgrades to ensure the nginx config is current
+        */}}
+        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
         app.kubernetes.io/name: cloud-cost
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: cloud-cost
@@ -85,11 +89,10 @@ spec:
           emptyDir: {}
         - name: plugins-config
           secret:
-            {{- if (eq .Values.kubecostModel.plugins.configSecret "") }}
-            secretName: {{ template "cost-analyzer.fullname" . }}-plugins-config
-            {{- else }}
-            secretName: {{  .Values.kubecostModel.plugins.configSecret }}
-            {{- end }}
+            secretName: {{ .Values.kubecostModel.plugins.configSecret }}
+            items:
+              - key: datadog_config.json
+                path: datadog_config.json
         - name: tmp
           emptyDir: {}
         {{- end }}

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -75,6 +75,38 @@ spec:
             All data stored here is ephemeral, and does not require persistence. */}}
         - name: persistent-configs
           emptyDir: {}
+        {{- if .Values.kubecostModel.plugins.enabled  }}
+        {{- if .Values.kubecostModel.plugins.install.enabled}}
+        - name: install-script
+          configMap:
+            name: {{ template "cost-analyzer.fullname" . }}-install-plugins
+        {{- end }}
+        - name: plugins-dir
+          emptyDir: {}
+        - name: plugins-config
+          secret:
+            {{- if (eq .Values.kubecostModel.plugins.configSecret "") }}
+            secretName: {{ template "cost-analyzer.fullname" . }}-plugins-config
+            {{- else }}
+            secretName: {{  .Values.kubecostModel.plugins.configSecret }}
+            {{- end }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
+      initContainers:
+      {{- if (and .Values.kubecostModel.plugins.enabled .Values.kubecostModel.plugins.install.enabled )}}
+      - name: plugin-installer
+        image: {{ .Values.kubecostModel.plugins.install.fullImageName }}
+        command: ["sh", "/install/install_plugins.sh"]
+      {{- with .Values.kubecostModel.plugins.install.securityContext }}
+        securityContext: {{- toYaml . | nindent 12 }}
+      {{- end }}
+        volumeMounts:
+          - name: install-script
+            mountPath: /install
+          - name: plugins-dir
+            mountPath: {{ .Values.kubecostModel.plugins.folder }}
+      {{- end }}
       containers:
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
     {{- if .Values.imagePullSecrets }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -65,6 +65,8 @@ spec:
       restartPolicy: Always
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       volumes:
+        - name: plugins-dir
+          emptyDir: {}
         {{- if .Values.global.gcpstore.enabled }}
         - name: ubbagent-config
           configMap:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -714,8 +714,6 @@ spec:
             - name: METRICS_CONFIGMAP_NAME
               value: {{ .Values.metricsConfigmapName }}
             {{- end }}
-            - name: CUSTOM_COST_ENABLED
-              value: {{ .Values.kubecostModel.plugins.enabled | quote }}
             - name: READ_ONLY
               value: {{ (quote .Values.readonly) | default (quote false) }}
             - name: PROMETHEUS_SERVER_ENDPOINT
@@ -723,6 +721,8 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: prometheus-server-endpoint
+            - name: CUSTOM_COST_ENABLED
+              value: {{ .Values.kubecostModel.plugins.enabled | quote }}
             - name: CLOUD_COST_ENABLED
               value: "false"
             - name: CLOUD_PROVIDER_API_KEY

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -256,23 +256,6 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- if .Values.kubecostModel.plugins.enabled  }}
-        {{- if .Values.kubecostModel.plugins.install.enabled}}
-        - name: install-script
-          configMap:
-            name: {{ template "cost-analyzer.fullname" . }}-install-plugins
-        {{- end }}
-        - name: plugins-dir
-          emptyDir: {}
-
-        - name: plugins-config
-          secret:
-            {{- if (eq .Values.kubecostModel.plugins.configSecret "") }}
-            secretName: {{ template "cost-analyzer.fullname" . }}-plugins-config
-            {{- else }}
-            secretName: {{  .Values.kubecostModel.plugins.configSecret }}
-            {{- end }}
-        {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
         {{- toYaml .Values.extraVolumes | nindent 8 }}
@@ -312,19 +295,6 @@ spec:
 {{- end }}
 {{- end }}
       initContainers:
-      {{- if (and .Values.kubecostModel.plugins.enabled .Values.kubecostModel.plugins.install.enabled )}}
-        - name: plugin-installer
-          image: {{ .Values.kubecostModel.plugins.install.fullImageName }}
-          command: ["sh", "/install/install_plugins.sh"]
-      {{- with .Values.kubecostModel.plugins.install.securityContext }}
-          securityContext: {{- toYaml . | nindent 12 }}
-      {{- end }}
-          volumeMounts:
-            - name: install-script
-              mountPath: /install
-            - name: plugins-dir
-              mountPath: {{ .Values.kubecostModel.plugins.folder }}
-      {{- end }}
       {{- if .Values.supportNFS }}
         - name: config-db-perms-fix
         {{- if .Values.initChownDataImage }}
@@ -550,19 +520,6 @@ spec:
               mountPath: /var/secrets
               readOnly: true
             {{- end }}
-            {{- if .Values.kubecostModel.plugins.enabled }}
-            - mountPath: /opt/opencost/plugin
-              name: plugins-dir
-              readOnly: false
-            - name: tmp
-              mountPath: /tmp
-            {{- range $key := .Values.kubecostModel.plugins.enabledPlugins }}
-            - mountPath: /opt/opencost/plugin/config/{{$key}}_config.json
-              subPath: {{$key}}_config.json
-              name: plugins-config
-              readOnly: true
-            {{- end }}
-            {{- end }}
             - name: persistent-configs
               mountPath: /var/configs
             {{- if .Values.extraVolumeMounts }}
@@ -714,8 +671,6 @@ spec:
             - name: METRICS_CONFIGMAP_NAME
               value: {{ .Values.metricsConfigmapName }}
             {{- end }}
-            - name: CUSTOM_COST_ENABLED
-              value: {{ .Values.kubecostModel.plugins.enabled | quote }}
             - name: READ_ONLY
               value: {{ (quote .Values.readonly) | default (quote false) }}
             - name: PROMETHEUS_SERVER_ENDPOINT

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -714,6 +714,8 @@ spec:
             - name: METRICS_CONFIGMAP_NAME
               value: {{ .Values.metricsConfigmapName }}
             {{- end }}
+            - name: CUSTOM_COST_ENABLED
+              value: {{ .Values.kubecostModel.plugins.enabled | quote }}
             - name: READ_ONLY
               value: {{ (quote .Values.readonly) | default (quote false) }}
             - name: PROMETHEUS_SERVER_ENDPOINT
@@ -721,8 +723,6 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: prometheus-server-endpoint
-            - name: CUSTOM_COST_ENABLED
-              value: {{ .Values.kubecostModel.plugins.enabled | quote }}
             - name: CLOUD_COST_ENABLED
               value: "false"
             - name: CLOUD_PROVIDER_API_KEY

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1058,6 +1058,22 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/customCost/status {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/customCost/total;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/customCost/rebuild {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/customCost/timeseries;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
 {{- end }}
         location = /model/hideOrphanedResources {
             default_type 'application/json';

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1060,7 +1060,7 @@ data:
         }
         location = /model/customCost/status {
             proxy_read_timeout          300;
-            proxy_pass http://aggregator/customCost/total;
+            proxy_pass http://cloudCost/customCost/status;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
@@ -1068,7 +1068,7 @@ data:
         }
         location = /model/customCost/rebuild {
             proxy_read_timeout          300;
-            proxy_pass http://aggregator/customCost/timeseries;
+            proxy_pass http://cloudCost/customCost/rebuild;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;

--- a/cost-analyzer/templates/plugins-config.yaml
+++ b/cost-analyzer/templates/plugins-config.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.kubecostModel.plugins.enabled }}
-{{- if (eq .Values.kubecostModel.plugins.configSecret "") }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "cost-analyzer.fullname" . }}-plugins-config
+  name: {{ .Values.kubecostModel.plugins.configSecret }}
   labels:
      {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
@@ -12,4 +11,4 @@ data:
     {{ $config | b64enc | indent 4}}
   {{- end }}
 {{- end }}
-{{- end }}
+

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -570,7 +570,7 @@ kubecostModel:
       # - datadog
 
     # pre-existing secret for plugin configuration
-    configSecret: ""
+    configSecret: kubecost-plugin-secret
 
     # uncomment this to define plugin configuration via the values file
     # configs:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -546,7 +546,7 @@ kubecostModel:
 
   # Installs Kubecost/OpenCost plugins
   plugins:
-    enabled: false
+    enabled: true
     install:
       enabled: true
       fullImageName: curlimages/curl:latest


### PR DESCRIPTION
## What does this PR change?
* Routes `/customCost/status` and `/customCost/repair` to the `cloud-cost` pod.
* Enables Custom Cost plugins by default.

## Does this PR rely on any other PRs?
* [OC](https://github.com/opencost/opencost/pull/2676).
* [KCM](https://github.com/kubecost/kubecost-cost-model/pull/2342).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Custom Cost pages in the FE will be able to reliably determine if Custom Costs are enabled.

## What risks are associated with merging this PR? What is required to fully test this PR?
* No risks, the current routing setup means Custom Costs are broken.

## How was this PR tested?
* To be tested.