### PR TITLE
fix option for non-federated primary

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: development
 description: Kubecost Helm chart - monitor your cloud costs!
 name: cost-analyzer
-version: v2024.06.06
+version: 2.2.2
 icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
 annotations:
   "artifacthub.io/links": |

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: development
 description: Kubecost Helm chart - monitor your cloud costs!
 name: cost-analyzer
-version: 2.2.2
+version: v2024.06.06
 icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
 annotations:
   "artifacthub.io/links": |

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -851,7 +851,7 @@ spec:
             {{- end }}
             {{- if or .Values.federatedETL.federatedCluster .Values.kubecostModel.federatedStorageConfigSecret }}
             - name: FEDERATED_CLUSTER
-              {{- if eq .Values.federatedETL.federatedCluster false }}
+              {{- if eq .Values.federatedETL.readOnlyPrimary true }}
               value: "false"
               {{- else }}
               value: "true"

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -851,7 +851,11 @@ spec:
             {{- end }}
             {{- if or .Values.federatedETL.federatedCluster .Values.kubecostModel.federatedStorageConfigSecret }}
             - name: FEDERATED_CLUSTER
+              {{- if eq .Values.federatedETL.federatedCluster false }}
+              value: "false"
+              {{- else }}
               value: "true"
+              {{- end }}
             {{- end }}
             {{- if .Values.federatedETL.redirectS3Backup }}
             - name: FEDERATED_REDIRECT_BACKUP

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3148,8 +3148,10 @@ federatedETL:
   ## If true, push ETL data to the federated storage bucket
   federatedCluster: false
 
-  ## If true, the primary cluster will only read from the primary cluster and not ship it's own metrics
-  ## this allows a global kubecost-agent to be deployed to clusters, without a separate config for the primary cluster
+  ## If true, this cluster will be able to read from the federated-store but will
+  ## not write to it. This is useful in situations when you want to deploy a
+  ## primary cluster, but don't want the primary cluster's ETL data to be
+  ## pushed to the bucket
   readOnlyPrimary: false
 
   ## If true, changes the dir of S3 backup to the Federated combined store.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3148,6 +3148,10 @@ federatedETL:
   ## If true, push ETL data to the federated storage bucket
   federatedCluster: false
 
+  ## If true, the primary cluster will only read from the primary cluster and not ship it's own metrics
+  ## this allows a global kubecost-agent to be deployed to clusters, without a separate config for the primary cluster
+  readOnlyPrimary: false
+
   ## If true, changes the dir of S3 backup to the Federated combined store.
   ## Commonly used when transitioning from Thanos to Federated ETL architecture.
   redirectS3Backup: false


### PR DESCRIPTION
## What does this PR change?
allows the primary to serve UI without shipping the local cluster metrics to s3. This can be useful when 
1. a global Kubecost agent is deployed to all clusters already
2. for a parallel kubecost environment on the same primary

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Add option for readOnly primary Kubecost configurations

## What risks are associated with merging this PR? What is required to fully test this PR?
Low risk as this is a new key pair and would only be used for specific goals

## How was this PR tested?
Tested by setting readOnlyPrimary=true and check the /federated folder to verify the cluster_id was not present

```yaml
federatedETL:
  readOnlyPrimary: true
```
## Have you made an update to documentation? If so, please provide the corresponding PR.
Added comments. I see this as mostly an option for support to help our enterprise customers as of now.
