### PR TITLE
add aggregator metrics to prometheus

### DIFF
--- a/cost-analyzer/templates/aggregator-servicemonitor.yaml
+++ b/cost-analyzer/templates/aggregator-servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceMonitor.aggregatorMetrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "aggregator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "aggregator.commonLabels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.aggregatorMetrics.additionalLabels }}
+    {{ toYaml .Values.serviceMonitor.aggregatorMetrics.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: tcp-api
+      interval: {{ .Values.serviceMonitor.aggregatorMetrics.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.aggregatorMetrics.scrapeTimeout }}
+      path: /metrics
+      scheme: http
+      {{- with .Values.serviceMonitor.aggregatorMetrics.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.aggregatorMetrics.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+    {{- include "aggregator.commonLabels" . | nindent 6 }}
+{{- end }}

--- a/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
@@ -14,8 +14,8 @@ spec:
   endpoints:
     - port: tcp-model
       honorLabels: true
-      interval: 1m
-      scrapeTimeout: 10s
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       path: /metrics
       scheme: http
       {{- with .Values.serviceMonitor.metricRelabelings }}

--- a/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
@@ -13,7 +13,7 @@ spec:
   endpoints:
     - port: metrics
       honorLabels: true
-      interval: 1m
+      interval: {{ .Values.serviceMonitor.networkCosts.interval }}
       scrapeTimeout: {{ .Values.serviceMonitor.networkCosts.scrapeTimeout }}
       path: /metrics
       scheme: http

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -867,6 +867,20 @@ prometheus:
         - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
           action: keep
           regex:  network-costs
+    - job_name: kubecost-aggregator
+      scrape_interval: 1m
+      scrape_timeout: 60s
+      metrics_path: /metrics
+      scheme: http
+      dns_sd_configs:
+      - names:
+        - {{ template "aggregator.serviceName" . }}
+        type: 'A'
+        {{- if or .Values.saml.enabled .Values.oidc.enabled }}
+        port: 9008
+        {{- else }}
+        port: 9004
+        {{- end }}
   server:
     # If clusterIDConfigmap is defined, instead use user-generated configmap with key CLUSTER_ID
     # to use as unique cluster ID in kubecost cost-analyzer deployment.
@@ -2777,16 +2791,25 @@ reporting:
 
 serviceMonitor:  # the kubecost included prometheus uses scrapeConfigs and does not support service monitors. The following options assume an existing prometheus that supports serviceMonitors.
   enabled: false
+  interval: 1m
+  scrapeTimeout: 10s
   additionalLabels: {}
   metricRelabelings: []
   relabelings: []
   networkCosts:
     enabled: false
+    interval: 1m
     scrapeTimeout: 10s
     additionalLabels: {}
     metricRelabelings: []
     relabelings: []
-
+  aggregatorMetrics:
+    enabled: false
+    interval: 1m
+    scrapeTimeout: 10s
+    additionalLabels: {}
+    metricRelabelings: []
+    relabelings: []
 prometheusRule:
   enabled: false
   additionalLabels: {}


### PR DESCRIPTION
## What does this PR change?
add scrape config for new aggregator telemetry metrics

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Added metrics for better visibility into aggregator health
- Added parameters to serviceMonitors to configure scrape intervals for all metrics

## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
Tested the scrape config with default prometheus as well as servicemonitor

## Have you made an update to documentation? If so, please provide the corresponding PR.
Docs needed
