### PR TITLE
add api config endpoints to nginx config

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1016,6 +1016,22 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/getApiConfig {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/getApiConfig;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/setApiConfig {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/setApiConfig;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/enablements {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/enablements;


### PR DESCRIPTION
## What does this PR change?
Nginx config for get and set api config endpoints in aggregator

## Does this PR rely on any other PRs?
https://github.com/kubecost/kubecost-cost-model/pull/2575

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fix a bug that broke custom labels

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
https://kubecost.atlassian.net/browse/ENG-2392


## What risks are associated with merging this PR? What is required to fully test this PR?
No risks, PR can be tested by setting custom labels in the settings UI and observing that custom labels have carried over to the allocations page

## How was this PR tested?
Put a custom image of this PR on qa-eks3 controller namespace, changed custom labels in settings UI, observed new custom label was working properly in the allocations UI. Also checked the apiconfig.json file in the aggregator pod, which contained all the expected custom label configurations.

## Have you made an update to documentation? If so, please provide the corresponding PR.
No docs needed
