### PR TITLE
Collections Idle Support

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -792,9 +792,9 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location = /model/collection/settings/idle {
+        location = /model/collection/configs {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection/settings/idle;
+            proxy_pass http://aggregator/collection/configs;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -792,6 +792,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/collection/settings/idle {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/collection/settings/idle;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/networkinsights {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/networkinsights;


### PR DESCRIPTION
## What does this PR change?
* Proxies the `/model/collection/configs` endpoint, in order to enable idle collections in KCM.

## Does this PR rely on any other PRs?
* [KCM](https://github.com/kubecost/kubecost-cost-model/pull/2601).
* [Core](https://github.com/kubecost/kubecost-core/pull/62).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Users will now be able to view the impact of idle costs on their collections.

## Links to Issues or tickets this PR addresses or fixes
* [KC-270](https://kubecost.atlassian.net/jira/polaris/projects/KC/ideas/view/2936873?selectedIssue=KC-270&atlOrigin=eyJpIjoiYzE4YjZhNjE2NDdmNDgxN2IxZmUzZmFlZmNjNzgyZmUiLCJwIjoiaiJ9).

## What risks are associated with merging this PR? What is required to fully test this PR?
* No risks.

## How was this PR tested?
* Many iterations of testing with Niko, Ligon, and Cliff.

[KC-270]: https://kubecost.atlassian.net/browse/KC-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ