### PR TITLE
feat: create checksum for configmaps and secrets to enforce restart w…

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1434,3 +1434,39 @@ for more information
 {{- printf "false" -}}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+  Compute a checksum based on the rendered content of specific ConfigMaps and Secrets.
+*/ -}}
+{{- define "configsChecksum" -}}
+{{- $files := list
+  "cost-analyzer-account-mapping-configmap.yaml"
+  "cost-analyzer-advanced-reports-configmap.yaml"
+  "cost-analyzer-alerts-configmap.yaml"
+  "cost-analyzer-asset-reports-configmap.yaml"
+  "cost-analyzer-cloud-cost-reports-configmap.yaml"
+  "cost-analyzer-config-map-template.yaml"
+  "cost-analyzer-frontend-config-map-template.yaml"
+  "cost-analyzer-metrics-config-map-template.yaml"
+  "cost-analyzer-network-costs-config-map-template.yaml"
+  "cost-analyzer-oidc-config-map-template.yaml"
+  "cost-analyzer-pkey-configmap.yaml"
+  "cost-analyzer-pricing-configmap.yaml"
+  "cost-analyzer-saml-config-map-template.yaml"
+  "cost-analyzer-saved-reports-configmap.yaml"
+  "cost-analyzer-server-configmap.yaml"
+  "cost-analyzer-smtp-configmap.yaml"
+  "gcpstore-config-map-template.yaml"
+  "install-plugins.yaml"
+  "integrations-postgres-queries-configmap.yaml"
+  "kubecost-cluster-controller-actions-config.yaml"
+  "kubecost-cluster-manager-configmap-template.yaml"
+  "mimir-proxy-configmap-template.yaml"
+-}}
+{{- $checksum := "" -}}
+{{- range $files -}}
+  {{- $content := include (print $.Template.BasePath (printf "/%s" .)) $ -}}
+  {{- $checksum = printf "%s%s" $checksum $content | sha256sum -}}
+{{- end -}}
+{{- $checksum | sha256sum -}}
+{{- end -}}

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -41,10 +41,11 @@ spec:
         {{- with .Values.global.additionalLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.global.podAnnotations}}
       annotations:
+        {{- with .Values.global.podAnnotations}}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        checksum/configs: {{ include "configsChecksum" . }}
     spec:
       {{- if .Values.global.platforms.openshift.enabled }}
       securityContext:

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -52,10 +52,11 @@ spec:
         {{- with .Values.global.additionalLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.global.podAnnotations}}
       annotations:
+        {{- with .Values.global.podAnnotations}}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        checksum/configs: {{ include "configsChecksum" . }}
     spec:
       restartPolicy: Always
     {{- if .Values.kubecostAggregator.securityContext }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -51,10 +51,11 @@ spec:
         {{- if and .Values.kubecostDeployment .Values.kubecostDeployment.labels }}
         {{- toYaml .Values.kubecostDeployment.labels | nindent 8 }}
         {{- end }}
-      {{- with .Values.global.podAnnotations}}
       annotations:
+        {{- with .Values.global.podAnnotations}}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        checksum/configs: {{ include "configsChecksum" . }}
     spec:
       {{- if .Values.global.platforms.openshift.enabled }}
       securityContext:

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         {{- with .Values.global.podAnnotations}}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        checksum/configs: {{ include "configsChecksum" . }}
     spec:
       restartPolicy: Always
       {{- if .Values.diagnostics.deployment.securityContext }}

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -49,10 +49,11 @@ spec:
         {{- if and .Values.kubecostDeployment .Values.kubecostDeployment.labels }}
         {{- toYaml .Values.kubecostDeployment.labels | nindent 8 }}
         {{- end }}
-      {{- with .Values.global.podAnnotations}}
       annotations:
+        {{- with .Values.global.podAnnotations}}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        checksum/configs: {{ include "configsChecksum" . }}
     spec:
       {{- if .Values.global.platforms.openshift.enabled }}
       securityContext:

--- a/cost-analyzer/templates/prometheus-server-deployment.yaml
+++ b/cost-analyzer/templates/prometheus-server-deployment.yaml
@@ -26,10 +26,11 @@ spec:
   {{- end }}
   template:
     metadata:
-    {{- if .Values.prometheus.server.podAnnotations }}
       annotations:
+    {{- if .Values.prometheus.server.podAnnotations }}
 {{ toYaml .Values.prometheus.server.podAnnotations | indent 8 }}
     {{- end }}
+        checksum/configs: {{ include "configsChecksum" . }}
       labels:
         {{/*
         Force pod restarts on upgrades to ensure the configmap is current


### PR DESCRIPTION
…hen really needed in a gitops friendly way

## What does this PR change?



with this PR deployments where "helm-rollout-restarter" annotation or label is used, I introduced a checksum of rendered configmaps and secrets. the configmaps and secrets which are honored are listed in the _helpers.tpl function configsChecksum. So this list needs to be maintained.

## Does this PR rely on any other PRs?

this PR is a duplicate of https://github.com/kubecost/cost-analyzer-helm-chart/pull/3407 since I deleted my fork repo by accident

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

with this PR pods get restarted also when cicd is set to true

## Links to Issues or tickets this PR addresses or fixes

fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/3403



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?

```
helm template . |grep checksum
        checksum/configs: df0658db2eb919288b37b12dc7dde460d4d19890c81e085c945f39c468d33256
        checksum/configs: df0658db2eb919288b37b12dc7dde460d4d19890c81e085c945f39c468d33256

helm template . --set kubecostToken=blub | grep checksum
        checksum/configs: b472370c2d05a1e7b3dabf7b269fddb5722c91b90d63fa1a9d253ac89793e52e
        checksum/configs: b472370c2d05a1e7b3dabf7b269fddb5722c91b90d63fa1a9d253ac89793e52e
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

no