### PR TITLE
2.3.1 notice for values change

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 2.3.0
+appVersion: development
 description: Kubecost Helm chart - monitor your cloud costs!
 name: cost-analyzer
-version: 2.3.0
+version: 2.2.2
 icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
 annotations:
   "artifacthub.io/links": |

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: development
+appVersion: 2.3.0
 description: Kubecost Helm chart - monitor your cloud costs!
 name: cost-analyzer
-version: 2.2.2
+version: 2.3.0
 icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
 annotations:
   "artifacthub.io/links": |

--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -1,6 +1,5 @@
 --------------------------------------------------
 {{- include "kubecostV2-preconditions" . -}}
-{{- include "kubecostV2-3-preconditions" . -}}
 {{- include "cloudIntegrationSourceCheck" . -}}
 {{- include "eksCheck" . -}}
 {{- include "cloudIntegrationSecretCheck" . -}}
@@ -25,3 +24,4 @@ Please allow 25 minutes for Kubecost to gather metrics. A progress indicator wil
 
 Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install
 
+{{- include "kubecostV2-3-notices" . -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -32,13 +32,11 @@ Set important variables before starting main templates
 {{- end -}}
 
 {{/*
-Kubecost 2.3 preconditions
+Kubecost 2.3 notices
 */}}
 {{- define "kubecostV2-3-notices" -}}
   {{- if (.Values.kubecostAggregator).env -}}
-    {{- if (.Values.kubecostAggregator.env) -}}
-    {{- printf "\n\n\nNotice: Detected issue in values!\nKubecost 2.3 has updated the aggregator's environment variables. Please update your Helm values to use the new key pairs.\nFor more information, see: https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations\nIn Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs. This was done to prevent unexpected behavior and to simplify the aggregator's configuration." -}}
-    {{- end -}}
+    {{- printf "\n\n\nNotice: Issue in values detected.\nKubecost 2.3 has updated the aggregator's environment variables. Please update your Helm values to use the new key pairs.\nFor more information, see: https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations\nIn Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs. This was done to prevent unexpected behavior and to simplify the aggregator's configuration." -}}
   {{- end -}}
 {{- end -}}
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -36,8 +36,8 @@ Kubecost 2.3 preconditions
 */}}
 {{- define "kubecostV2-3-notices" -}}
   {{- if (.Values.kubecostAggregator).env -}}
-    {{- if hasKey .Values.kubecostAggregator.env "DB_BUCKET_REFRESH_INTERVAL" -}}
-      {{- printf "\n\nNotice: DB_BUCKET_REFRESH_INTERVAL is defined in your values. This setting is no longer needed in most environments as of Kubecost 2.3.\n\nFor more information, see: https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations" -}}
+    {{- if (.Values.kubecostAggregator.env) -}}
+    {{- printf "\n\n\nNotice: Detected issue in values!\nKubecost 2.3 has updated the aggregator's environment variables. Please update your Helm values to use the new key pairs.\nFor more information, see: https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations\nIn Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs. This was done to prevent unexpected behavior and to simplify the aggregator's configuration." -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -881,21 +881,6 @@ Create the name of the service account
 Begin Kubecost 2.0 templates
 ==============================================================
 */}}
-{{- define "aggregator.ETLDurationDays" -}}
-  {{- if hasKey .Values.kubecostAggregator.env "ETL_DAILY_STORE_DURATION_DAYS" -}}
-    {{- (index .Values.kubecostAggregator.env "ETL_DAILY_STORE_DURATION_DAYS") -}}
-  {{- else if .Values.kubecostAggregator.etlDailyStoreDurationDays -}}
-    {{- .Values.kubecostAggregator.etlDailyStoreDurationDays -}}
-  {{- end -}}
-{{- end -}}
-
-{{- define "aggregator.logLevel" -}}
-  {{- if hasKey .Values.kubecostAggregator.env "LOG_LEVEL" -}}
-    {{- (index .Values.kubecostAggregator.env "LOG_LEVEL") -}}
-  {{- else if .Values.kubecostAggregator.logLevel -}}
-    {{- .Values.kubecostAggregator.logLevel -}}
-  {{- end -}}
-{{- end -}}
 
 {{- define "aggregator.containerTemplate" }}
 - name: aggregator
@@ -1121,7 +1106,7 @@ Begin Kubecost 2.0 templates
       {{- end }}
     {{- end }}
     - name: LOG_LEVEL
-      value: {{ include "aggregator.logLevel" . | quote }}
+      value: {{ .Values.kubecostAggregator.logLevel }}
     - name: DB_COPY_FULL
       value: {{ (quote .Values.kubecostAggregator.dbCopyFull) | default (quote true) }}
     - name: DB_READ_THREADS
@@ -1139,7 +1124,7 @@ Begin Kubecost 2.0 templates
       value: {{ .Values.kubecostAggregator.dbWriteMemoryLimit | quote }}
     {{- end }}
     - name: ETL_DAILY_STORE_DURATION_DAYS
-      value: {{ include "aggregator.ETLDurationDays" . | quote }}
+      value: {{ .Values.kubecostAggregator.etlDailyStoreDurationDays | quote }}
     - name: KUBECOST_NAMESPACE
       value: {{ .Release.Namespace }}
     {{- if .Values.oidc.enabled }}


### PR DESCRIPTION
## What does this PR change?
Displays a notice for users that have legacy kubecostAggergator.env values

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Displays a notice for users that have legacy kubecostAggergator.env values
This will default all users to 91d data ingestion. To increase the history, it is recommended to first let aggregator build 91d and verify Kubecost is working as expected.

Then upgrade the values to add:
```yaml
kubecostAggergator:
  etlDailyStoreDurationDays: 365
```

## What risks are associated with merging this PR? What is required to fully test this PR?
Fixes issue where users were not informed of a change to default behavior.

## How was this PR tested?
Both with and without env to verify the message is output.

The message:
```
Kubecost 2.x is a major upgrade from previous versions and includes major new features including a brand new API Backend. Please review the following documentation to ensure a smooth transition: https://docs.kubecost.com/install-and-configure/install/kubecostv2

When pods are Ready, you can enable port-forwarding with the following command:

    kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090

Then, navigate to http://localhost:9090 in a web browser.

Please allow 25 minutes for Kubecost to gather metrics. A progress indicator will appear at the top of the UI.

Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install


Notice: Issue in values detected.
Kubecost 2.3 has updated the aggregator's environment variables. Please update your Helm values to use the new key pairs.
For more information, see: https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator#aggregator-optimizations
In Kubecost 2.3, kubecostAggregator.env is no longer used in favor of the new key pairs. This was done to prevent unexpected behavior and to simplify the aggregator's configuration.
```

## Have you made an update to documentation? If so, please provide the corresponding PR.
Already complete
