### PR TITLE
ENG-2660: schedule report test end point routes

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1246,6 +1246,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location ~* ^/model/reports/(.*)/schedule/test {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/reports/$1/schedule/test;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
 {{- end }}
         location = /model/hideOrphanedResources {
             default_type 'application/json';


### PR DESCRIPTION
## What does this PR change?
Add Nginx route to schedule report test end points

## Does this PR rely on any other PRs?
[2660](https://github.com/kubecost/kubecost-cost-model/pull/2660)

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No impact

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Jira: [ENG-2609](https://kubecost.atlassian.net/browse/ENG-2609)

## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
Putting latest image with the new nginx config it in single cluster and hitting these test end points

## Have you made an update to documentation? If so, please provide the corresponding PR.
There is no need of documentation at this time. This is more for us to not wait for scheduled reports and test if they work immediately.


[ENG-2609]: https://kubecost.atlassian.net/browse/ENG-2609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ