### PR TITLE
Resolved issue where aggregator pod fails due to missing smtp-secret volume

### DIFF
--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -100,6 +100,14 @@ spec:
             - key: productkey.json
               path: productkey.json
         {{- end }}
+        {{- if ((.Values.kubecostProductConfigs).smtp).secretname }}
+        - name: smtp-secret
+          secret:
+            secretName: {{ .Values.kubecostProductConfigs.smtp.secretname }}
+            items:
+            - key: smtp.json
+              path: smtp.json
+        {{- end }}
         {{- if .Values.saml }}
         {{- if .Values.saml.enabled }}
         {{- if .Values.saml.secretName }}


### PR DESCRIPTION
Resolved issue where, when using an SMTP secret, the aggregator statefulset pod would fail to start due to a missing smtp-secret volume.

## What does this PR change?


## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

