### PR TITLE
allow multi-cluster prometheus

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -64,14 +64,6 @@ Kubecost 2.0 preconditions
     {{- fail "\n\nYou are attempting to upgrade to Kubecost 2.x.\nKubecost no longer includes Thanos by default. \nPlease see https://docs.kubecost.com/install-and-configure/install/kubecostv2 for more information.\nIf you have any questions or concerns, please reach out to us at product@kubecost.com" -}}
   {{- end -}}
 
-  {{- if or (((.Values.global).amp).enabled) (((.Values.global).gmp).enabled) (((.Values.global).thanos).queryService) (((.Values.global).mimirProxy).enabled) -}}
-    {{- if (not (.Values.federatedETL).federatedCluster)  -}}
-      {{- if (not (.Values.upgrade).toV2) -}}
-      {{- fail "\n\nMulti-Cluster-Prometheus Error:\nYou are attempting to upgrade to Kubecost 2.x\nSupport for multi-cluster Prometheus (Thanos/AMP/GMP/mimir/etc) without using `Kubecost Federated ETL Object Storage` will be added in future release. \nIf this is a single cluster Kubecost environment, upgrading is supported using a flag to acknowledge this change.\nMore information can be found here: \nhttps://docs.kubecost.com/install-and-configure/install/kubecostv2\nIf you have any questions or concerns, please reach out to us at product@kubecost.com\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-
   {{- if or ((.Values.saml).rbac).enabled ((.Values.oidc).rbac).enabled -}}
     {{- if (not (.Values.upgrade).toV2) -}}
       {{- fail "\n\nSSO with RBAC is enabled.\nNote that Kubecost 2.x has significant architectural changes that may impact RBAC.\nThis should be tested before giving end-users access to the UI.\nKubecost has tested various configurations and believe that 2.x will be 100% compatible with existing configurations.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\n\nWhen ready to upgrade, add `--set upgrade.toV2=true`." -}}
@@ -83,9 +75,6 @@ Kubecost 2.0 preconditions
   {{- end -}}
 
 
-  {{- if (.Values.agent) -}}
-    {{- fail "\n\nKubecost 2.0 Does not support Thanos based agents. For Thanos, please continue to use 1.108.x.\nConsider moving to Kubecost Federated ETL based agents.\nRefer to the following documentation for more information: https://docs.kubecost.com/install-and-configure/install/kubecostv2\nSupport for Thanos agents is under consideration.\nIf you have any questions or concerns, please reach out to us at product@kubecost.com" -}}
-  {{- end -}}
   {{- if .Values.kubecostModel.openSourceOnly -}}
     {{- fail "In Kubecost 2.0, kubecostModel.openSourceOnly is not supported" -}}
   {{- end -}}


### PR DESCRIPTION
## What does this PR change?
allow allow multi-cluster prometheus configs / without warnings

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
allow allow multi-cluster prometheus configs, supported as of Kubecost 2.2.0

## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
Helm upgrade of environment with AMP

## Have you made an update to documentation? If so, please provide the corresponding PR.
Already done.
