### PR TITLE
[CI] Replace EKS 1.27 test clusters with 1.29

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -203,9 +203,9 @@ jobs:
       matrix:
         cluster:
         - distribution: eks
-          version: v1.27
-        - distribution: eks
           version: v1.28
+        - distribution: eks
+          version: v1.29
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Replaces EKS 1.27 clusters with 1.29 in the v2.3 branch. EKS 1.27 is going into extended support so testing against these costs us more.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Non, CI only.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

CI may have issues but this is already in develop.

## How was this PR tested?

Tested effectively in develop branch where this version has been tested for a while.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A