### PR TITLE
increase default data build to 731d from 91d

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1026,7 +1026,7 @@ Begin Kubecost 2.0 templates
       value: {{ .Values.smtpConfigmapName }}
     {{- end }}
     - name: ETL_DAILY_STORE_DURATION_DAYS
-      value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 731) }}
+      value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) }}
     {{- if (gt (int .Values.kubecostAggregator.numDBCopyPartitions) 0) }}
     - name: NUM_DB_COPY_CHUNKS
       value: {{ .Values.kubecostAggregator.numDBCopyPartitions | quote }}
@@ -1260,7 +1260,7 @@ Begin Kubecost 2.0 templates
       value: "true"
     {{- end}}
     - name: ETL_DAILY_STORE_DURATION_DAYS
-      value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 731) }}
+      value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) }}
     - name: CLOUD_COST_REFRESH_RATE_HOURS
       value: {{ .Values.kubecostAggregator.cloudCost.refreshRateHours | default 6 | quote }}
     - name: CLOUD_COST_QUERY_WINDOW_DAYS

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1025,6 +1025,8 @@ Begin Kubecost 2.0 templates
     - name: SMTP_CONFIGMAP_NAME
       value: {{ .Values.smtpConfigmapName }}
     {{- end }}
+    - name: ETL_DAILY_STORE_DURATION_DAYS
+      value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 731) }}
     {{- if (gt (int .Values.kubecostAggregator.numDBCopyPartitions) 0) }}
     - name: NUM_DB_COPY_CHUNKS
       value: {{ .Values.kubecostAggregator.numDBCopyPartitions | quote }}
@@ -1258,7 +1260,7 @@ Begin Kubecost 2.0 templates
       value: "true"
     {{- end}}
     - name: ETL_DAILY_STORE_DURATION_DAYS
-      value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 91) }}
+      value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 731) }}
     - name: CLOUD_COST_REFRESH_RATE_HOURS
       value: {{ .Values.kubecostAggregator.cloudCost.refreshRateHours | default 6 | quote }}
     - name: CLOUD_COST_QUERY_WINDOW_DAYS

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -870,7 +870,7 @@ spec:
             - name: ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES
               value: {{ (quote .Values.kubecostModel.maxPrometheusQueryDurationMinutes) | default (quote 1440) }}
             - name: ETL_DAILY_STORE_DURATION_DAYS
-              value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 731) }}
+              value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) }}
             - name: ETL_HOURLY_STORE_DURATION_HOURS
               value: {{ (quote .Values.kubecostModel.etlHourlyStoreDurationHours) | default (quote 49) }}
             - name: ETL_WEEKLY_STORE_DURATION_WEEKS

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -870,7 +870,7 @@ spec:
             - name: ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES
               value: {{ (quote .Values.kubecostModel.maxPrometheusQueryDurationMinutes) | default (quote 1440) }}
             - name: ETL_DAILY_STORE_DURATION_DAYS
-              value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 91) }}
+              value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) | default (quote 731) }}
             - name: ETL_HOURLY_STORE_DURATION_HOURS
               value: {{ (quote .Values.kubecostModel.etlHourlyStoreDurationHours) | default (quote 49) }}
             - name: ETL_WEEKLY_STORE_DURATION_WEEKS

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -566,7 +566,7 @@ kubecostModel:
   etlFileStoreEnabled: true
   # The total number of days the ETL pipelines will build
   # Set to 0 to disable daily ETL (not recommended)
-  etlDailyStoreDurationDays: 91
+  etlDailyStoreDurationDays: 731
   # The total number of hours the ETL pipelines will build
   # Set to 0 to disable hourly ETL (not recommended)
   # Must be < prometheus server retention, otherwise empty data may overwrite


### PR DESCRIPTION
## What does this PR change?
increase default retention to 731d from 91d. The previous value was low to save resources with the previous Kubecost architecture. With aggregator, there is no longer a need for this to be 91d. 

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Changed default Kubecost retention to 731d from 91d

## What risks are associated with merging this PR? What is required to fully test this PR?
Many users already do this. Slightly more memory usage over time.

## How was this PR tested?
local qa envs

## Have you made an update to documentation? If so, please provide the corresponding PR.
@bstuder99 please take a look for the retention defaults and update?

to use the previous default, set:
```yaml
kubecostModel:
  etlDailyStoreDurationDays: 91
```
