### PR TITLE
fix diagnostics and federatedStorageConfig

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -1120,8 +1120,8 @@ spec:
             {{- if not (.Values.diagnostics.enabled) }}
             - name: DIAGNOSTICS_RUN_IN_COST_MODEL
               value: "false"
-            {{- /*A pre-requisite for running MultiClusterDiagnostics in the cost-model container is a configured federated-store secret and cluster_id*/}}
-            {{- else if and (empty .Values.kubecostModel.federatedStorageConfigSecret) (not .Values.kubecostModel.federatedStorageConfig) (eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one") }}
+            {{- /* Cannot run MultiClusterDiagnostics in the cost-model container without federated-store config */}}
+            {{- else if and (empty .Values.kubecostModel.federatedStorageConfigSecret) (not .Values.kubecostModel.federatedStorageConfig) }}
             - name: DIAGNOSTICS_RUN_IN_COST_MODEL
               value: "false"
             {{- else if .Values.diagnostics.deployment.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -932,7 +932,7 @@ spec:
             - name: FEDERATED_STORE_CONFIG
               value: "/var/configs/etl/federated/federated-store.yaml"
             {{- end }}
-            {{- if or .Values.federatedETL.federatedCluster .Values.kubecostModel.federatedStorageConfigSecret }}
+            {{- if or .Values.federatedETL.federatedCluster .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig }}
             - name: FEDERATED_CLUSTER
               {{- if eq .Values.federatedETL.readOnlyPrimary true }}
               value: "false"
@@ -1121,7 +1121,7 @@ spec:
             - name: DIAGNOSTICS_RUN_IN_COST_MODEL
               value: "false"
             {{- /*A pre-requisite for running MultiClusterDiagnostics in the cost-model container is a configured federated-store secret and cluster_id*/}}
-            {{- else if and (empty .Values.kubecostModel.federatedStorageConfigSecret) (empty .Values.kubecostModel.federatedStorageConfig) (eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one") }}
+            {{- else if and (empty .Values.kubecostModel.federatedStorageConfigSecret) (not .Values.kubecostModel.federatedStorageConfig) (eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one") }}
             - name: DIAGNOSTICS_RUN_IN_COST_MODEL
               value: "false"
             {{- else if .Values.diagnostics.deployment.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -81,7 +81,7 @@ spec:
             items:
               - key: datadog_config.json
                 path: datadog_config.json
-        {{- end }}        
+        {{- end }}
         {{- if .Values.kubecostModel.plugins.existingCustomSecret.enabled }}
         - name: plugins-config
           secret:
@@ -136,11 +136,11 @@ spec:
            defaultMode: 420
            secretName: {{ $etlBackupBucketSecret }}
         {{- end }}
-        {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+        {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig }}
         - name: federated-storage-config
           secret:
            defaultMode: 420
-           secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
+           secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname }}
@@ -659,7 +659,7 @@ spec:
             - name: persistent-db
               mountPath: /var/db
             {{- end }}
-            {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+            {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig }}
             - name: federated-storage-config
               mountPath: /var/configs/etl/federated
               readOnly: true
@@ -1121,7 +1121,7 @@ spec:
             - name: DIAGNOSTICS_RUN_IN_COST_MODEL
               value: "false"
             {{- /*A pre-requisite for running MultiClusterDiagnostics in the cost-model container is a configured federated-store secret and cluster_id*/}}
-            {{- else if or (empty .Values.kubecostModel.federatedStorageConfigSecret) (eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one") }}
+            {{- else if and (empty .Values.kubecostModel.federatedStorageConfigSecret) (empty .Values.kubecostModel.federatedStorageConfig) (eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one") }}
             - name: DIAGNOSTICS_RUN_IN_COST_MODEL
               value: "false"
             {{- else if .Values.diagnostics.deployment.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -143,7 +143,7 @@ data:
   {{- end }}
 
     {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
-    {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
+    {{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig }}
     upstream multi-cluster-diagnostics {
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9007;
@@ -1303,7 +1303,7 @@ data:
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
             {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled }}
-            {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
+            {{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig }}
             return 200 '{"multiClusterDiagnosticsEnabled": true}';
             {{- end }}
             {{- else }}
@@ -1312,7 +1312,7 @@ data:
         }
 
         {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
-        {{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) }}
+        {{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig }}
 
         # When the Multi-cluster Diagnostics Service is run within the
         # cost-model container, its endpoint is available at the path

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.diagnostics.enabled .Values.diagnostics.deployment.enabled }}
-{{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) -}}
+{{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig -}}
 
 {{- if eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one" }}
 {{- fail "Error: The 'cluster_id' is set to default 'cluster-one'. Please update so that the diagnostics service can uniquely identify data coming from this cluster." }}
@@ -50,11 +50,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       volumes:
-        {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+        {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig }}
         - name: federated-storage-config
           secret:
             defaultMode: 420
-            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
+            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
         - name: config-db
           {{- /* #TODO: make pv? */}}

--- a/cost-analyzer/templates/diagnostics-service.yaml
+++ b/cost-analyzer/templates/diagnostics-service.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.diagnostics.enabled .Values.diagnostics.deployment.enabled .Values.diagnostics.primary.enabled }}
-{{- if (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) -}}
+{{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/cost-analyzer/templates/etl-utils-deployment.yaml
+++ b/cost-analyzer/templates/etl-utils-deployment.yaml
@@ -39,11 +39,11 @@ spec:
             defaultMode: 420
             secretName: {{ .Values.etlUtils.thanosSourceBucketSecret }}
         {{- end }}
-        {{- if .Values.kubecostModel.federatedStorageConfigSecret }}
+        {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig}}
         - name: federated-storage-config
           secret:
             defaultMode: 420
-            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret }}
+            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
## What does this PR change?
allows new federatedStorageConfig via helm to be used in agent configs and sets the diagnostics to run in cost-model

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Diagnostics is now enabled by default, which runs in the cost-model container. This writes to the federated-store under /diagnostics. 

## Links to Issues or tickets this PR addresses or fixes
NA

## What risks are associated with merging this PR? What is required to fully test this PR?
Fixes 2 issues created by https://github.com/kubecost/cost-analyzer-helm-chart/pull/3411

## How was this PR tested?
1. diagnostics:

`helm upgrade kubecost ../cost-analyzer --dry-run|ag diag -f values-federatedStorageConfig.yaml -A1`
```
            - name: DIAGNOSTICS_RUN_IN_COST_MODEL
              value: "true"
```

2. federated storage is configured and used by cost-model
before:
`helm upgrade kubecost ../cost-analyzer --dry-run|ag diag -f values-federatedStorageConfig.yaml -A1`
```
# Source: cost-analyzer/templates/federated-store.yaml
  name: federated-store
  federated-store.yaml: dHlxxx==
            - name: FEDERATED_STORE_CONFIG
              value: "/var/configs/etl/federated/federated-store.yaml"
```
after, adds teh secret mapping:
```
# Source: cost-analyzer/templates/federated-store.yaml
  name: federated-store
  federated-store.yaml: dHlxxx==
        - name: federated-storage-config
           secretName: federated-store
            - name: federated-storage-config
              mountPath: /var/configs/etl/federated
            - name: FEDERATED_STORE_CONFIG
              value: "/var/configs/etl/federated/federated-store.yaml"
```


## Have you made an update to documentation? If so, please provide the corresponding PR.

NA