### PR TITLE
networkCosts-on-by-default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2235,7 +2235,7 @@ prometheus:
 ## Module for measuring network costs
 ## Ref: https://github.com/kubecost/docs/blob/main/network-allocation.md
 networkCosts:
-  enabled: false
+  enabled: true
   image:
     repository: gcr.io/kubecost1/kubecost-network-costs
     tag: v0.17.3
@@ -2311,13 +2311,13 @@ networkCosts:
     services:
       # google-cloud-services: when set to true, enables labeling traffic metrics with google cloud
       # service endpoints
-      google-cloud-services: false
+      google-cloud-services: true
       # amazon-web-services: when set to true, enables labeling traffic metrics with amazon web service
       # endpoints.
-      amazon-web-services: false
+      amazon-web-services: true
       # azure-cloud-services: when set to true, enables labeling traffic metrics with azure cloud service
       # endpoints
-      azure-cloud-services: false
+      azure-cloud-services: true
       # user defined services provide a way to define custom service endpoints which will label traffic metrics
       # falling within the defined address range.
       # services:


### PR DESCRIPTION
## What does this PR change?
turn networkCosts on by default

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Enables network insights for all without having to find the settings to enable it

## What risks are associated with merging this PR? What is required to fully test this PR?
This has been used by hundreds of users for years. Some may not want this, but it is easily disabled. 

## How was this PR tested?
local helm installs

## Have you made an update to documentation? If so, please provide the corresponding PR.

@bstuder99 could you help with this please?

We need to modify networkcosts doc to show how to disable the DS and or cloud provider support by settings these to false.

```yaml
networkCosts:
  enabled: true
  config:
    services:
      google-cloud-services: true
      amazon-web-services: true
      azure-cloud-services: true
```
