### PR TITLE
no dupe labels

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -44,7 +44,6 @@ spec:
         {{- if not .Values.global.platforms.cicd.enabled }}
         helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
         {{- end }}
-        {{- include "cost-analyzer.commonLabels" . | nindent 8 }}
         {{- if .Values.global.additionalLabels }}
         {{ toYaml .Values.global.additionalLabels | nindent 8 }}
         {{- end }}

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -41,7 +41,6 @@ spec:
         {{- if not .Values.global.platforms.cicd.enabled }}
         helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
         {{- end }}
-        {{- include "cost-analyzer.commonLabels" . | nindent 8 }}
         {{- include "frontend.selectorLabels" . | nindent 8 }}
         {{- if .Values.global.additionalLabels }}
         {{- toYaml .Values.global.additionalLabels | nindent 8 }}


### PR DESCRIPTION
## What does this PR change?
Remove duplicate labels from cost-analyzer and frontend deployments

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Removed duplicate labels from cost-analyzer and frontend pods

## Links to Issues or tickets this PR addresses or fixes
Resolve issue reported by FluxCD helm-controller via slack

## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
Manually verified the labels are not duplicated and that Kubecost is still healthy 

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
