### PR TITLE
move ingestion and derivation diagnostic endpoints

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -984,25 +984,25 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location = /model/diagnostic/ingestionRecords {
+        location = /model/debug/ingestionRecords {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/ingestionRecords;
+            proxy_pass http://aggregator/debug/ingestionRecords;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location = /model/diagnostic/ingestionSummary {
+        location = /model/debug/ingestionSummary {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/ingestionSummary;
+            proxy_pass http://aggregator/debug/ingestionSummary;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location = /model/diagnostic/derivationRecords {
+        location = /model/debug/derivationRecords {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/derivationRecords;
+            proxy_pass http://aggregator/debug/derivationRecords;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;


### PR DESCRIPTION
## What does this PR change?
Requested changes for diagnostics (directly hitting the write DB) caused code in KCM to move to a different package, and thus rename these endpoints. I am not implementing a re-direct since these endpoints have not been released yet.

## Does this PR rely on any other PRs?
https://github.com/kubecost/kubecost-cost-model/pull/2457

## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/SELFHOST-1395

## What risks are associated with merging this PR? What is required to fully test this PR?
none

## How was this PR tested?
manually

## Have you made an update to documentation? If so, please provide the corresponding PR.
to be done
