### PR TITLE
add required flag for upgrade to ack full reingest but not on install

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,4 +1,5 @@
 --------------------------------------------------
+{{- include "kubecostV2.3-reingestion-precondition" . -}}
 {{- include "kubecostV2-preconditions" . -}}
 {{- include "cloudIntegrationSourceCheck" . -}}
 {{- include "eksCheck" . -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -32,6 +32,18 @@ Set important variables before starting main templates
 {{- end -}}
 
 {{/*
+Kubecost 2.3 precondition that a full re-ingestion will be triggered for aggregator
+*/}}
+{{- define "kubecostV2.3-reingestion-precondition" -}}
+    {{- if semverCompare ">= 2.1.0-0 <2.4.0-0" .Chart.Version }}
+        {{- if gt .Release.Revision 1 -}}
+            {{- if not .Values.upgrade.acknowledgeV2dot3FullReingestion -}}
+                {{- fail "\n\nKubecost 2.3 requires a full reingestion of all data which will could significant time. Please acknowledge by setting 'upgrade.acknowledgeV2dot3FullReingestion' to 'true' in your values file." -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{/*
 Kubecost 2.0 preconditions
 */}}
 {{- define "kubecostV2-preconditions" -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Set important variables before starting main templates
 Kubecost 2.3 precondition that a full re-ingestion will be triggered for aggregator
 */}}
 {{- define "kubecostV2.3-reingestion-precondition" -}}
-    {{- if semverCompare ">= 2.1.0-0 <2.4.0-0" .Chart.Version }}
+    {{- if semverCompare ">= 2.3.0-0 <2.4.0-0" .Chart.Version }}
         {{- if gt .Release.Revision 1 -}}
             {{- if not .Values.upgrade.acknowledgeV2dot3FullReingestion -}}
                 {{- fail "\n\nKubecost 2.3 requires a full reingestion of all data which will could take significant time. Please acknowledge by setting 'upgrade.acknowledgeV2dot3FullReingestion' to 'true' in your values file." -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Kubecost 2.3 precondition that a full re-ingestion will be triggered for aggrega
     {{- if semverCompare ">= 2.1.0-0 <2.4.0-0" .Chart.Version }}
         {{- if gt .Release.Revision 1 -}}
             {{- if not .Values.upgrade.acknowledgeV2dot3FullReingestion -}}
-                {{- fail "\n\nKubecost 2.3 requires a full reingestion of all data which will could significant time. Please acknowledge by setting 'upgrade.acknowledgeV2dot3FullReingestion' to 'true' in your values file." -}}
+                {{- fail "\n\nKubecost 2.3 requires a full reingestion of all data which will could take significant time. Please acknowledge by setting 'upgrade.acknowledgeV2dot3FullReingestion' to 'true' in your values file." -}}
             {{- end -}}
         {{- end -}}
     {{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Set important variables before starting main templates
 Kubecost 2.3 precondition that a full re-ingestion will be triggered for aggregator
 */}}
 {{- define "kubecostV2.3-reingestion-precondition" -}}
-    {{- if semverCompare ">= 2.3.0-0 <2.4.0-0" .Chart.Version }}
+    {{- if semverCompare ">= 2.3.0-0" .Chart.Version }}
         {{- if gt .Release.Revision 1 -}}
             {{- if not .Values.upgrade.acknowledgeV2dot3FullReingestion -}}
                 {{- fail "\n\nKubecost 2.3 requires a full reingestion of all data which will could take significant time. Please acknowledge by setting 'upgrade.acknowledgeV2dot3FullReingestion' to 'true' in your values file." -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -304,10 +304,9 @@ global:
 ##
 upgrade:
   toV2: false
+  ## This flag is only required for users upgrading to 2.3 from a previous version.
+  ## This is because 2.3 will trigger a full re-ingestion of all available data into aggregator.
   acknowledgeV2dot3FullReingestion: false
-
-## This flag is only required for users upgrading to 2.3 from a previous version.
-## This is because 2.3 will trigger a full re-ingestion of all available data into aggregator.
 
 # generated at http://kubecost.com/install, used for alerts tracking and free trials
 kubecostToken:  # ""

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -304,7 +304,7 @@ global:
 ##
 upgrade:
   toV2: false
-  ## This flag is only required for users upgrading to 2.3 from a previous version.
+  ## This flag is only required for users upgrading to 2.3 or later from a previous version.
   ## This is because 2.3 will trigger a full re-ingestion of all available data into aggregator.
   acknowledgeV2dot3FullReingestion: false
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -304,6 +304,10 @@ global:
 ##
 upgrade:
   toV2: false
+  acknowledgeV2dot3FullReingestion: false
+
+## This flag is only required for users upgrading to 2.3 from a previous version.
+## This is because 2.3 will trigger a full re-ingestion of all available data into aggregator.
 
 # generated at http://kubecost.com/install, used for alerts tracking and free trials
 kubecostToken:  # ""


### PR DESCRIPTION
## What does this PR change?
Users upgrading to a version through helm starting with 2.3.0 will be required to pass a helm value acknowledging a full re-ingestion may be triggered. Fresh installs will not require the flag (but on an additional helm revision to another 2.3.x version, will be required to pass the flag).

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Values.upgrade.acknowledgeV2dot3FullReingestion will be required for upgrading users

## Links to Issues or tickets this PR addresses or fixes
n/a?

## What risks are associated with merging this PR? What is required to fully test this PR?
Annoyance - this flag is currently fairly dumb - it will be required on any (non-installation) upgrade for 2.3 bugfixes, even though there is no full reingestion and db migration taking place.

## How was this PR tested?
Manually

## Have you made an update to documentation? If so, please provide the corresponding PR.
Not yet - this PR is just a fast way to collect feedback
