### PR TITLE
fix units

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1113,11 +1113,11 @@ Begin Kubecost 2.0 templates
       value: {{ .Values.kubecostAggregator.dbWriteThreads | quote }}
     - name: DB_CONCURRENT_INGESTION_COUNT
       value: {{ .Values.kubecostAggregator.dbConcurrentIngestionCount | quote }}
-    {{- if ne .Values.kubecostAggregator.dbMemoryLimit "0Gi" }}
+    {{- if ne .Values.kubecostAggregator.dbMemoryLimit "0GB" }}
     - name: DB_MEMORY_LIMIT
       value: {{ .Values.kubecostAggregator.dbMemoryLimit | quote }}
     {{- end }}
-    {{- if ne .Values.kubecostAggregator.dbWriteMemoryLimit "0Gi" }}
+    {{- if ne .Values.kubecostAggregator.dbWriteMemoryLimit "0GB" }}
     - name: DB_WRITE_MEMORY_LIMIT
       value: {{ .Values.kubecostAggregator.dbWriteMemoryLimit | quote }}
     {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2545,11 +2545,11 @@ kubecostAggregator:
   # at the expense of additional memory usages.
   dbCopyFull: false
   # Memory limit applied to read database connections.
-  # default: 0Gi is no limit
-  dbMemoryLimit: 0Gi
+  # default: 0GB is no limit
+  dbMemoryLimit: 0GB
   # Memory limit applied to write database connections.
-  # default: 0Gi is no limit
-  dbWriteMemoryLimit: 0Gi
+  # default: 0GB is no limit
+  dbWriteMemoryLimit: 0GB
   # How much data to ingest from the federated store bucket, and how much data
   # to keep in the DB before rolling the data off.
   #


### PR DESCRIPTION
## What does this PR change?
fixes units used by duckdb memory limits

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
NA


## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
tested in a real environment, befofe change:
```
RR Failed executing W boot query 'SET memory_limit TO '1Gi'': Parser Error: Unknown unit for memory_limit: %s (expected: KB, MB, GB, TB for 1000^i units or KiB, MiB, GiB, TiB for 1024^i unites)
```

after, no log error.

## Have you made an update to documentation? If so, please provide the corresponding PR.
will update in TN's pending docs PR
