### PR TITLE
Enhance Pod utilization Grafana dashboard with GPU utilization widget

### DIFF
--- a/cost-analyzer/grafana-dashboards/pod-utilization.json
+++ b/cost-analyzer/grafana-dashboards/pod-utilization.json
@@ -692,7 +692,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_PROF_GR_ENGINE_ACTIVE{namespace=\"$namespace\",container=\"$container\",pod=\"$pod\"}",
+          "expr": "DCGM_FI_PROF_GR_ENGINE_ACTIVE{namespace=~\"$namespace\",container=~\"$container\",pod=~\"$pod\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/cost-analyzer/grafana-dashboards/pod-utilization.json
+++ b/cost-analyzer/grafana-dashboards/pod-utilization.json
@@ -603,12 +603,115 @@
       "timeFrom": "",
       "title": "CPU throttle percent",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "NVIDIA GPU usage for this container.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 3600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "DCGM_FI_PROF_GR_ENGINE_ACTIVE{namespace=\"$namespace\",container=\"$container\",pod=\"$pod\"}",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "__auto",
+          "metric": "container_cpu",
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "timeFrom": "",
+      "title": "GPU Usage",
+      "type": "timeseries"
     }
   ],
   "refresh": "",
   "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "kubecost",
     "utilization",


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Adds a GPU utilization widget to the Pod utilization Grafana dashboard allowing users to view NVIDIA GPU utilization for a given container.

![image](https://github.com/user-attachments/assets/2696c95d-1302-49b8-8a77-73f151c13587)


## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows users to see the NVIDIA GPU utilization of their container if applicable.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

(internal Jira task} ENG-2541


## What risks are associated with merging this PR? What is required to fully test this PR?

The widget may not work in some scenarios if not tested there.

## How was this PR tested?

0. Created an EKS cluster with an NVIDIA GPU, deployed GPU operator, created Deployment with one replica and one container running a benchmarking application.
1. Deployed Kubecost 2.4.0-rc.3.
2. Edited the `grafana-dashboard-pod-utilization` ConfigMap to add the widget JSON.
3. Drilled down into a container from the Allocations view, clicked on "Open in Grafana" link.
4. Confirmed the container with GPU access was reporting and displaying the graph correctly on the widget.

## Have you made an update to documentation? If so, please provide the corresponding PR.

No