### PR TITLE
alerts NGINX routing to aggregator pod

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1204,8 +1204,8 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # alert end points 
-        location = /model/alerts {
+        # alert end points with v2 will be routed to aggregator server
+        location = /model/v2/alerts {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/alerts;
             proxy_redirect off;
@@ -1213,7 +1213,7 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location ~* ^/model/alerts/(.*) {
+        location ~* ^/model/v2/alerts/(.*) {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/alerts/$1;
             proxy_redirect off;
@@ -1221,7 +1221,23 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-         
+        # alert end points without any version will be routed to model server
+        location = /model/alerts {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://model/alerts;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location ~* ^/model/alerts/(.*) {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://model/alerts/$1;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
 {{- end }}
         location = /model/hideOrphanedResources {
             default_type 'application/json';

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1203,6 +1203,25 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+
+        # alert end points 
+        location = /model/alerts {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/alerts;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location ~* ^/model/alerts/(.*) {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/alerts/$1;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+         
 {{- end }}
         location = /model/hideOrphanedResources {
             default_type 'application/json';


### PR DESCRIPTION
## What does this PR change?
Route to the new create end points in aggregator that use multi cluster data

## Does this PR rely on any other PRs?
[KCM PR ](https://github.com/kubecost/kubecost-cost-model/pull/2650)

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Alerts will be multi cluster 

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
All of the alerts with filter value passed

## How was this PR tested?
Tested all the alerts with filter values passed.

## Have you made an update to documentation? If so, please provide the corresponding PR.
None required changes are consistent with existing [doc](https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/alerts)
