### PR TITLE
update prometheus.server.retion to 97h

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Parameter | Description | Default
 `prometheus.server.persistentVolume.enabled` | If true, Prometheus server will create a Persistent Volume Claim. | `true`
 `prometheus.server.persistentVolume.size` | Prometheus server data Persistent Volume size. Default set to retain ~6000 samples per second for 15 days. | `32Gi`
 `prometheus.server.persistentVolume.storageClass` | Define storage class for Prometheus persistent volume  | `-`
-`prometheus.server.retention` | Determines when to remove old data. | `15d`
+`prometheus.server.retention` | Determines when to remove old data. | `97h`
 `prometheus.server.resources` | Prometheus server resource requests and limits. | `{}`
 `prometheus.nodeExporter.resources` | Node exporter resource requests and limits. | `{}`
 `prometheus.nodeExporter.enabled` `prometheus.serviceAccounts.nodeExporter.create` | If false, do not create NodeExporter daemonset.  | `true`


### PR DESCRIPTION
## What does this PR change?
According to v2.3.5 chart, this value is set to 97h in the `values.yaml`
https://github.com/kubecost/cost-analyzer-helm-chart/blob/v2.3.5/cost-analyzer/values.yaml#L1303C16-L1303C19

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

