### PR TITLE
chore: use ghcr.io instead of defaulting to DockerHub due to rate limit

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3195,7 +3195,7 @@ grafana:
   ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
   sidecar:
     image:
-      repository: kiwigrid/k8s-sidecar
+      repository: ghcr.io/kiwigrid/k8s-sidecar
       tag: 1.27.5
       pullPolicy: IfNotPresent
     resources: {}


### PR DESCRIPTION
## What does this PR change?

Use ghcr.io instead of defaulting to DockerHub due to rate limit

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Use ghcr.io instead of defaulting to DockerHub due to rate limit
Internal note: this will be disabled by default in 2.5.0, disregard this PR in the release notes. 

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

