### PR TITLE
bump cc version

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2735,7 +2735,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.3
+    tag: v0.16.4
   imagePullPolicy: IfNotPresent
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
## What does this PR change?
* https://github.com/kubecost/cluster-controller/pull/99
* https://github.com/kubecost/cluster-controller/pull/100

## Does this PR rely on any other PRs?
* See above for related PRs

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Release note from CC PR 99: Request Right Sizing Actions set via Helm will now properly populate in the Kubecost UI.
* Release note from CC PR 100: Prevent users from submitting namespace turndown actions with names that cause k8s api to error

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
* https://kubecost.atlassian.net/browse/ENG-2340
* https://kubecost.atlassian.net/browse/ENG-2302


## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Tested against controller namespace in qa-eks3

## Have you made an update to documentation? If so, please provide the corresponding PR.

