### PR TITLE
fix ext-costs config

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1192,11 +1192,9 @@ Begin Kubecost 2.0 templates
       readOnly: false
     - name: tmp
       mountPath: /tmp
-    {{- range $key := .Values.kubecostModel.plugins.enabledPlugins }}
     - mountPath: {{ $.Values.kubecostModel.plugins.folder }}/config
       name: plugins-config
       readOnly: true
-    {{- end }}
     {{- end }}
   env:
     - name: CONFIG_PATH

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -101,9 +101,9 @@ spec:
       - name: plugin-installer
         image: {{ .Values.kubecostModel.plugins.install.fullImageName }}
         command: ["sh", "/install/install_plugins.sh"]
-      {{- with .Values.kubecostModel.plugins.install.securityContext }}
+        {{- with .Values.kubecostModel.plugins.install.securityContext }}
         securityContext: {{- toYaml . | nindent 12 }}
-      {{- end }}
+        {{- end }}
         volumeMounts:
           - name: install-script
             mountPath: /install

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -65,8 +65,21 @@ spec:
       restartPolicy: Always
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       volumes:
+        {{- if .Values.kubecostModel.plugins.enabled }}
         - name: plugins-dir
           emptyDir: {}
+        - name: plugins-config
+          secret:
+            secretName: {{ .Values.kubecostModel.plugins.configSecret }}
+            items:
+              - key: datadog_config.json
+                path: datadog_config.json
+        {{- if .Values.kubecostModel.plugins.install.enabled}}
+        - name: install-script
+          configMap:
+            name: {{ template "cost-analyzer.fullname" . }}-install-plugins
+        {{- end }}
+        {{- end }}
         {{- if .Values.global.gcpstore.enabled }}
         - name: ubbagent-config
           configMap:
@@ -297,7 +310,20 @@ spec:
 {{- end }}
 {{- end }}
       initContainers:
-      {{- if .Values.supportNFS }}
+        {{- if and .Values.kubecostModel.plugins.enabled (not (eq (include "aggregator.deployMethod" .) "statefulset")) }}
+        - name: plugin-installer
+          image: {{ .Values.kubecostModel.plugins.install.fullImageName }}
+          command: ["sh", "/install/install_plugins.sh"]
+          {{- with .Values.kubecostModel.plugins.install.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: install-script
+              mountPath: /install
+            - name: plugins-dir
+              mountPath: {{ .Values.kubecostModel.plugins.folder }}
+        {{- end }}
+        {{- if .Values.supportNFS }}
         - name: config-db-perms-fix
         {{- if .Values.initChownDataImage }}
           image: {{ .Values.initChownDataImage }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -546,9 +546,9 @@ kubecostModel:
 
   # Installs Kubecost/OpenCost plugins
   plugins:
-    enabled: true
+    enabled: false
     install:
-      enabled: true
+      enabled: false
       fullImageName: curlimages/curl:latest
       securityContext:
         allowPrivilegeEscalation: false
@@ -559,7 +559,7 @@ kubecostModel:
           - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 1001
     folder: /opt/opencost/plugin
 
     # leave this commented to always download most recent version of plugins


### PR DESCRIPTION
## What does this PR change?
Fixes external (datadog) costs introduced in 2.2.0

## Does this PR rely on any other PRs?
KCM PR has already merged and picked in to nightly.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixed external (datadog) costs introduced in 2.2.0

## Links to Issues or tickets this PR addresses or fixes

## What risks are associated with merging this PR? What is required to fully test this PR?
Unknown configs

## How was this PR tested?
Using nightly:
1. With and without aggregator statefulset
2. with and without: 

```
kubecostModel:
  plugins:
    enabled: true
    enabledPlugins:
    - datadog
    configs:
      datadog: |
        {
        "datadog_site": "us5.datadoghq.com",
        "datadog_api_key": "xxx",
        "datadog_app_key": "xxx"
        }
    install:
      enabled: true
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

