### PR TITLE
add commonLabels to pods

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -44,6 +44,7 @@ spec:
         {{- if not .Values.global.platforms.cicd.enabled }}
         helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
         {{- end }}
+        {{- include "cost-analyzer.commonLabels" . | nindent 8 }}
         {{- if .Values.global.additionalLabels }}
         {{ toYaml .Values.global.additionalLabels | nindent 8 }}
         {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1194,7 +1194,8 @@ data:
                 "frontendDeployMethod": "{{ template "frontend.deployMethod" . }}",
                 "pluginsEnabled": "{{ template "pluginsEnabled" . }}",
                 "carbonEstimatesEnabled": "{{ template "carbonEstimatesEnabled" . }}",
-                "clusterControllerEnabled": "{{ template "clusterControllerEnabled" . }}"
+                "clusterControllerEnabled": "{{ template "clusterControllerEnabled" . }}",
+                "chartVersion": "DEVELOP_BRANCH"
                 }
             ';
         }

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -41,6 +41,7 @@ spec:
         {{- if not .Values.global.platforms.cicd.enabled }}
         helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
         {{- end }}
+        {{- include "cost-analyzer.commonLabels" . | nindent 8 }}
         {{- include "frontend.selectorLabels" . | nindent 8 }}
         {{- if .Values.global.additionalLabels }}
         {{- toYaml .Values.global.additionalLabels | nindent 8 }}


### PR DESCRIPTION
## What does this PR change?
- adds `cost-analyzer.commonLabels` to cost-analyzer and ha-frontend pods. This is primarily being done for diagnostics reasons so we can check if the helm chart matches the container images. 
- add placeholder for the chart version to nginx configmap

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Added `cost-analyzer.commonLabels` to cost-analyzer and ha-frontend pods

## What risks are associated with merging this PR? What is required to fully test this PR?
Only if it interferes with seleector labels

## How was this PR tested?
Upgraded a couple QA environmens with single pod and HA frontend configs.

## Have you made an update to documentation? If so, please provide the corresponding PR.

NA