### PR TITLE
bump cluster controller from 0.16.1 to 0.16.2 for go version bump CVE…

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2699,7 +2699,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.1
+    tag: v0.16.2
   imagePullPolicy: IfNotPresent
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
…-2024-24790

Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
bump cluster controller from 0.16.1 to 0.16.2 for go toolchain CVE 2024-24790

## Does this PR rely on any other PRs?
https://github.com/kubecost/cluster-controller/pull/91

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
na

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
na, builder change only, built locally to test

## How was this PR tested?
built container locally

## Have you made an update to documentation? If so, please provide the corresponding PR.
na
