### PR TITLE
additional aggregator tuning

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,5 +1,6 @@
 --------------------------------------------------
 {{- include "kubecostV2-preconditions" . -}}
+{{- include "kubecostV2-3-preconditions" . -}}
 {{- include "cloudIntegrationSourceCheck" . -}}
 {{- include "eksCheck" . -}}
 {{- include "cloudIntegrationSecretCheck" . -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Kubecost 2.3 preconditions
 */}}
 {{- define "kubecostV2-3-preconditions" -}}
   {{- if (.Values.kubecostAggregator.env) -}}
-    {{- fail "Upgrade issue:\nKubecost 2.3 has updated the aggregator's environment variables. \nPlease update your Helm values to use the new key pairs. See:\nhttps://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations \nfor additional information. \nIn Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs.\nThis was done to prevent unexpected behavior and to simplify the aggregator's configuration." -}}
+    {{- fail "Upgrade issue: Kubecost 2.3 has updated the aggregator's environment variables. Please update your Helm values to use the new key pairs. \n\n For more information, see: https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations \n\n In Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs. This was done to prevent unexpected behavior and to simplify the aggregator's configuration." -}}
   {{- end -}}
 {{- end -}}
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1122,7 +1122,7 @@ Begin Kubecost 2.0 templates
       value: {{ .Values.kubecostAggregator.dbWriteMemoryLimit | quote }}
     {{- end }}
     - name: ETL_DAILY_STORE_DURATION_DAYS
-      value: {{ .Values.kubecostAggregator.etlDayStoreDurationDays | quote }}
+      value: {{ .Values.kubecostAggregator.etlDailyStoreDurationDays | quote }}
     - name: KUBECOST_NAMESPACE
       value: {{ .Release.Namespace }}
     {{- if .Values.oidc.enabled }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1104,6 +1104,16 @@ Begin Kubecost 2.0 templates
       value: {{ .Values.kubecostAggregator.dbWriteThreads | quote }}
     - name: DB_CONCURRENT_INGESTION_COUNT
       value: {{ .Values.kubecostAggregator.dbConcurrentIngestionCount | quote }}
+    {{- if ne .Values.kubecostAggregator.dbMemoryLimit "0Gi" }}
+    - name: DB_MEMORY_LIMIT
+      value: {{ .Values.kubecostAggregator.dbMemoryLimit | quote }}
+    {{- end }}
+    {{- if ne .Values.kubecostAggregator.dbWriteMemoryLimit "0Gi" }}
+    - name: DB_WRITE_MEMORY_LIMIT
+      value: {{ .Values.kubecostAggregator.dbWriteMemoryLimit | quote }}
+    {{- end }}
+    - name: ETL_DAILY_STORE_DURATION_DAYS
+      value: {{ .Values.kubecostAggregator.etlDayStoreDurationDays | quote }}
     - name: KUBECOST_NAMESPACE
       value: {{ .Release.Namespace }}
     {{- if .Values.oidc.enabled }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -32,6 +32,15 @@ Set important variables before starting main templates
 {{- end -}}
 
 {{/*
+Kubecost 2.3 preconditions
+*/}}
+{{- define "kubecostV2-3-preconditions" -}}
+  {{- if (.Values.kubecostAggregator.env) -}}
+    {{- fail "Upgrade issue:\nKubecost 2.3 has updated the aggregator's environment variables. \nPlease update your values.yaml to use the new key pairs. See:\nhttps://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations \nfor additional information. \nIn Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs.\nThis was done to prevent unexpected behavior and to simplify the aggregator's configuration." -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Kubecost 2.0 preconditions
 */}}
 {{- define "kubecostV2-preconditions" -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Kubecost 2.3 preconditions
 */}}
 {{- define "kubecostV2-3-preconditions" -}}
   {{- if (.Values.kubecostAggregator.env) -}}
-    {{- fail "Upgrade issue:\nKubecost 2.3 has updated the aggregator's environment variables. \nPlease update your values.yaml to use the new key pairs. See:\nhttps://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations \nfor additional information. \nIn Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs.\nThis was done to prevent unexpected behavior and to simplify the aggregator's configuration." -}}
+    {{- fail "Upgrade issue:\nKubecost 2.3 has updated the aggregator's environment variables. \nPlease update your Helm values to use the new key pairs. See:\nhttps://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations \nfor additional information. \nIn Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs.\nThis was done to prevent unexpected behavior and to simplify the aggregator's configuration." -}}
   {{- end -}}
 {{- end -}}
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2554,7 +2554,7 @@ kubecostAggregator:
   # to keep in the DB before rolling the data off.
   #
   # Note: If increasing this value to backfill historical data, it will take
-  # time to gradually ingest & process those historical ETL files. Consider
+  # time to gradually ingest and process those historical ETL files. Consider
   # also increasing the resources available to the aggregator as well as the
   # refresh & concurrency env vars.
   #

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2541,7 +2541,7 @@ kubecostAggregator:
   # but can be increased if trying to backfill historical data.
   # default: 1
   dbConcurrentIngestionCount: 1
-  # dbCopyFull: "true" can improve the time it takes to copy the write DB, 
+  # dbCopyFull: "true" can improve the time it takes to copy the write DB,
   # at the expense of additional memory usages.
   dbCopyFull: "false"
   # Memory limit applied to read database connections.
@@ -2552,12 +2552,12 @@ kubecostAggregator:
   dbWriteMemoryLimit: 0Gi
   # How much data to ingest from the federated store bucket, and how much data
   # to keep in the DB before rolling the data off.
-  # 
+  #
   # Note: If increasing this value to backfill historical data, it will take
   # time to gradually ingest & process those historical ETL files. Consider
   # also increasing the resources available to the aggregator as well as the
   # refresh & concurrency env vars.
-  # 
+  #
   # default: 91
   etlDayStoreDurationDays: 91
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2556,7 +2556,7 @@ kubecostAggregator:
   # Note: If increasing this value to backfill historical data, it will take
   # time to gradually ingest and process those historical ETL files. Consider
   # also increasing the resources available to the aggregator as well as the
-  # refresh & concurrency env vars.
+  # refresh and concurrency env vars.
   #
   # default: 91
   etlDayStoreDurationDays: 91

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2525,10 +2525,41 @@ kubecostAggregator:
   # extraEnv: can be used to add new environment variables to the aggregator pod
 
   # the below settings should only be modified with support from Kubecost staff
+
+  # How many threads the read database is configured with (i.e. Kubecost API /
+  # UI queries). If increasing this value, it is recommended to increase the
+  # aggregator's memory requests & limits.
+  # default: 1
   dbReadThreads: 1
+  # How many threads the write database is configured with (i.e. ingestion of
+  # new data from S3). If increasing this value, it is recommended to increase
+  # the aggregator's memory requests & limits.
+  # default: 1
   dbWriteThreads: 1
+  # How many threads to use when ingesting Asset/Allocation/CloudCost data
+  # from the federated store bucket. In most cases the default is sufficient,
+  # but can be increased if trying to backfill historical data.
+  # default: 1
   dbConcurrentIngestionCount: 1
-  dbCopyFull: false
+  # dbCopyFull: "true" can improve the time it takes to copy the write DB, 
+  # at the expense of additional memory usages.
+  dbCopyFull: "false"
+  # Memory limit applied to read database connections.
+  # default: 0Gi is no limit
+  dbMemoryLimit: 0Gi
+  # Memory limit applied to write database connections.
+  # default: 0Gi is no limit
+  dbWriteMemoryLimit: 0Gi
+  # How much data to ingest from the federated store bucket, and how much data
+  # to keep in the DB before rolling the data off.
+  # 
+  # Note: If increasing this value to backfill historical data, it will take
+  # time to gradually ingest & process those historical ETL files. Consider
+  # also increasing the resources available to the aggregator as well as the
+  # refresh & concurrency env vars.
+  # 
+  # default: 91
+  etlDayStoreDurationDays: 91
 
   persistentConfigsStorage:
     storageClass: ""  # default storage class

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2559,7 +2559,7 @@ kubecostAggregator:
   # refresh and concurrency env vars.
   #
   # default: 91
-  etlDayStoreDurationDays: 91
+  etlDailyStoreDurationDays: 91
 
   persistentConfigsStorage:
     storageClass: ""  # default storage class

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2543,7 +2543,7 @@ kubecostAggregator:
   dbConcurrentIngestionCount: 1
   # dbCopyFull: "true" can improve the time it takes to copy the write DB,
   # at the expense of additional memory usages.
-  dbCopyFull: "false"
+  dbCopyFull: false
   # Memory limit applied to read database connections.
   # default: 0Gi is no limit
   dbMemoryLimit: 0Gi


### PR DESCRIPTION
## What does this PR change?
Adding key pairs for more common tuning parameters.
Added helm failure to prevent unknowingly removing required variables.

Message to users with .Values.kubecostAggregator.env`  settings:

```
Error: UPGRADE FAILED: execution error at (cost-analyzer/templates/NOTES.txt:3:4): Upgrade issue:
Kubecost 2.3 has updated the aggregator's environment variables. 
Please update your values.yaml to use the new key pairs. See:
https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations 
for additional information. 
In Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs.
This was done to prevent unexpected behavior and to simplify the aggregator's configuration.
```

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adding key pairs for more common tuning parameters. Any user with `.Values.kubecostAggregator.env` configurations must update the configuration to use these key pairs. 

## Links to Issues or tickets this PR addresses or fixes
NA

## What risks are associated with merging this PR? What is required to fully test this PR?
Fixes an issue discovered internally by @thomasvn 

## How was this PR tested?
Helm templating and against QA environments to ensure no duplicate values are created.

## Have you made an update to documentation? If so, please provide the corresponding PR.

https://github.com/kubecost/docs/pull/1074