### PR TITLE
[CI] Bump/add cluster versions

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -61,17 +61,19 @@ jobs:
           - name: v1.23
             version: v1.23.17
           - name: v1.24
-            version: v1.24.15
+            version: v1.24.17
           - name: v1.25
-            version: v1.25.11
+            version: v1.25.16
           - name: v1.26
-            version: v1.26.6
+            version: v1.26.15
           - name: v1.27
-            version: v1.27.3
+            version: v1.27.13
           - name: v1.28
-            version: v1.28.0
+            version: v1.28.9
           - name: v1.29
-            version: v1.29.0
+            version: v1.29.4
+          - name: v1.30
+            version: v1.30.0
     needs: test-chart
     name: ${{ matrix.k8s-version.name }} test
     steps:

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -154,6 +154,8 @@ jobs:
           version: 4.13.0-okd
         - distribution: openshift
           version: 4.14.0-okd
+        - distribution: openshift
+          version: 4.15.0-okd
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -206,6 +206,8 @@ jobs:
           version: v1.28
         - distribution: eks
           version: v1.29
+        - distribution: eks
+          version: v1.30
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -232,7 +234,7 @@ jobs:
       - name: Install Kubecost chart with EKS values
         working-directory: ./cost-analyzer
         run: |
-          helm install --wait --wait-for-jobs kubecost . -n kubecost -f values-eks-cost-monitoring.yaml
+          helm install --wait --wait-for-jobs kubecost . -n kubecost -f values-eks-cost-monitoring.yaml --set persistentVolume.storageClass=gp2
         # run: ct install --namespace kubecost --chart-dirs=cost-analyzer/ --charts cost-analyzer/
       - name: Wait for ready 
         run: kubectl wait -n kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=120s


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

* Adds EKS v1.30 to the test matrix and forces the `gp2` StorageClass for all EKS installations.
* Updates all KinD minor versions to latest patch image
* Adds 1.30 to KinD test matrix
* Adds OKD 4.15 to test matrix

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

None, CI only.

## Links to Issues or tickets this PR addresses or fixes

Closes #3493



## What risks are associated with merging this PR? What is required to fully test this PR?

None, CI only.

## How was this PR tested?

Will be tested manually after PR is merged. Testing of this change will not be reflected in the Actions run as part of this PR (known limitation).

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A