### PR TITLE
update cluster controller to v0.16.3

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2730,7 +2730,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.2
+    tag: v0.16.3
   imagePullPolicy: IfNotPresent
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
## What does this PR change?
Enables http response codes to go in http header rather than the response body for all cluster turndown endpoints

## Does this PR rely on any other PRs?
* https://github.com/kubecost/cluster-controller/pull/98
* https://github.com/kubecost/cluster-turndown/pull/90

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Does not impact users

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/ENG-751
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
Low risk, only process that could be impacted is cluster turndown. Was unit tested and tests passed.

## How was this PR tested?
Unit tests in the cluster-turndown repo

## Have you made an update to documentation? If so, please provide the corresponding PR.

