### PR TITLE
[ENG-2674] Add routes for savings recommendations allow list validation API

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -517,6 +517,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/savings/recommendations/allowLists {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/savings/recommendations/allowLists;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/cloudCost {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/cloudCost;

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -334,22 +334,6 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location = /model/savings/nodeGroupSizingETL {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/savings/nodeGroupSizingETL;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/recommendations/allowLists {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/savings/recommendations/allowLists;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
         location = /model/cloudCost {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/cloudCost;

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -334,6 +334,22 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/savings/nodeGroupSizingETL {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/nodeGroupSizingETL;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/savings/recommendations/allowLists {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/recommendations/allowLists;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/cloudCost {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/cloudCost;


### PR DESCRIPTION
## What does this PR change?
This PR adds routes for the `/savings/recommendations/allowLists` API in the nginx config.

## Does this PR rely on any other PRs?
API implementation: https://github.com/kubecost/kubecost-cost-model/pull/2772

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can use this API to validate whether the supplied instance type allowlists contain valid instance types. 

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/ENG-2674

## What risks are associated with merging this PR? What is required to fully test this PR?
N/A

## How was this PR tested?
N/A

## Have you made an update to documentation? If so, please provide the corresponding PR.
N/A
