### PR TITLE
quick fix for athena cc integration on single pod deployments

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -588,7 +588,8 @@ spec:
             - name: azure-storage-config
               mountPath: /var/azure-storage-config
             {{- end }}
-            {{- if or (.Values.kubecostProductConfigs.cloudIntegrationSecret) (.Values.kubecostProductConfigs.cloudIntegrationJSON) }}
+            # TODO remove this if-clause when CloudCost has been removed from Opencost Cost-Model
+            {{- if or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaBucketName) }}
             - name: cloud-integration
               mountPath: /var/configs/cloud-integration
             {{- end }}


### PR DESCRIPTION
## What does this PR change?
quick fix for Athena cc integration on single pod deployments when using helm values. v2.2 has an issue where the cost-analyzer pod runs the cloud-cost integration controller within the Opencost Cost model. On a single pod deployment this causes issues when the controller on one of the containers has access to the secret that is being mounted by the helm chart and not the other, causing them to save conflicting configurations to their backing file on the shared pv. The long term solution is to remove CloudCost from Open Cost cost model which there are PR's for, but the change is too big for this stage in the 2.2 release cycle. This change ensures that when configuring Athena cloud cost with helm values the secret that is created is accessible by the controllers in both containers, which prevents conflict between the two.


## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Test on deployment created with helm values set

## Have you made an update to documentation? If so, please provide the corresponding PR.

