### PR TITLE
add fe flag for retention, remove obsolete weekly retention

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -873,8 +873,6 @@ spec:
               value: {{ (quote .Values.kubecostModel.etlDailyStoreDurationDays) }}
             - name: ETL_HOURLY_STORE_DURATION_HOURS
               value: {{ (quote .Values.kubecostModel.etlHourlyStoreDurationHours) | default (quote 49) }}
-            - name: ETL_WEEKLY_STORE_DURATION_WEEKS
-              value: {{ (quote .Values.kubecostModel.etlWeeklyStoreDurationWeeks) | default (quote 53) }}
             - name: ETL_FILE_STORE_ENABLED
               value: {{ (quote .Values.kubecostModel.etlFileStoreEnabled) | default (quote true) }}
             - name: ETL_ASSET_RECONCILIATION_ENABLED

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1302,7 +1302,9 @@ data:
                 "carbonEstimatesEnabled": "{{ template "carbonEstimatesEnabled" . }}",
                 "clusterControllerEnabled": "{{ template "clusterControllerEnabled" . }}",
                 "forecastingEnabled": "{{ template "forecastingEnabled" . }}",
-                "chartVersion": "DEVELOP_BRANCH"
+                "chartVersion": "DEVELOP_BRANCH",
+                "hourlyDataRetention": "{{ (.Values.kubecostModel.etlHourlyStoreDurationHours) }}",
+                "dailyDataRetention": "{{ (.Values.kubecostModel.etlDailyStoreDurationDays) }}"
                 }
             ';
         }

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -568,14 +568,10 @@ kubecostModel:
   # Set to 0 to disable daily ETL (not recommended)
   etlDailyStoreDurationDays: 731
   # The total number of hours the ETL pipelines will build
-  # Set to 0 to disable hourly ETL (not recommended)
+  # Set to 0 to disable hourly ETL (recommended for large environments)
   # Must be < prometheus server retention, otherwise empty data may overwrite
   # known-good data
   etlHourlyStoreDurationHours: 49
-  # The total number of weeks the ETL pipelines will build
-  # Set to 0 to disable weekly ETL (not recommended)
-  # The default is 53 to ensure at least a year of coverage (371 days)
-  etlWeeklyStoreDurationWeeks: 53
   # For deploying kubecost in a cluster that does not self-monitor
   etlReadOnlyMode: false
 


### PR DESCRIPTION
## What does this PR change?
-Adds FE flag to show what retention to expect for each store
-Recommend disabling hourly data in large environments
-Remove obsolete values for weekly store

## Does this PR rely on any other PRs?
No, required for FE enhancement

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Kubecost recomends disabling hourly data in large environements- this will double the performance of data ingestion and halve size etl data store in the PV and S3

## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
Helm template:

```sh
helm template kubecost ./cost-analyzer |ag Retention               
                "hourlyDataRetention": "49",
                "dailyDataRetention": "731",
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

