### PR TITLE
reduced memory

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1111,8 +1111,6 @@ Begin Kubecost 2.0 templates
     {{- end }}
     - name: LOG_LEVEL
       value: {{ .Values.kubecostAggregator.logLevel }}
-    - name: DB_COPY_FULL
-      value: {{ (quote .Values.kubecostAggregator.dbCopyFull) | default (quote true) }}
     - name: DB_READ_THREADS
       value: {{ .Values.kubecostAggregator.dbReadThreads | quote }}
     - name: DB_WRITE_THREADS

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2564,7 +2564,7 @@ kubecostAggregator:
   # set to 0 for max partitioning (minimum possible ram usage, but the slowest)
   # the default of 25 is sufficient for 95%+ of users. This should only be modified
   # after consulting with Kubecost's support team
-  numDBCopyPartitions: 1
+  numDBCopyPartitions: 25
 
   # How many threads the read database is configured with (i.e. Kubecost API /
   # UI queries). If increasing this value, it is recommended to increase the

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2584,10 +2584,6 @@ kubecostAggregator:
   # default: 1
   dbConcurrentIngestionCount: 1
 
-  # dbCopyFull: "true" can improve the time it takes to copy the write DB,
-  # at the expense of additional memory usages.
-  dbCopyFull: false
-
   # Memory limit applied to read database and write database connections. The
   # default of "no limit" is appropriate when first establishing a baseline of
   # resource usage required. It is eventually recommended to set these values


### PR DESCRIPTION
## What does this PR change?
change db copy partitions to 25 from 1, which was a typo
remove obsolete env var DB_COPY_FULL

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Reduced memory during read db copy operation
remove obsolete env var DB_COPY_FULL

## What risks are associated with merging this PR? What is required to fully test this PR?
NA, many configurations running this already.

## How was this PR tested?
confirmed with Bolt on obsolete var
25 copy partitions was and should be our default. tested on nightly. 

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
