### PR TITLE
Add `/providerOptimization` proxy

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -992,6 +992,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/providerOptimization {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/providerOptimization;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
 
         #Cloud Cost Endpoints
         location = /model/cloudCost/status {


### PR DESCRIPTION
## What does this PR change?
* Adds a proxy for `/providerOptimization`.

## Does this PR rely on any other PRs?
* [OC](https://github.com/opencost/opencost/pull/2686).
* [KCM](https://github.com/kubecost/kubecost-cost-model/pull/2356).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* It will allow for gating based on whether a deployment is EKS optimized.

## How was this PR tested?
* Tested [in-cluster](https://nightly-eks-optimized.qa-eks1.aws.kubecost.xyz/model/providerOptimization)