### PR TITLE
disable helm-rollout-restarter if cicd=true

### DIFF
--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -32,7 +32,9 @@ spec:
         {{/*
         Force pod restarts on upgrades to ensure the nginx config is current
         */}}
+        {{- if not .Values.global.platforms.cicd.enabled }}
         helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
+        {{- end }}
         app.kubernetes.io/name: cloud-cost
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: cloud-cost

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -45,7 +45,9 @@ spec:
         app.kubernetes.io/name: aggregator
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{/* Force pod restarts on upgrades to ensure the nginx config is current */}}
+        {{- if not .Values.global.platforms.cicd.enabled }}
         helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
+        {{- end }}
         app: aggregator
         {{- with .Values.global.additionalLabels }}
         {{- toYaml . | nindent 8 }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -38,7 +38,9 @@ spec:
       labels:
         {{- include "cost-analyzer.selectorLabels" . | nindent 8 }}
         {{/* Force pod restarts on upgrades to ensure the nginx config is current */}}
+        {{- if not .Values.global.platforms.cicd.enabled }}
         helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
+        {{- end }}
         {{- if .Values.global.additionalLabels }}
         {{ toYaml .Values.global.additionalLabels | nindent 8 }}
         {{- end }}

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -26,7 +26,9 @@ spec:
         {{- include "diagnostics.selectorLabels" . | nindent 8 }}
       annotations:
         # Generates a unique annotation upon each `helm upgrade`, forcing a redeployment
-        helm.sh/pod-restarter: {{ randNumeric 3 | quote}}
+        {{- if not .Values.global.platforms.cicd.enabled }}
+        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
+        {{- end }}
         {{- with .Values.global.podAnnotations}}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -35,7 +35,9 @@ spec:
         {{/*
         Force pod restarts on upgrades to ensure the nginx config is current
         */}}
+        {{- if not .Values.global.platforms.cicd.enabled }}
         helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
+        {{- end }}
         {{- include "frontend.selectorLabels" . | nindent 8 }}
         {{- if .Values.global.additionalLabels }}
         {{- toYaml .Values.global.additionalLabels | nindent 8 }}

--- a/cost-analyzer/templates/prometheus-server-deployment.yaml
+++ b/cost-analyzer/templates/prometheus-server-deployment.yaml
@@ -31,7 +31,9 @@ spec:
         {{/*
         Force pod restarts on upgrades to ensure the configmap is current
         */}}
+        {{- if not .Values.global.platforms.cicd.enabled }}
         helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
+        {{- end }}
         {{- include "prometheus.server.labels" . | nindent 8 }}
         {{- if .Values.prometheus.server.podLabels}}
         {{ toYaml .Values.prometheus.server.podLabels | nindent 8 }}


### PR DESCRIPTION
## What does this PR change?
disable helm-rollout-restarter if cicd=true

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
add helm option to disable helm-rollout-restarter if cicd=true

## Links to Issues or tickets this PR addresses or fixes
Issue reported in slack support


## What risks are associated with merging this PR? What is required to fully test this PR?
These pods restart for a reason, if configmaps/secrets change, pods do not restart and Kubecost does not use a configmap reloader. Added note to values.yaml comments

## How was this PR tested?
with and without:
```yaml
global:
  platforms:
    cicd:
      enabled: true
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

