### PR TITLE
Aggregator extraVolumes and extraVolumeMounts

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -980,6 +980,9 @@ Begin Kubecost 2.0 templates
     {{- end }}
     {{- end }}
     {{- end }}
+    {{- if and .Values.kubecostAggregator.extraVolumeMounts (eq (include "aggregator.deployMethod" .) "statefulset") }}
+    {{- toYaml .Values.extraVolumeMounts | nindent 4 }}
+    {{- end }}
   env:
     {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.clusterIDConfigmap) }}
     - name: CLUSTER_ID

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -980,8 +980,9 @@ Begin Kubecost 2.0 templates
     {{- end }}
     {{- end }}
     {{- end }}
+    {{- /* Only adds extraVolumeMounts if aggregator is running as its own pod */}}
     {{- if and .Values.kubecostAggregator.extraVolumeMounts (eq (include "aggregator.deployMethod" .) "statefulset") }}
-    {{- toYaml .Values.extraVolumeMounts | nindent 4 }}
+    {{- toYaml .Values.kubecostAggregator.extraVolumeMounts | nindent 4 }}
     {{- end }}
   env:
     {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.clusterIDConfigmap) }}
@@ -1054,7 +1055,6 @@ Begin Kubecost 2.0 templates
       value: "true"
       {{- end }}
     {{- end }}
-
     {{- range $key, $value := .Values.kubecostAggregator.env }}
     - name: {{ $key | quote }}
       value: {{ $value | quote }}
@@ -1186,6 +1186,10 @@ Begin Kubecost 2.0 templates
   {{- if or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaBucketName) }}
     - name: cloud-integration
       mountPath: /var/configs/cloud-integration
+  {{- end }}
+  {{- /* Only adds extraVolumeMounts when cloudcosts is running as its own pod */}}
+  {{- if and .Values.kubecostAggregator.cloudCost.extraVolumeMounts (eq (include "aggregator.deployMethod" .) "statefulset") }}
+    {{- toYaml .Values.kubecostAggregator.cloudCost.extraVolumeMounts | nindent 4 }}
   {{- end }}
   env:
     - name: CONFIG_PATH

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -75,6 +75,9 @@ spec:
             All data stored here is ephemeral, and does not require persistence. */}}
         - name: persistent-configs
           emptyDir: {}
+        {{- if .Values.kubecostAggregator.cloudCost.extraVolumes }}
+        {{- toYaml .Values.kubecostAggregator.cloudCost.extraVolumes | nindent 8 }}
+        {{- end }}
       containers:
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
     {{- if .Values.imagePullSecrets }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -147,7 +147,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.kubecostAggregator.extraVolumes }}
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- toYaml .Values.kubecostAggregator.extraVolumes | nindent 8 }}
         {{- end }}
       containers:
         {{- include "aggregator.containerTemplate" . | nindent 8 }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -146,6 +146,9 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if .Values.kubecostAggregator.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
       containers:
         {{- include "aggregator.containerTemplate" . | nindent 8 }}
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2457,10 +2457,10 @@ kubecostAggregator:
     "DB_CONCURRENT_INGESTION_COUNT": "3"
 
   persistentConfigsStorage:
-    storageClass: "" # default storage class
+    storageClass: ""  # default storage class
     storageRequest: 1Gi
   aggregatorDbStorage:
-    storageClass: "" # default storage class
+    storageClass: ""  # default storage class
     storageRequest: 128Gi
 
   resources: {}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2450,23 +2450,23 @@ kubecostAggregator:
   # after consulting with Kubecost's support team
   numDBCopyPartitions: 25
 
-  resources: {}
-    # requests:
-    #   cpu: 1000m
-    #   memory: 1Gi
   env:
     "LOG_LEVEL": "info"
     "DB_READ_THREADS": "1"
     "DB_WRITE_THREADS": "1"
     "DB_CONCURRENT_INGESTION_COUNT": "3"
+
   persistentConfigsStorage:
-    # default storage class
-    storageClass: ""
+    storageClass: "" # default storage class
     storageRequest: 1Gi
   aggregatorDbStorage:
-    # default storage class
-    storageClass: ""
+    storageClass: "" # default storage class
     storageRequest: 128Gi
+
+  resources: {}
+    # requests:
+    #   cpu: 1000m
+    #   memory: 1Gi
 
   readinessProbe:
     enabled: true
@@ -2474,40 +2474,26 @@ kubecostAggregator:
     periodSeconds: 10
     failureThreshold: 200
 
+  ## Set additional environment variables for the aggregator pod
+  # extraEnv:
+  # - name: SOME_VARIABLE
+  #   value: "some_value"
+
   ## Add a priority class to the aggregator pod
   # priority:
   #   enabled: false
   #   name: ""
 
-  # extraEnv:
-  # - name: SOME_VARIABLE
-  #   value: "some_value"
-  # securityContext:
-  #   runAsGroup: 1001
-  #   runAsUser: 1001
-  #   fsGroup: 1001
-  #   fsGroupChangePolicy: OnRootMismatch
-  #   seccompProfile:
-  #     type: RuntimeDefault
-  #   runAsNonRoot: true
-  # containerSecurityContext:
-  #   allowPrivilegeEscalation: false
-  #   readOnlyRootFilesystem: true
-  #   runAsNonRoot: true
-  #   seccompProfile:
-  #     type: RuntimeDefault
-  #   capabilities:
-  #     drop:
-  #       - ALL
-  #
-  # Optional - add extra ports to the aggregator container. For kubecost development purposes only - not recommended for users.
-  extraPorts: []
-    # - name: debug
-    #   port: 40000
-    #   targetPort: 40000
-    #   containerPort: 40000
+  ## Optional - add extra ports to the aggregator container. For kubecost development purposes only - not recommended for users.
+  # extraPorts: []
+  #   - name: debug
+  #     port: 40000
+  #     targetPort: 40000
+  #     containerPort: 40000
+
   ## Define a securityContext for the aggregator pod. This will take highest precedence.
-  securityContext: {}
+  # securityContext: {}
+
   ## Define the container-level security context for the aggregator pod. This will take highest precedence.
   # containerSecurityContext: {}
 
@@ -2523,8 +2509,11 @@ kubecostAggregator:
   ## Define Pod affinity for the aggregator pod
   # affinity: {}
 
-  extraVolumes: []
-  extraVolumeMounts: []
+  ## Define extra volumes for the aggregator pod
+  # extraVolumes: []
+
+  ## Define extra volumemounts for the aggregator pod
+  # extraVolumeMounts: []
 
   ## Creates a new container/pod to retrieve CloudCost data. By default it uses
   ## the same serviceaccount as the cost-analyzer pod. A custom serviceaccount
@@ -2563,6 +2552,12 @@ kubecostAggregator:
 
     ## Define environment variables for cloud cost
     # env: {}
+
+    ## Define extra volumes for the cloud cost pod
+    # extraVolumes: []
+
+    ## Define extra volumemounts for the cloud cost pod
+    # extraVolumeMounts: []
 
     ## Configure the Collections service for aggregator.
     # collections:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2523,6 +2523,9 @@ kubecostAggregator:
   ## Define Pod affinity for the aggregator pod
   # affinity: {}
 
+  extraVolumes: []
+  extraVolumeMounts: []
+
   ## Creates a new container/pod to retrieve CloudCost data. By default it uses
   ## the same serviceaccount as the cost-analyzer pod. A custom serviceaccount
   ## can be specified.


### PR DESCRIPTION
## What does this PR change?

- Allows users to add `extraVolumes` and `extraVolumeMounts` to the Aggregator pod and CloudCost pod, when Aggregator is running as a Statefulset.
- Cleanup values.yaml file under `kubecostAggregator`

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

As titled

## Links to Issues or tickets this PR addresses or fixes

Implements https://github.com/kubecost/cost-analyzer-helm-chart/issues/3261

## What risks are associated with merging this PR? What is required to fully test this PR?

None. This is an optional config.

## How was this PR tested?

```yaml
kubecostAggregator:
  deployMethod: "statefulset"
  extraVolumes:
    - name: test1
      secret:
        secretName: test1-secret
  extraVolumeMounts:
    - name: test1
      mountPath: /var/configs/test1
  cloudCost:
    extraVolumes:
      - name: test2
        configMap:
          name: test2-configmap
    extraVolumeMounts:
      - name: test2
        mountPath: /var/configs/test2
kubecostModel:
  federatedStorageConfigSecret: "federated-store"
```

```sh
helm template ./cost-analyzer -f values.yaml
```

Validated that the `test1` and `test2` volumes and volumemounts were templated as expected.

## Have you made an update to documentation? If so, please provide the corresponding PR.

Documented via values.yaml