### PR TITLE
[ENG-2603] Add /savings/nodeGroupSizingETL to aggregator

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -509,6 +509,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/savings/nodeGroupSizingETL {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/savings/nodeGroupSizingETL;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/cloudCost {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/cloudCost;


### PR DESCRIPTION
## What does this PR change?
This PR adds the new `/savings/nodeGroupSizingETL` API to the list of aggregator routes.

## Does this PR rely on any other PRs?
KCM: https://github.com/kubecost/kubecost-cost-model/pull/2658

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
New `/savings/nodeGroupSizingETL` API

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/ENG-2603

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

## What risks are associated with merging this PR? What is required to fully test this PR?
N/A

## How was this PR tested?
N/A

## Have you made an update to documentation? If so, please provide the corresponding PR.
N/A
