### PR TITLE
fix grafana enabled bool on aggregator

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1129,6 +1129,10 @@ Begin Kubecost 2.0 templates
       value: {{ .Values.kubecostAggregator.dbTrimMemoryOnClose | quote }}
     - name: KUBECOST_NAMESPACE
       value: {{ .Release.Namespace }}
+    {{- if .Values.global.grafana }}
+    - name: GRAFANA_ENABLED
+      value: "{{ template "cost-analyzer.grafanaEnabled" . }}"
+    {{- end}}
     {{- if .Values.oidc.enabled }}
     - name: OIDC_ENABLED
       value: "true"


### PR DESCRIPTION
## What does this PR change?
Adds GRAFANA_ENABLED env var to aggregator

Probably caused by https://github.com/kubecost/cost-analyzer-helm-chart/pull/3532? 

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixes error where grafana would show disabled even though it was enabled

## Links to Issues or tickets this PR addresses or fixes

https://github.com/kubecost/cost-analyzer-helm-chart/pull/3532

## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
Helm templating
```
helm template kubecost ../cost-analyzer |ag GRAFANA_ -A1 
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

NA