### PR TITLE
networkCosts off by default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2232,17 +2232,18 @@ prometheus:
     enabled: false
 
 
-## Module for measuring network costs
-## Ref: https://github.com/kubecost/docs/blob/main/network-allocation.md
+## Optional daemonset to more accurately attribute network costs to the correct workload
+## https://docs.kubecost.com/install-and-configure/advanced-configuration/network-costs-configuration
 networkCosts:
-  enabled: true
+  enabled: false
   image:
     repository: gcr.io/kubecost1/kubecost-network-costs
     tag: v0.17.3
   imagePullPolicy: Always
   updateStrategy:
     type: RollingUpdate
-  # For existing Prometheus Installs, annotates the Service which generates Endpoints for each of the network-costs pods.
+  # For existing Prometheus Installs, use the serviceMonitor: or prometheusScrape below.
+  # the below setting annotates the networkCost service endpoints for each of the network-costs pods.
   # The Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.
   # NOTE: Setting this option to true and leaving the above extraScrapeConfig "job_name: kubecost-networking" configured will cause the
   # NOTE: pods to be scraped twice.


### PR DESCRIPTION
## What does this PR change?
Reverts part of:
https://github.com/kubecost/cost-analyzer-helm-chart/pull/3383

Docs impact:
https://github.com/kubecost/docs/pull/1031

reasoning: 
network costs consumes resources, and the added value for many may not outweigh the costs of running the DS. 
