### PR TITLE
fix bug #3219

### DIFF
--- a/cost-analyzer/templates/grafana-attached-disk-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-attached-disk-metrics-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-networkcosts-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-networkcosts-metrics-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cost-analyzer/templates/grafana-pod-utilization-multi-cluster-template.yaml
+++ b/cost-analyzer/templates/grafana-pod-utilization-multi-cluster-template.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.grafana -}}
 {{- if .Values.grafana.sidecar -}}
 {{- if .Values.grafana.sidecar.dashboards -}}
-{{- if and (.Values.grafana.sidecar.dashboards.enabled ) (eq (include "cost-analyzer.grafanaEnabled" .) "true") -}}
+{{- if .Values.grafana.sidecar.dashboards.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## What does this PR change?
grafana dashboards configmaps are created if sidecar dashboars are enabled. it no longer relies of global grafana setup

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Allow grafana dashboards to be created for use with external grafana

## What risks are associated with merging this PR? What is required to fully test this PR?
unknown configs

## How was this PR tested?
Local helm install

## Have you made an update to documentation? If so, please provide the corresponding PR.
@bstuder99 simple change to grafana page that the grafana dashboards will be deployed unless they are disabled.
to disable, set:
```
--set grafana.sidecar.dashboards.enabled
```
