### PR TITLE
Add useClientSecretPost to fix okta oidc redirect loop

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -24,7 +24,7 @@ data:
         "discoveryURL" : "{{ .Values.oidc.discoveryURL }}",
         "hostedDomain" : "{{ .Values.oidc.hostedDomain }}",
         "skipOnlineTokenValidation" : "{{ .Values.oidc.skipOnlineTokenValidation | default "false" }}",
-        "useClientSecretPost": {{ .Values.oidc.useClientSecretPost | default "false" }},
+        "useClientSecretPost": {{ .Values.oidc.useClientSecretPost }},
         "rbac" : {
           "enabled" : {{ .Values.oidc.rbac.enabled }},
           "groups" : [

--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -24,6 +24,7 @@ data:
         "discoveryURL" : "{{ .Values.oidc.discoveryURL }}",
         "hostedDomain" : "{{ .Values.oidc.hostedDomain }}",
         "skipOnlineTokenValidation" : "{{ .Values.oidc.skipOnlineTokenValidation | default "false" }}",
+        "useClientSecretPost": {{ .Values.oidc.useClientSecretPost | default "false" }},
         "rbac" : {
           "enabled" : {{ .Values.oidc.rbac.enabled }},
           "groups" : [

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -376,6 +376,7 @@ oidc:
   # loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
   # discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
   skipOnlineTokenValidation: false  # if true, will skip accessing OIDC introspection endpoint for online token verification, and instead try to locally validate JWT claims
+  # useClientSecretPost: true # if true, client secret will specifically only use client_secret_post method, otherwise it will attempt to send the secret in both the header and the body.
   # hostedDomain: "example.com" # optional, blocks access to the auth domain specified in the hd claim of the provider ID token
   rbac:
     enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -376,7 +376,7 @@ oidc:
   # loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize" # Kubecost url configured in provider for redirect after authentication
   # discoveryURL: "https://my.auth.server/.well-known/openid-configuration" # url for OIDC endpoint discovery
   skipOnlineTokenValidation: false  # if true, will skip accessing OIDC introspection endpoint for online token verification, and instead try to locally validate JWT claims
-  # useClientSecretPost: true # if true, client secret will specifically only use client_secret_post method, otherwise it will attempt to send the secret in both the header and the body.
+  useClientSecretPost: false  # if true, client secret will specifically only use client_secret_post method, otherwise it will attempt to send the secret in both the header and the body.
   # hostedDomain: "example.com" # optional, blocks access to the auth domain specified in the hd claim of the provider ID token
   rbac:
     enabled: false


### PR DESCRIPTION
## What does this PR change?
Adds `useClientSecretPost` config to `.Values.oidc` which explicitly disables all auth methods except `client_secret_post` when doing client authentication while verifying tokens through the introspection endpoint.

## Does this PR rely on any other PRs?
Yes, see linked KCM PR.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds ability to disable all client auth methods except `client_secret_post`, which fixes issues where the Authorization header was invalid.

## Links to Issues or tickets this PR addresses or fixes


## What risks are associated with merging this PR? What is required to fully test this PR?
Testing done in linked PR.

## How was this PR tested?
Testing done in linked PR.

## Have you made an update to documentation? If so, please provide the corresponding PR.
No.
