### PR TITLE
Bump clustercontroller 0.16.1

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2655,7 +2655,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.0
+    tag: v0.16.1
   imagePullPolicy: IfNotPresent
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
Bump cluster controller 0.16.1 for Fixing CVE-2023-45288 and CVE-2024-24788

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

