### PR TITLE
bump network-costs 0.17.6

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -23,7 +23,7 @@ forecasting:
 networkCosts:
   image:
     repository: public.ecr.aws/kubecost/kubecost-network-costs
-    tag: v0.17.5
+    tag: v0.17.6
 
 clusterController:
   image:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2319,7 +2319,7 @@ networkCosts:
   enabled: false
   image:
     repository: gcr.io/kubecost1/kubecost-network-costs
-    tag: v0.17.5
+    tag: v0.17.6
   imagePullPolicy: IfNotPresent
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
### Comparing images: gcr.io/kubecost1/kubecost-network-costs:v0.17.5 and gcr.io/kubecost1/kubecost-network-costs:v0.17.6
#### Image 1: gcr.io/kubecost1/kubecost-network-costs:v0.17.5
#### Total vulnerabilities: 2

| Severity | Count |
|----------|-------|
| Critical | 0    |
| High     | 0    |
| Medium   | 2    |
| Low      | 0    |

#### Image 2: gcr.io/kubecost1/kubecost-network-costs:v0.17.6
#### Total vulnerabilities: 0

| Severity | Count |
|----------|-------|
| Critical | 0    |
| High     | 0    |
| Medium   | 0    |
| Low      | 0    |

### Added vulnerabilities:
### Removed vulnerabilities:
#### medium
| VulnerabilityID |
| --------------- |
| CVE-2024-6119 |
| CVE-2024-6119 |

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
NA

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
nightly

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
