### PR TITLE
remove reference to deprecated env variables

### DIFF
--- a/cost-analyzer/ci/federatedetl-primary-netcosts-values.yaml
+++ b/cost-analyzer/ci/federatedetl-primary-netcosts-values.yaml
@@ -6,9 +6,6 @@ federatedETL:
   federatedCluster: true
 kubecostModel:
   containerStatsEnabled: true
-  cloudCost:
-    enabled: true  # Set to true to enable CloudCost view that gives you visibility of your Cloud provider resources cost
-  etlCloudAsset: false  # Set etlCloudAsset to false when cloudCost.enabled=true
   federatedStorageConfigSecret: federated-store
 serviceAccount:  # this example uses AWS IRSA, which creates a service account with rights to the s3 bucket. If using keys+secrets in the federated-store, set create: true
   create: true

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1215,16 +1215,6 @@ Begin Kubecost 2.0 templates
       value: {{ .Values.kubecostAggregator.cloudCost.runWindowDays | default 3 | quote }}
     - name: CUSTOM_COST_ENABLED
       value: {{ .Values.kubecostModel.plugins.enabled | quote }}
-    {{- with .Values.kubecostModel.cloudCost }}
-    {{- with .labelList }}
-    - name: CLOUD_COST_IS_INCLUDE_LIST
-      value: {{ (quote .IsIncludeList) | default (quote false) }}
-    - name: CLOUD_COST_LABEL_LIST
-      value: {{ (quote .labels) }}
-    {{- end }}
-    - name: CLOUD_COST_TOP_N
-      value: {{ (quote .topNItems) | default (quote 1000) }}
-    {{- end }}
     {{- range $key, $value := .Values.kubecostAggregator.cloudCost.env }}
     - name: {{ $key | quote }}
       value: {{ $value | quote }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1010,8 +1010,6 @@ Begin Kubecost 2.0 templates
     - name: ETL_PATH_PREFIX
       value: "/var/db"
     {{- end }}
-    - name: ETL_ENABLED
-      value: "false" # this container should never run KC's concept of "ETL"
     - name: CLOUD_PROVIDER_API_KEY
       value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API key.This GCP api key is expected to be here and is limited to accessing google's billing API.'
     {{- if .Values.systemProxy.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -817,17 +817,10 @@ spec:
             {{- end }}
             - name: LEGACY_EXTERNAL_API_DISABLED
               value: {{ (quote .Values.kubecostModel.legacyOutOfClusterAPIDisabled) | default (quote false) }}
-            - name: OUT_OF_CLUSTER_PROM_METRICS_ENABLED
-              value: {{ (quote .Values.kubecostModel.outOfClusterPromMetricsEnabled) | default (quote false) }}
             - name: CACHE_WARMING_ENABLED
               value: {{ (quote .Values.kubecostModel.warmCache) | default (quote true) }}
             - name: SAVINGS_ENABLED
               value: {{ (quote .Values.kubecostModel.warmSavingsCache) | default (quote true) }}
-            - name: ETL_ENABLED
-              value: {{ (quote .Values.kubecostModel.etl) | default (quote true) }}
-            {{- if .Values.kubecostModel.etlReadOnlyMode }}
-            - name: ETL_READ_ONLY
-              value: "true"
             {{- end }}
             {{- if $etlBackupBucketSecret }}
             - name: ETL_BUCKET_CONFIG
@@ -849,18 +842,6 @@ spec:
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             {{- end }}
-            - name: ETL_STORE_READ_ONLY
-              value: {{ (quote .Values.kubecostModel.etlStoreReadOnly) | default (quote false) }}
-            - name : ETL_CLOUD_USAGE_ENABLED
-            {{- if kindIs "bool" .Values.kubecostModel.etlCloudUsage }}
-              value: {{ (quote .Values.kubecostModel.etlCloudUsage) }}
-            {{- else if kindIs "bool" .Values.kubecostModel.etlCloudAsset }}
-              value: {{ (quote .Values.kubecostModel.etlCloudAsset) }}
-            {{- else }}
-              value: "false"
-            {{- end }}
-            - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
-              value: {{ (quote .Values.kubecostModel.cloudAssetsExcludeProviderID) | default (quote false) }}
             {{- if .Values.persistentVolume.dbPVEnabled }}
             - name: ETL_PATH_PREFIX
               value: "/var/db"
@@ -879,8 +860,7 @@ spec:
               value: {{ (quote .Values.kubecostModel.etlFileStoreEnabled) | default (quote true) }}
             - name: ETL_ASSET_RECONCILIATION_ENABLED
               value: {{ (quote .Values.kubecostModel.etlAssetReconciliationEnabled) | default (quote true) }}
-            - name: ETL_USE_UNBLENDED_COST
-              value: {{ (quote .Values.kubecostModel.etlUseUnblendedClost) | default (quote false) }}
+
             {{- if .Values.kubecostModel }}
             {{- if .Values.kubecostModel.allocation }}
             {{- if .Values.kubecostModel.allocation.nodeLabels }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -706,8 +706,6 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: prometheus-server-endpoint
-            - name: CLOUD_COST_ENABLED
-              value: "false"
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API key.This GCP api key is expected to be here and is limited to accessing google's billing API.
             {{- if .Values.kubecostProductConfigs }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -821,7 +821,6 @@ spec:
               value: {{ (quote .Values.kubecostModel.warmCache) | default (quote true) }}
             - name: SAVINGS_ENABLED
               value: {{ (quote .Values.kubecostModel.warmSavingsCache) | default (quote true) }}
-            {{- end }}
             {{- if $etlBackupBucketSecret }}
             - name: ETL_BUCKET_CONFIG
               value: "/var/configs/etl/object-store.yaml"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -581,16 +581,6 @@ kubecostModel:
       #   "datadog_app_key": "<INSERT_DATADOG_APP_KEY>"
       #   }
 
-  ## Feature to view your out-of-cluster costs and their k8s utilization
-  ## Ref: https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer
-  cloudCost:
-    # enabled: true # this logic is always enabled if cloud billing integration is configured. This option is no longer configurable.
-    labelList:
-      IsIncludeList: false
-      # format labels as comma separated string (ex. "label1,label2,label3")
-      labels: ""
-    topNItems: 1000
-
   allocation:
     # Enables or disables adding node labels to allocation data (i.e. workloads).
     # Defaults to "true" and starts with a sensible includeList for basics like
@@ -2531,7 +2521,6 @@ kubecostAggregator:
     # kubecostAggregator.deployMethod:
     # kA.dM = "singlepod" -> cloudCost is run as container inside cost-analyzer
     # kA.dM = "statefulset" -> cloudCost is run as single-replica Deployment
-    enabled: false
     resources: {}
       # requests:
       #   cpu: 1000m

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -514,9 +514,6 @@ kubecostModel:
   #   value: "some_value"
   # securityContext:
   #   readOnlyRootFilesystem: true
-  # Enables the emission of the kubecost_cloud_credit_total and
-  # kubecost_cloud_expense_total metrics
-  outOfClusterPromMetricsEnabled: false
   # Build local cost allocation cache
   warmCache: false
   # Run allocation ETL pipelines

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -20370,20 +20370,10 @@ spec:
               value: "https://71964476292e4087af8d5072afe43abd@o394722.ingest.sentry.io/5245431"
             - name: LEGACY_EXTERNAL_API_DISABLED
               value: "false"
-            - name: OUT_OF_CLUSTER_PROM_METRICS_ENABLED
-              value: "false"
             - name: CACHE_WARMING_ENABLED
               value: "false"
             - name: SAVINGS_ENABLED
               value: "true"
-            - name: ETL_ENABLED
-              value: "true"
-            - name: ETL_STORE_READ_ONLY
-              value: "false"
-            - name : ETL_CLOUD_USAGE_ENABLED
-              value: "false"
-            - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
-              value: "false"
             - name: ETL_RESOLUTION_SECONDS
               value: "300"
             - name: ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -20386,18 +20386,6 @@ spec:
               value: "53"
             - name: ETL_FILE_STORE_ENABLED
               value: "true"
-            - name: ETL_ASSET_RECONCILIATION_ENABLED
-              value: "true"
-            - name: ETL_USE_UNBLENDED_COST
-              value: "false"
-            - name: CLOUD_COST_ENABLED
-              value: "true"
-            - name: CLOUD_COST_IS_INCLUDE_LIST
-              value: "false"
-            - name: CLOUD_COST_LABEL_LIST
-              value: ""
-            - name: CLOUD_COST_TOP_N
-              value: "1000"
             - name: CLOUD_COST_REFRESH_RATE_HOURS
               value: "6"
             - name: CLOUD_COST_QUERY_WINDOW_DAYS


### PR DESCRIPTION
## What does this PR change?
This PR removes references  to environment variables that no longer have a function in the application along with their associated helm values
- `ETL_ENABLED`
- `OUT_OF_CLUSTER_PROM_METRICS_ENABLED`
- `ETL_READ_ONLY`
- `ETL_STORE_READ_ONLY`
- `ETL_CLOUD_USAGE_ENABLED`
- `CLOUD_ASSETS_EXCLUDE_PROVIDER_ID`
- `ETL_USE_UNBLENDED_COST`
- `CLOUD_COST_IS_INCLUDE_LIST`
- `CLOUD_COST_LABEL_LIST`
- `CLOUD_COST_TOP_N`

The Helm Value `etlReadOnlyMode` which is associated with `ETL_READ_ONLY` has been retained because it has templating implication that I do not fully understand at this point.

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Tested via `helm template`

## Have you made an update to documentation? If so, please provide the corresponding PR.

