### PR TITLE
Adding support for the Azure Monitor Managed Service for Prometheus

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
@@ -19,6 +19,8 @@ data:
     prometheus-server-endpoint: {{ .Values.global.gmp.prometheusServerEndpoint }}
   {{- else if .Values.global.amp.enabled }}
     prometheus-server-endpoint: {{ .Values.global.amp.prometheusServerEndpoint }}
+  {{- else if .Values.global.ammsp.enabled }}
+    prometheus-server-endpoint: {{ .Values.global.ammsp.prometheusServerEndpoint }}
   {{- else if .Values.global.prometheus.enabled }}
   {{- if .Values.global.zone }}
     prometheus-server-endpoint: http://{{ template "cost-analyzer.prometheus.server.name" . }}.{{ .Release.Namespace  }}.svc.{{ .Values.global.zone }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -491,6 +491,77 @@ spec:
           - name: ubbagent-config
             mountPath: /etc/ubbagent
         {{- end }}
+        {{- if .Values.global.ammsp.enabled }}
+        - name: {{ .Values.global.ammsp.aadAuthProxy.name }}
+          image: {{ .Values.global.ammsp.aadAuthProxy.image }}
+          {{- if .Values.global.ammsp.aadAuthProxy.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.global.ammsp.aadAuthProxy.imagePullPolicy }}
+          {{- else }}
+          imagePullPolicy: Always
+          {{- end }}
+          env:
+          - name: AUDIENCE
+            value: {{ .Values.global.ammsp.aadAuthProxy.audience }}
+          - name: TARGET_HOST
+            value: {{ .Values.global.ammsp.queryEndpoint }}
+          - name: LISTENING_PORT
+            value: {{ .Values.global.ammsp.aadAuthProxy.port | quote }}
+          - name: IDENTITY_TYPE
+            value: {{ .Values.global.ammsp.aadAuthProxy.identityType }}
+          {{- if eq .Values.global.ammsp.aadAuthProxy.identityType "userAssigned"}}
+          - name: AAD_CLIENT_ID
+            value: {{ required "aadClientId is required for userAssigned identity types" .Values.global.ammsp.aadAuthProxy.aadClientId | toString | trim | quote }}
+          {{- else if eq .Values.global.ammsp.aadAuthProxy.identityType "aadApplication" }}
+          - name: AAD_CLIENT_ID
+            value: {{ required "aadClientId is required for aadApplication identity types" .Values.global.ammsp.aadAuthProxy.aadClientId | toString | trim | quote }}
+          - name: AAD_TENANT_ID
+            value: {{ required "aadTenantId is required for aadApplication identity type" .Values.global.ammsp.aadAuthProxy.aadTenantId | toString | trim | quote }}
+          - name: AAD_CLIENT_CERTIFICATE_PATH
+            value: {{ required "aadClientCertificatePath is required for aadApplication identity type" .Values.global.ammsp.aadAuthProxy.aadClientCertificatePath | toString | trim | quote }}
+          {{- end}}
+          - name: AAD_TOKEN_REFRESH_INTERVAL_IN_PERCENTAGE
+            value: "10"
+          - name: OTEL_SERVICE_NAME
+            value: {{ .Values.global.ammsp.aadAuthProxy.name | replace "-" "_" }}
+          {{- if .Values.systemProxy.enabled }}
+          - name: HTTP_PROXY
+            value: "{{ .Values.systemProxy.httpProxyUrl }}"
+          - name: http_proxy
+            value: "{{ .Values.systemProxy.httpProxyUrl }}"
+          - name: HTTPS_PROXY
+            value: "{{ .Values.systemProxy.httpsProxyUrl }}"
+          - name: https_proxy
+            value: "{{ .Values.systemProxy.httpsProxyUrl }}"
+          - name: NO_PROXY
+            value: "{{ .Values.systemProxy.noProxy }}"
+          - name: no_proxy
+            value: "{{ .Values.systemProxy.noProxy }}"
+          {{- end }}
+          ports:
+          - name: http
+            containerPort: {{ .Values.global.ammsp.aadAuthProxy.port | int }}
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+        {{- end }}
         {{- if .Values.kubecostModel }}
         {{- if .Values.kubecostModel.fullImageName }}
         - image: {{ .Values.kubecostModel.fullImageName }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -492,6 +492,8 @@ spec:
             mountPath: /etc/ubbagent
         {{- end }}
         {{- if .Values.global.ammsp.enabled }}
+        # This section of the chart borrows liberally from
+        # https://github.com/Azure/aad-auth-proxy/blob/main/deploy/chart/aad-auth-proxy/templates/deployment.yaml
         - name: {{ .Values.global.ammsp.aadAuthProxy.name }}
           image: {{ .Values.global.ammsp.aadAuthProxy.image }}
           {{- if .Values.global.ammsp.aadAuthProxy.imagePullPolicy }}
@@ -508,7 +510,7 @@ spec:
             value: {{ .Values.global.ammsp.aadAuthProxy.port | quote }}
           - name: IDENTITY_TYPE
             value: {{ .Values.global.ammsp.aadAuthProxy.identityType }}
-          {{- if eq .Values.global.ammsp.aadAuthProxy.identityType "userAssigned"}}
+          {{- if eq .Values.global.ammsp.aadAuthProxy.identityType "userAssigned" }}
           - name: AAD_CLIENT_ID
             value: {{ required "aadClientId is required for userAssigned identity types" .Values.global.ammsp.aadAuthProxy.aadClientId | toString | trim | quote }}
           {{- else if eq .Values.global.ammsp.aadAuthProxy.identityType "aadApplication" }}
@@ -518,7 +520,7 @@ spec:
             value: {{ required "aadTenantId is required for aadApplication identity type" .Values.global.ammsp.aadAuthProxy.aadTenantId | toString | trim | quote }}
           - name: AAD_CLIENT_CERTIFICATE_PATH
             value: {{ required "aadClientCertificatePath is required for aadApplication identity type" .Values.global.ammsp.aadAuthProxy.aadClientCertificatePath | toString | trim | quote }}
-          {{- end}}
+          {{- end }}
           - name: AAD_TOKEN_REFRESH_INTERVAL_IN_PERCENTAGE
             value: "10"
           - name: OTEL_SERVICE_NAME

--- a/cost-analyzer/templates/prometheus-server-configmap.yaml
+++ b/cost-analyzer/templates/prometheus-server-configmap.yaml
@@ -22,6 +22,8 @@ data:
 {{ $root.Values.global.amp.sigv4 | toYaml | indent 8 }}
 {{- end }}
 {{- if $root.Values.global.ammsp.enabled }}
+    # See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
+    # for guidance on this configuration option
     remote_write:
       - url: {{ $root.Values.global.ammsp.remoteWriteService }}
         azuread:

--- a/cost-analyzer/templates/prometheus-server-configmap.yaml
+++ b/cost-analyzer/templates/prometheus-server-configmap.yaml
@@ -21,6 +21,14 @@ data:
       sigv4:
 {{ $root.Values.global.amp.sigv4 | toYaml | indent 8 }}
 {{- end }}
+{{- if $root.Values.global.ammsp.enabled }}
+    remote_write:
+      - url: {{ $root.Values.global.ammsp.remoteWriteService }}
+        azuread:
+          cloud: 'AzurePublic'
+          managed_identity:
+            client_id: {{ $root.Values.global.ammsp.aadAuthProxy.aadClientId }}
+{{- end }}
 {{- if $root.Values.prometheus.server.remoteWrite }}
     remote_write:
 {{ $root.Values.prometheus.server.remoteWrite | toYaml | indent 4 }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -63,6 +63,27 @@ global:
       # username: user
       # password: pwd
 
+  # Azure Monitor Managed Service for Prometheus
+  # See https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-monitor/essentials/prometheus-metrics-overview.md for information
+  # and https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/prometheus-remote-write-virtual-machines for more information on setting this up
+  ammsp:
+    enabled: false
+    prometheusServerEndpoint: http://localhost:8081/
+    remoteWriteService: $<AMMSP_METRICS_INGESTION_ENDPOINT>
+    queryEndpoint: $<AMMSP_QUERY_ENDPOINT>
+
+    aadAuthProxy:
+      enabled: false
+      # per https://github.com/Azure/aad-auth-proxy/releases/tag/0.1.0-main-04-10-2024-7067ac84
+      image: mcr.microsoft.com/azuremonitor/auth-proxy/prod/aad-auth-proxy/images/aad-auth-proxy:0.1.0-main-04-10-2024-7067ac84
+      imagePullPolicy: IfNotPresent
+      name: aad-auth-proxy
+      port: 8081
+      audience: https://prometheus.monitor.azure.com/.default
+      identityType: userAssigned
+      aadClientId: $<AZURE_MANAGED_IDENTITY_CLIENT_ID>
+      aadTenantId: $<AZURE_MANAGED_IDENTITY_TENANT_ID>
+
   notifications:
     # Kubecost alerting configuration
     # Ref: http://docs.kubecost.com/alerts

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -75,7 +75,7 @@ global:
     aadAuthProxy:
       enabled: false
       # per https://github.com/Azure/aad-auth-proxy/releases/tag/0.1.0-main-04-10-2024-7067ac84
-      image: mcr.microsoft.com/azuremonitor/auth-proxy/prod/aad-auth-proxy/images/aad-auth-proxy:0.1.0-main-04-10-2024-7067ac84
+      image: $<IMAGE>  # Example: mcr.microsoft.com/azuremonitor/auth-proxy/prod/aad-auth-proxy/images/aad-auth-proxy:0.1.0-main-04-10-2024-7067ac84
       imagePullPolicy: IfNotPresent
       name: aad-auth-proxy
       port: 8081


### PR DESCRIPTION
## What does this PR change?

This PR adds support for the [Azure Monitor Managed Service for Prometheus](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/prometheus-metrics-overview) as a target for remote writes and queries. My intention was for it to work in the same way as the other cloud providers' listed in the [Prometheus Configuration Guide](https://docs.kubecost.com/install-and-configure/advanced-configuration/custom-prom).

## Does this PR rely on any other PRs?

No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

With this PR, users will be able to use Azure's managed Prometheus offering as a remote_write target and query source, bypassing the bundled Prometheus.

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

I am not fully familiar with the risks, but none of the new functionality is enabled by default, so it shouldn't do anything unless someone turns it on.

## How was this PR tested?

I installed it on my own cluster and validated that 1) I was able to see the Kubecost metrics in Azure-managed Prometheus, and 2) Kubecost was able to issue queries even with the bundled Prometheus pod scaled down to zero.

## Have you made an update to documentation? If so, please provide the corresponding PR.

No.