### PR TITLE
Custom SMTP server patch

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -947,7 +947,7 @@ Begin Kubecost 2.0 templates
     - name: productkey-secret
       mountPath: /var/configs/productkey
     {{- end }}
-    {{- if and ((.Values.kubecostProductConfigs).smtp).enabled ((.Values.kubecostProductConfigs).smtp).secretname (eq (include "aggregator.deployMethod" .) "statefulset") }}
+    {{- if and ((.Values.kubecostProductConfigs).smtp).secretname (eq (include "aggregator.deployMethod" .) "statefulset") }}
     - name: smtp-secret
       mountPath: /var/configs/smtp
     {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -141,7 +141,7 @@ spec:
             - key: productkey.json
               path: productkey.json
         {{- end }}
-        {{- if and ((.Values.kubecostProductConfigs).smtp).enabled ((.Values.kubecostProductConfigs).smtp).secretname }}
+        {{- if ((.Values.kubecostProductConfigs).smtp).secretname }}
         - name: smtp-secret
           secret:
             secretName: {{ .Values.kubecostProductConfigs.smtp.secretname }}
@@ -594,7 +594,7 @@ spec:
             - name: productkey-secret
               mountPath: /var/configs/productkey
             {{- end }}
-            {{- if and ((.Values.kubecostProductConfigs).smtp).enabled ((.Values.kubecostProductConfigs).smtp).secretname }}
+            {{- if ((.Values.kubecostProductConfigs).smtp).secretname }}
             - name: smtp-secret
               mountPath: /var/configs/smtp
             {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-smtp-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-smtp-configmap.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
-{{- if .Values.kubecostProductConfigs.smtp.config }}
+{{- if (((.Values.kubecostProductConfigs).smtp).config) }}
 data:
   config: {{  .Values.kubecostProductConfigs.smtp.config | quote }}
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-smtp-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-smtp-configmap.yaml
@@ -1,8 +1,3 @@
-{{- if (((.Values.kubecostProductConfigs).smtp).enabled) }}
-# If the smtp.config is not specified, the configmap will not be created
-{{- if .Values.kubecostProductConfigs.smtp.config }}
-# If the secretname is specified, the configmap will not be created
-{{- if not .Values.kubecostProductConfigs.smtp.secretname }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,10 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+{{- if .Values.kubecostProductConfigs.smtp.config }}
 data:
-  {{- if .Values.kubecostProductConfigs.smtp.config }}
   config: {{  .Values.kubecostProductConfigs.smtp.config | quote }}
-  {{- end -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3274,7 +3274,6 @@ costEventsAudit:
 #     mountPath: "/some/custom/path/productkey.json" # (use instead of secretname) Declare the path at which the product key file is mounted (eg. by a secrets provisioner). The file must be of format { "key": "enterprise-key-here" }.
 #   # The following block enables the use of a custom SMTP server which overrides Kubecost's built-in, external SMTP server for alerts and reports
 #   smtp:
-#     enabled: false
 #     config:  |
 #       {
 #         "sender_email": "",


### PR DESCRIPTION
## What does this PR change?
- Removes the `kubecostProductConfigs.smtp.enabled` value. `enabled` was a misnomer, and was actually used to determine whether SMTP was _able_ to be configured, not whether it _is_ configured.
- This fix will allow the FE to set an SMTP config, when one hasn't already been set via Helm.

## Does this PR rely on any other PRs?
- Nope.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- SMTP will be configurable via FE.

## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

