### PR TITLE
update prometheus to chainguard for CVE-2024-41110

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -974,8 +974,8 @@ prometheus:
     ## Prometheus server container image
     ##
     image:
-      repository: quay.io/prometheus/prometheus
-      tag: v2.53.1
+      repository: cgr.dev/chainguard/prometheus
+      tag: latest
       pullPolicy: IfNotPresent
 
     ## prometheus server priorityClassName
@@ -1385,8 +1385,8 @@ prometheus:
     ## alertmanager container image
     ##
     image:
-      repository: quay.io/prometheus/alertmanager
-      tag: v0.27.0
+      repository: cgr.dev/chainguard/prometheus-alertmanager
+      tag: latest
       pullPolicy: IfNotPresent
 
     ## alertmanager priorityClassName
@@ -1671,8 +1671,8 @@ prometheus:
       ## configmap-reload container image
       ##
       image:
-        repository: quay.io/prometheus-operator/prometheus-config-reloader
-        tag: v0.74.0
+        repository: cgr.dev/chainguard/prometheus-config-reloader
+        tag: latest
         pullPolicy: IfNotPresent
 
       ## Additional configmap-reload container arguments
@@ -1711,8 +1711,8 @@ prometheus:
       ## configmap-reload container image
       ##
       image:
-        repository: quay.io/prometheus-operator/prometheus-config-reloader
-        tag: v0.74.0
+        repository: cgr.dev/chainguard/prometheus-config-reloader
+        tag: latest
         pullPolicy: IfNotPresent
 
       ## Additional configmap-reload container arguments

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -23789,7 +23789,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.52.0"
+          image: "cgr.dev/chainguard/prometheus:latest"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=97h


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
Update prom reference to point to chainguard latest, fixes CVE-2024-41110
# Vulnerability Comparison Report

## Image 1: `quay.io/prometheus/prometheus:v2.53.1`

Total vulnerabilities: **4**

| Severity | Count |
|----------|-------|
| Critical | 1 |
| High     | 0 |
| Medium   | 2 |
| Low      | 1 |

## Image 2: `cgr.dev/chainguard/prometheus`

Total vulnerabilities: **0**

| Severity | Count |
|----------|-------|
| Critical | 0 |
| High     | 0 |
| Medium   | 0 |
| Low      | 0 |

## Added Vulnerabilities
none

## Removed Vulnerabilities

### CRITICAL

| Vulnerability ID |
|-------------------|
| CVE-2024-41110 |

### LOW

| Vulnerability ID |
|-------------------|
| GHSA-xr7q-jx4m-x55m |

### MEDIUM

| Vulnerability ID |
|-------------------|
| CVE-2024-35255 |
| CVE-2024-6104 |

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
NA

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Locally

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
