### PR TITLE
remove helm rollout restarter

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1483,6 +1483,11 @@ for more information
 */ -}}
 {{- define "configsChecksum" -}}
 {{- $files := list
+  "alibaba-service-key-secret.yaml"
+  "aws-service-key-secret.yaml"
+  "azure-service-key-secret.yaml"
+  "azure-storage-config-secret.yaml"
+  "cloud-integration-secret.yaml"
   "cost-analyzer-account-mapping-configmap.yaml"
   "cost-analyzer-alerts-configmap.yaml"
   "cost-analyzer-asset-reports-configmap.yaml"
@@ -1498,12 +1503,22 @@ for more information
   "cost-analyzer-saved-reports-configmap.yaml"
   "cost-analyzer-server-configmap.yaml"
   "cost-analyzer-smtp-configmap.yaml"
+  "external-grafana-config-map-template.yaml"
   "gcpstore-config-map-template.yaml"
+  "grafana-secret.yaml"
   "install-plugins.yaml"
   "integrations-postgres-queries-configmap.yaml"
+  "integrations-postgres-secret.yaml"
+  "kubecost-agent-secret-template.yaml"
+  "kubecost-agent-secretprovider-template.yaml"
   "kubecost-cluster-controller-actions-config.yaml"
   "kubecost-cluster-manager-configmap-template.yaml"
+  "kubecost-oidc-secret-template.yaml"
+  "kubecost-saml-secret-template.yaml"
   "mimir-proxy-configmap-template.yaml"
+  "savings-recommendations-allowlists-config-map-template.yaml"
+  "savings-recommendations-config-map-template.yaml"
+  "savings-recommendations-cost-model-config-map-template.yaml"
 -}}
 {{- $checksum := "" -}}
 {{- range $files -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1517,8 +1517,6 @@ for more information
   "kubecost-saml-secret-template.yaml"
   "mimir-proxy-configmap-template.yaml"
   "savings-recommendations-allowlists-config-map-template.yaml"
-  "savings-recommendations-config-map-template.yaml"
-  "savings-recommendations-cost-model-config-map-template.yaml"
 -}}
 {{- $checksum := "" -}}
 {{- range $files -}}

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -29,12 +29,7 @@ spec:
   template:
     metadata:
       labels:
-        {{/*
-        Force pod restarts on upgrades to ensure the nginx config is current
-        */}}
-        {{- if not .Values.global.platforms.cicd.enabled }}
-        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
-        {{- end }}
+
         app.kubernetes.io/name: cloud-cost
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: cloud-cost

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -29,7 +29,6 @@ spec:
   template:
     metadata:
       labels:
-
         app.kubernetes.io/name: cloud-cost
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: cloud-cost

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -44,10 +44,6 @@ spec:
       labels:
         app.kubernetes.io/name: aggregator
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{/* Force pod restarts on upgrades to ensure the nginx config is current */}}
-        {{- if not .Values.global.platforms.cicd.enabled }}
-        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
-        {{- end }}
         app: aggregator
         {{- with .Values.global.additionalLabels }}
         {{- toYaml . | nindent 8 }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -40,10 +40,6 @@ spec:
     metadata:
       labels:
         {{- include "cost-analyzer.selectorLabels" . | nindent 8 }}
-        {{/* Force pod restarts on upgrades to ensure the nginx config is current */}}
-        {{- if not .Values.global.platforms.cicd.enabled }}
-        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
-        {{- end }}
         {{- if .Values.global.additionalLabels }}
         {{ toYaml .Values.global.additionalLabels | nindent 8 }}
         {{- end }}

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -31,10 +31,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        # Generates a unique annotation upon each `helm upgrade`, forcing a redeployment
-        {{- if not .Values.global.platforms.cicd.enabled }}
-        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
-        {{- end }}
         {{- with .Values.global.podAnnotations}}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -35,12 +35,6 @@ spec:
   template:
     metadata:
       labels:
-        {{/*
-        Force pod restarts on upgrades to ensure the nginx config is current
-        */}}
-        {{- if not .Values.global.platforms.cicd.enabled }}
-        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
-        {{- end }}
         {{- include "frontend.selectorLabels" . | nindent 8 }}
         {{- if .Values.global.additionalLabels }}
         {{- toYaml .Values.global.additionalLabels | nindent 8 }}

--- a/cost-analyzer/templates/prometheus-server-deployment.yaml
+++ b/cost-analyzer/templates/prometheus-server-deployment.yaml
@@ -32,12 +32,6 @@ spec:
     {{- end }}
         checksum/configs: {{ include "configsChecksum" . }}
       labels:
-        {{/*
-        Force pod restarts on upgrades to ensure the configmap is current
-        */}}
-        {{- if not .Values.global.platforms.cicd.enabled }}
-        helm-rollout-restarter: {{ randAlphaNum 5 | quote }}
-        {{- end }}
         {{- include "prometheus.server.labels" . | nindent 8 }}
         {{- with .Values.global.additionalLabels }}
         {{- toYaml . | nindent 8 }}

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -23237,8 +23237,6 @@ spec:
         app.kubernetes.io/name: cost-analyzer
         app.kubernetes.io/instance: kubecost
         app: cost-analyzer
-
-        helm-rollout-restarter: "e5zu5"
     spec:
       securityContext:
         fsGroup: 1001
@@ -23778,8 +23776,6 @@ spec:
   template:
     metadata:
       labels:
-
-        helm-rollout-restarter: "AoKZ9"
         component: "server"
         app: prometheus
         release: kubecost


### PR DESCRIPTION
## What does this PR change?
Removes the helm-rollout-restarter, which has been replaced by 
`checksum/configs: {{ include "configsChecksum" . }}`
introduced by https://github.com/kubecost/cost-analyzer-helm-chart/pull/3459

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Kubecost introduced a utility called the `helm-rollout-restarter` for the purpose of loading any changes to secrets/configmaps. This was problematic for CI/CD users. #3459 created a much more sophisticated method for doing this. 

## What risks are associated with merging this PR? What is required to fully test this PR?
Minimal risk- this simply removes a label that was a random string the forced pods to restart.

## How was this PR tested?
Tested against nightly environments. 

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
