### PR TITLE
bump network costs to 0.17.5

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -23,6 +23,7 @@ forecasting:
 networkCosts:
   image:
     repository: public.ecr.aws/kubecost/kubecost-network-costs
+    tag: v0.17.5
 
 clusterController:
   image:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2319,7 +2319,7 @@ networkCosts:
   enabled: false
   image:
     repository: gcr.io/kubecost1/kubecost-network-costs
-    tag: v0.17.3
+    tag: v0.17.5
   imagePullPolicy: IfNotPresent
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
# Vulnerability Comparison Report

## Image 1: `gcr.io/kubecost1/kubecost-network-costs:v0.17.3`

Total vulnerabilities: **8**

| Severity | Count |
|----------|-------|
| Critical | 0 |
| High     | 0 |
| Medium   | 7 |
| Low      | 1 |

## Image 2: `gcr.io/kubecost1/kubecost-network-costs:v0.17.5`

Total vulnerabilities: **0**

| Severity | Count |
|----------|-------|
| Critical | 0 |
| High     | 0 |
| Medium   | 0 |
| Low      | 0 |

## Added Vulnerabilities

## Removed Vulnerabilities

### MEDIUM

| Vulnerability ID |
|-------------------|
| CVE-2023-42363 |
| CVE-2023-42364 |
| CVE-2023-42365 |
| CVE-2023-42366 |
| CVE-2024-4603 |
| CVE-2024-4741 |
| CVE-2024-5535 |

### LOW

| Vulnerability ID |
|-------------------|
| CVE-2024-2511 |

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
removes CVE

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
arm64 in qa-eks3, and amd64 in aggregator.nightly

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
