### PR TITLE
remove env: from aggregator

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1094,10 +1094,16 @@ Begin Kubecost 2.0 templates
       value: "true"
       {{- end }}
     {{- end }}
-    {{- range $key, $value := .Values.kubecostAggregator.env }}
-    - name: {{ $key | quote }}
-      value: {{ $value | quote }}
-    {{- end }}
+    - name: LOG_LEVEL
+      value: {{ .Values.kubecostAggregator.logLevel }}
+    - name: DB_COPY_FULL
+      value: {{ (quote .Values.kubecostAggregator.dbCopyFull) | default (quote true) }}
+    - name: DB_READ_THREADS
+      value: {{ .Values.kubecostAggregator.dbReadThreads | quote }}
+    - name: DB_WRITE_THREADS
+      value: {{ .Values.kubecostAggregator.dbWriteThreads | quote }}
+    - name: DB_CONCURRENT_INGESTION_COUNT
+      value: {{ .Values.kubecostAggregator.dbConcurrentIngestionCount | quote }}
     - name: KUBECOST_NAMESPACE
       value: {{ .Release.Namespace }}
     {{- if .Values.oidc.enabled }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2518,13 +2518,13 @@ kubecostAggregator:
   # the default of 25 is sufficient for 95%+ of users. This should only be modified
   # after consulting with Kubecost's support team
   numDBCopyPartitions: 25
+  logLevel: info
 
   # env: has been removed to avoid unknown issues that would be caused by
   # customizations that were required to run aggregator in previous versions
   # extraEnv: can be used to add new environment variables to the aggregator pod
 
   # the below settings should only be modified with support from Kubecost staff
-  logLevel: info # info, debug, warn, error, fatal, panic
   dbReadThreads: 1
   dbWriteThreads: 1
   dbConcurrentIngestionCount: 3

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2519,12 +2519,16 @@ kubecostAggregator:
   # after consulting with Kubecost's support team
   numDBCopyPartitions: 25
 
-  env:
-    "LOG_LEVEL": "info"
-    "DB_READ_THREADS": "1"
-    "DB_WRITE_THREADS": "1"
-    "DB_CONCURRENT_INGESTION_COUNT": "3"
-    "DB_COPY_FULL": "true"
+  # env: has been removed to avoid unknown issues that would be caused by
+  # customizations that were required to run aggregator in previous versions
+  # extraEnv: can be used to add new environment variables to the aggregator pod
+
+  # the below settings should only be modified with support from Kubecost staff
+  logLevel: info # info, debug, warn, error, fatal, panic
+  dbReadThreads: 1
+  dbWriteThreads: 1
+  dbConcurrentIngestionCount: 3
+  dbCopyFull: true
 
   persistentConfigsStorage:
     storageClass: ""  # default storage class


### PR DESCRIPTION
## What does this PR change?
Removed kubecostAggregator.env from helm values to avoid unknown issues that would be caused by previous customizations.

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
kubecostAggregator.env has been removed from the helm values to avoid unknown issues that would be caused by previous customizations. Aggregator has been improved and should not need any of these previous settings. Any environment variables that are needed can be set with kubecostAggregator.extraEnv

## What risks are associated with merging this PR? What is required to fully test this PR?
Unknown user configurations

## How was this PR tested?
Test in QA environments and verified env: values were not used.

## Have you made an update to documentation? If so, please provide the corresponding PR.
Will have a strong note in release notes, but there should be little to no impact.
