### PR TITLE
add warning for federated storage

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -26,3 +26,4 @@ Please allow 25 minutes for Kubecost to gather metrics. A progress indicator wil
 Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install
 
 {{- include "kubecostV2-3-notices" . -}}
+{{- include "federatedStorageCheck" . -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -113,6 +113,14 @@ Kubecost 2.0 preconditions
   {{- end }}
 {{- end -}}
 
+{{- define "federatedStorageCheck" -}}
+  {{- if or (.Values.federatedETL).federatedStore (.Values.kubecostModel).federatedStorageConfig }}
+    {{- if and (not (eq (include "aggregator.deployMethod" .) "statefulset")) (not (.Values.federatedETL).agentOnly) }}
+      {{- printf "\n\n***Configuration issue detected:***\nWhen a federated store is provided, Kubecost should either be running as agentOnly or as a statefulset.\n.Values.federatedETL.agentOnly=true\nOr\n.Values.kubecostAggregator.deployMethod=statefulset\n***" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- define "cloudIntegrationFromProductConfigs" }}
   {
     {{- if ((.Values.kubecostProductConfigs).athenaBucketName) }}


### PR DESCRIPTION
## What does this PR change?
add warning to helm note when federated storage is not configured completely.

```
***Configuration issue detected:***
When a federated store is provided, Kubecost should either be running as agentOnly or as a statefulset.
.Values.federatedETL.agentOnly=true
Or
.Values.kubecostAggregator.deployMethod=statefulset
***
```

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
add warning to helm note when federated storage is not configured completely.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?

helm upgrades with and without federatedStorage, with and without agentOnly and statefulsets.


## Have you made an update to documentation? If so, please provide the corresponding PR.

