### PR TITLE
Pick #3605 into v2.4

### DIFF
--- a/cost-analyzer/templates/savings-recommendations-allowlists-config-map-template.yaml
+++ b/cost-analyzer/templates/savings-recommendations-allowlists-config-map-template.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.kubecostProductConfigs }}
+{{- if .Values.kubecostProductConfigs.savingsRecommendationsAllowLists }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "savings-recommendations-instance-allow-lists"
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  allow-lists.json: '{{ toJson .Values.kubecostProductConfigs.savingsRecommendationsAllowLists }}'
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3447,6 +3447,10 @@ costEventsAudit:
 #   hideCloudIntegrationsUI: false
 #   hideBellIcon: false
 #   hideTeams: false
+#   savingsRecommendationsAllowLists: # Define select list of instance types to be evaluated in computing Savings Recommendations
+#     AWS: []
+#     GCP: []
+#     Azure: []
 
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain
   ## a key with name `cloud-integration.json` and the contents must be in a specific format. It is expected


### PR DESCRIPTION
## What does this PR change?
Cherry-pick for https://github.com/kubecost/cost-analyzer-helm-chart/pull/3605

## Does this PR rely on any other PRs?
Cherry-pick for https://github.com/kubecost/cost-analyzer-helm-chart/pull/3605


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can now supply custom allow lists at CSP level to be then used in Savings Recommendations (cluster/node group right-sizing).

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/ENG-2691

## What risks are associated with merging this PR? What is required to fully test this PR?
N/A

## How was this PR tested?
N/A

## Have you made an update to documentation? If so, please provide the corresponding PR.
N/A
