### PR TITLE
bump kc-modeling v0.1.9

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -18,7 +18,7 @@ kubecostModel:
   image: public.ecr.aws/kubecost/cost-model
 
 forecasting:
-  fullImageName: public.ecr.aws/kubecost/kubecost-modeling:v0.1.7
+  fullImageName: public.ecr.aws/kubecost/kubecost-modeling:v0.1.9
 
 networkCosts:
   image:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2395,7 +2395,7 @@ forecasting:
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
   # Example: fullImageName: gcr.io/kubecost1/forecasting:v0.0.1
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.7
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.9
 
   # Resource specification block for the forecasting container.
   resources:


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
Bumps kc-modeling image to v0.1.9 with bug fixes for anomaly detection on an empty set of allocations and cloudcosts.


## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fix an issue with anomaly detection giving a http 500 error when querying a window that has no allocation or cloud cost data ingested yet.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
n/a

## How was this PR tested?
locally

## Have you made an update to documentation? If so, please provide the corresponding PR.
n/a
