### PR TITLE
Bump Prometheus from v2.52.0 to v2.53.1

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -951,7 +951,7 @@ prometheus:
     ##
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v2.52.0
+      tag: v2.53.1
       pullPolicy: IfNotPresent
 
     ## prometheus server priorityClassName


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Bumps Prometheus from v2.52.0 to v2.53.1. Don't know why Dependabot didn't pick this up. There are vulns in 2.52.0 that must be resolved.

## Does this PR rely on any other PRs?

No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

No expected impact other than running without vulns.


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
N/A


## What risks are associated with merging this PR? What is required to fully test this PR?

Prometheus may fail.

## How was this PR tested?

Will be tested in nightly environments.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A
