### PR TITLE
bump cluster-controller 0.16.9

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -418,8 +418,6 @@ systemProxy:
 # imageVersion:
 
 kubecostFrontend:
-  containerSecurityContext:
-    readOnlyRootFilesystem: false
   enabled: true
   deployMethod: singlepod  # haMode or singlepod - haMode is currently only supported with Enterprise tier
   haReplicas: 2  # only used with haMode

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -418,6 +418,8 @@ systemProxy:
 # imageVersion:
 
 kubecostFrontend:
+  containerSecurityContext:
+    readOnlyRootFilesystem: false
   enabled: true
   deployMethod: singlepod  # haMode or singlepod - haMode is currently only supported with Enterprise tier
   haReplicas: 2  # only used with haMode
@@ -2784,7 +2786,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.8
+    tag: v0.16.9
   imagePullPolicy: IfNotPresent
   ## PriorityClassName
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
Bump cluster-conteroller from 0.16.8 to 0.16.9
Fix nil reference panic on updateSchedule when deployment missing.

### Removed vulnerabilities:
#### medium
| VulnerabilityID |
| --------------- |
| CVE-2024-6119 |
| CVE-2024-6119 |
| CVE-2024-34155 |
| CVE-2024-34158 |

#### high
| VulnerabilityID |
| --------------- |
| CVE-2024-34156 |

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fix issues with niil reference panic, and update to remove cve

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
in nightly

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
