### PR TITLE
Fix bug from upstream grafana-dashboards-json-configmap.yaml

### DIFF
--- a/cost-analyzer/templates/grafana-dashboards-json-configmap.yaml
+++ b/cost-analyzer/templates/grafana-dashboards-json-configmap.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" $ }}-dashboards-{{ $provider }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "grafana.name" $ }}
     release: {{ $.Release.Name }}


### PR DESCRIPTION
see: https://github.com/helm/charts/pull/14441/files

## What does this PR change?
Fix a small bug which breaks dashboards in grafana. This was fixed upstream:

https://github.com/helm/charts/pull/14441/files

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixed a bug so creating grafana dashboards from values.yaml is possible again.

## Links to Issues or tickets this PR addresses or fixes
https://github.com/helm/charts/pull/14441/files



## What risks are associated with merging this PR? What is required to fully test this PR?
No risk, was broken, fix was posted upstream.

## How was this PR tested?
In grafana repo :) 

## Have you made an update to documentation? If so, please provide the corresponding PR.
No need.
