### PR TITLE
add namespace label

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2870,7 +2870,11 @@ serviceMonitor:  # the kubecost included prometheus uses scrapeConfigs and does 
     scrapeTimeout: 10s
     additionalLabels: {}
     metricRelabelings: []
-    relabelings: []
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_namespace
+      targetLabel: namespace
 prometheusRule:
   enabled: false
   additionalLabels: {}


### PR DESCRIPTION
## What does this PR change?
adds namespace label to aggregator serviceMonitor. 


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
For users with multiple Kubecost environments on a single cluster that use serviceMonitors, this adds the namespace the metrics come from.

Mostly used internally

## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
QA environments

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
