### PR TITLE
[ENG-2691] Set up InstanceAllowLists ConfigMap

### DIFF
--- a/cost-analyzer/templates/savings-recommendations-allowlists-config-map-template.yaml
+++ b/cost-analyzer/templates/savings-recommendations-allowlists-config-map-template.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.kubecostProductConfigs }}
+{{- if .Values.kubecostProductConfigs.savingsRecommendationsAllowLists }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "savings-recommendations-instance-allow-lists"
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  allow-lists.json: '{{ toJson .Values.kubecostProductConfigs.savingsRecommendationsAllowLists }}'
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3447,6 +3447,10 @@ costEventsAudit:
 #   hideCloudIntegrationsUI: false
 #   hideBellIcon: false
 #   hideTeams: false
+#   savingsRecommendationsAllowLists: # Define select list of instance types to be evaluated in computing Savings Recommendations
+#     AWS: []
+#     GCP: []
+#     Azure: []
 
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain
   ## a key with name `cloud-integration.json` and the contents must be in a specific format. It is expected


### PR DESCRIPTION
## What does this PR change?
This PR introduces support for users to supply custom allow lists at CSP level, to be then used in Savings Recommendations (cluster/node group right-sizing).

## Does this PR rely on any other PRs?
KCM PR: https://github.com/kubecost/kubecost-cost-model/pull/2712

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can now supply custom allow lists at CSP level to be then used in Savings Recommendations (cluster/node group right-sizing).

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/ENG-2691

## What risks are associated with merging this PR? What is required to fully test this PR?
This config is optional, no risks associated.

## How was this PR tested?
Ensure ConfigMap is created correctly via `helm template`

## Have you made an update to documentation? If so, please provide the corresponding PR.
This update will need public docs tracked in this ticket: https://kubecost.atlassian.net/browse/ENG-2729
