### PR TITLE
Add env variable to cloud-cost template

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1214,6 +1214,8 @@ Begin Kubecost 2.0 templates
     - name: FEDERATED_CLUSTER
       value: "true"
     {{- end}}
+    - name: ETL_DAILY_STORE_DURATION_DAYS
+      value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 91) }}
     - name: CLOUD_COST_REFRESH_RATE_HOURS
       value: {{ .Values.kubecostAggregator.cloudCost.refreshRateHours | default 6 | quote }}
     - name: CLOUD_COST_QUERY_WINDOW_DAYS


### PR DESCRIPTION
## What does this PR change?
This PR set the daily retention limit in the cloud-cost container which allows it to build historic cloud cost data to the correct retention limit

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

