### PR TITLE
Add custom SMTP support to chart

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -947,6 +947,10 @@ Begin Kubecost 2.0 templates
     - name: productkey-secret
       mountPath: /var/configs/productkey
     {{- end }}
+    {{- if and ((.Values.kubecostProductConfigs).smtp).enabled ((.Values.kubecostProductConfigs).smtp).secretname (eq (include "aggregator.deployMethod" .) "statefulset") }}
+    - name: smtp-secret
+      mountPath: /var/configs/smtp
+    {{- end }}
     {{- if .Values.saml }}
     {{- if .Values.saml.enabled }}
     {{- if .Values.saml.secretName }}
@@ -1008,6 +1012,10 @@ Begin Kubecost 2.0 templates
     {{- if and ((.Values.kubecostProductConfigs).productKey).mountPath (eq (include "aggregator.deployMethod" .) "statefulset") }}
     - name: PRODUCT_KEY_MOUNT_PATH
       value: {{ .Values.kubecostProductConfigs.productKey.mountPath }}
+    {{- end }}
+    {{- if and ((.Values.kubecostProductConfigs).smtp).mountPath (eq (include "aggregator.deployMethod" .) "statefulset") }}
+    - name: SMTP_CONFIG_MOUNT_PATH
+      value: {{ .Values.kubecostProductConfigs.smtp.mountPath }}
     {{- end }}
     {{- if (gt (int .Values.kubecostAggregator.numDBCopyPartitions) 0) }}
     - name: NUM_DB_COPY_CHUNKS

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1017,6 +1017,10 @@ Begin Kubecost 2.0 templates
     - name: SMTP_CONFIG_MOUNT_PATH
       value: {{ .Values.kubecostProductConfigs.smtp.mountPath }}
     {{- end }}
+    {{- if .Values.smtpConfigmapName }}
+    - name: SMTP_CONFIGMAP_NAME
+      value: {{ .Values.smtpConfigmapName }}
+    {{- end }}
     {{- if (gt (int .Values.kubecostAggregator.numDBCopyPartitions) 0) }}
     - name: NUM_DB_COPY_CHUNKS
       value: {{ .Values.kubecostAggregator.numDBCopyPartitions | quote }}

--- a/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
@@ -16,6 +16,15 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+    - ''
+  resources:
+    - configmaps
+  verbs:
+    - get
+    - list
+    - watch
+    - update
 ---
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -141,6 +141,14 @@ spec:
             - key: productkey.json
               path: productkey.json
         {{- end }}
+        {{- if and ((.Values.kubecostProductConfigs).smtp).enabled ((.Values.kubecostProductConfigs).smtp).secretname }}
+        - name: smtp-secret
+          secret:
+            secretName: {{ .Values.kubecostProductConfigs.smtp.secretname }}
+            items:
+            - key: smtp.json
+              path: smtp.json
+        {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if .Values.kubecostProductConfigs.gcpSecretName }}
         - name: gcp-key-secret
@@ -586,6 +594,10 @@ spec:
             - name: productkey-secret
               mountPath: /var/configs/productkey
             {{- end }}
+            {{- if and ((.Values.kubecostProductConfigs).smtp).enabled ((.Values.kubecostProductConfigs).smtp).secretname }}
+            - name: smtp-secret
+              mountPath: /var/configs/smtp
+            {{- end }}
             {{- if .Values.kubecostProductConfigs.gcpSecretName }}
             - name: gcp-key-secret
               mountPath: /var/secrets
@@ -673,6 +685,10 @@ spec:
             - name: PRODUCT_CONFIGMAP_NAME
               value: {{ .Values.productConfigmapName }}
             {{- end }}
+            {{- if .Values.smtpConfigmapName }}
+            - name: SMTP_CONFIGMAP_NAME
+              value: {{ .Values.smtpConfigmapName }}
+            {{- end }}
             {{- if .Values.appConfigmapName }}
             - name: APP_CONFIGMAP_NAME
               value: {{ .Values.appConfigmapName }}
@@ -734,6 +750,10 @@ spec:
             {{- if ((.Values.kubecostProductConfigs).productKey).mountPath }}
             - name: PRODUCT_KEY_MOUNT_PATH
               value: {{ .Values.kubecostProductConfigs.productKey.mountPath }}
+            {{- end }}
+            {{- if ((.Values.kubecostProductConfigs).smtp).mountPath }}
+            - name: SMTP_CONFIG_MOUNT_PATH
+              value: {{ .Values.kubecostProductConfigs.smtp.mountPath }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs.ingestPodUID }}
             - name: INGEST_POD_UID

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -816,6 +816,22 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/smtp {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/smtp;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/smtp/test {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/smtp/test;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/teams {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/teams;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -816,22 +816,6 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location = /model/smtp {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/smtp;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/smtp/test {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/smtp/test;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
         location = /model/teams {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/teams;

--- a/cost-analyzer/templates/cost-analyzer-smtp-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-smtp-configmap.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.kubecostProductConfigs }}
+{{- if .Values.kubecostProductConfigs.smtp }}
+{{- if .Values.kubecostProductConfigs.smtp.enabled }}
+# If the smtp.config is not specified, the configmap will not be created
+{{- if .Values.kubecostProductConfigs.smtp.config }}
+# If the secretname is specified, the configmap will not be created
+{{- if not .Values.kubecostProductConfigs.smtp.secretname }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ default "smtp-configs" .Values.smtpConfigmapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  {{- if .Values.kubecostProductConfigs.smtp.config }}
+  config: {{  .Values.kubecostProductConfigs.smtp.config | quote }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-smtp-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-smtp-configmap.yaml
@@ -1,6 +1,4 @@
-{{- if .Values.kubecostProductConfigs }}
-{{- if .Values.kubecostProductConfigs.smtp }}
-{{- if .Values.kubecostProductConfigs.smtp.enabled }}
+{{- if (((.Values.kubecostProductConfigs).smtp).enabled) }}
 # If the smtp.config is not specified, the configmap will not be created
 {{- if .Values.kubecostProductConfigs.smtp.config }}
 # If the secretname is specified, the configmap will not be created
@@ -11,13 +9,11 @@ metadata:
   name: {{ default "smtp-configs" .Values.smtpConfigmapName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   {{- if .Values.kubecostProductConfigs.smtp.config }}
   config: {{  .Values.kubecostProductConfigs.smtp.config | quote }}
   {{- end -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3272,6 +3272,11 @@ costEventsAudit:
 #     key: ""
 #     secretname: productkeysecret # Reference an existing k8s secret created from a file named productkey.json of format { "key": "enterprise-key-here" }. If the secretname is specified, a configmap with the key will not be created.
 #     mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) Declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "enterprise-key-here" }.
+#   smtp:
+#     enabled: false
+#     config: ""
+#     secretname: smtpconfigsecret
+#     mountPath: "/some/custom/path/smtp.json"
 #   carbonEstimates: false # Enables Kubecost beta carbon estimation endpoints /assets/carbon and /allocations/carbon
 
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3272,11 +3272,21 @@ costEventsAudit:
 #     key: ""
 #     secretname: productkeysecret # Reference an existing k8s secret created from a file named productkey.json of format { "key": "enterprise-key-here" }. If the secretname is specified, a configmap with the key will not be created.
 #     mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) Declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "enterprise-key-here" }.
+#   # The following block enables the use of a custom SMTP server which overrides Kubecost's built-in, external SMTP server for alerts and reports
 #   smtp:
 #     enabled: false
-#     config: ""
-#     secretname: smtpconfigsecret
-#     mountPath: "/some/custom/path/smtp.json"
+#     config:  |
+#       {
+#         "sender_email": "",
+#         "host": "",
+#         "port": 587,
+#         "authentication": true,
+#         "username": "",
+#         "password": "",
+#         "secure": true
+#       }
+#     secretname: smtpconfigsecret # Reference an existing k8s secret created from a file named smtp.json of format specified by config above. If the secretname is specified, a configmap with the key will not be created.
+#     mountPath: "/some/custom/path/smtp.json" # (use instead of secretname) Declare the path at which the SMTP config file is mounted (eg. by a secrets provisioner). The file must be of format specified by config above.
 #   carbonEstimates: false # Enables Kubecost beta carbon estimation endpoints /assets/carbon and /allocations/carbon
 
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3341,8 +3341,10 @@ costEventsAudit:
   # ingestPodUID: false # Enables using UIDs to uniquely ID pods. This requires either Kubecost's replicated KSM metrics, or KSM v2.1.0+. This may impact performance, and changes the default cost-model allocation behavior.
   # regionOverrides: "region1,region2,region3" # list of regions which will override default costmodel provider regions
 
-# Explicit name of the ConfigMap to use for pricing overrides. If not set, a default will apply.
+# Explicit names of various ConfigMaps to use. If not set, a default will apply.
 # pricingConfigmapName: ""
+# productConfigmapName: ""
+# smtpConfigmapName: ""
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates


### PR DESCRIPTION
## What does this PR change?
* Enables the associated KCM changes, allowing for a configurable SMTP server.

## Does this PR rely on any other PRs?
* [KCM](https://github.com/kubecost/kubecost-cost-model/pull/2397).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Users will now be able to configure a custom SMTP server through which to send alert, report, etc. email.

## What risks are associated with merging this PR? What is required to fully test this PR?
* Minimal risks involved; features are being added, not modified.

## How was this PR tested?
* Validated that SMTP configs are populated as expected via all the various configuration methods:
  * Helm config map.
  * Helm secret.
  * API.