### PR TITLE
Remove cloud integration secret mount from cost-model container

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -606,10 +606,6 @@ spec:
             - name: azure-storage-config
               mountPath: /var/azure-storage-config
             {{- end }}
-            {{- if or (.Values.kubecostProductConfigs.cloudIntegrationSecret) (.Values.kubecostProductConfigs.cloudIntegrationJSON) }}
-            - name: cloud-integration
-              mountPath: /var/configs/cloud-integration
-            {{- end }}
             {{- if or .Values.kubecostProductConfigs.serviceKeySecretName .Values.kubecostProductConfigs.createServiceKeySecret }}
             - name: service-key-secret
               mountPath: /var/secrets


### PR DESCRIPTION
## What does this PR change?
Cloud Integration Secret should not be mounted to this container as the processes that uses it should not be running within it.

## Does this PR rely on any other PRs?
This PR should not be merged until these PR's are in
https://github.com/kubecost/kubecost-cost-model/pull/2363
https://github.com/opencost/opencost/pull/2691

## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

