### PR TITLE
bump kubecost-modeling fixing xz vulnerability CVE-2024-3094

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -18,7 +18,7 @@ kubecostModel:
   image: public.ecr.aws/kubecost/cost-model
 
 forecasting:
-  fullImageName: public.ecr.aws/kubecost/kubecost-modeling:v0.1.5
+  fullImageName: public.ecr.aws/kubecost/kubecost-modeling:v0.1.6
 
 networkCosts:
   image:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2351,7 +2351,7 @@ forecasting:
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
   # Example: fullImageName: gcr.io/kubecost1/forecasting:v0.0.1
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.5
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.6
 
   # Resource specification block for the forecasting container.
   resources:


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
* Bump kubecost-modeling to v0.1.6 to fix CVE-2024-3094

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes
fixes #3306



## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
Updated local environments
ran `docker run --rm --entrypoint xz gcr.io/kubecost1/kubecost-modeling:v0.1.6 --version` to ensure xz version 5.4.6 that does not include the CVE.

## Have you made an update to documentation? If so, please provide the corresponding PR.

