### PR TITLE
Add option for additional chart labels in values

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -467,6 +467,7 @@ Create the chart labels.
 {{- define "cost-analyzer.chartLabels" -}}
 helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ .Values.additionalChartLabels }}
 {{- end -}}
 {{- define "kubecost.chartLabels" -}}
 app.kubernetes.io/name: {{ include "cost-analyzer.name" . }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -467,7 +467,9 @@ Create the chart labels.
 {{- define "cost-analyzer.chartLabels" -}}
 helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ .Values.additionalChartLabels }}
+{{- with .Values.additionalChartLabels }}
+{{- .}}
+{{- end }}
 {{- end -}}
 {{- define "kubecost.chartLabels" -}}
 app.kubernetes.io/name: {{ include "cost-analyzer.name" . }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -467,8 +467,8 @@ Create the chart labels.
 {{- define "cost-analyzer.chartLabels" -}}
 helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.additionalChartLabels }}
-{{- .}}
+{{- if .Values.additionalChartLabels }}
+{{ tpl (.Values.additionalChartLabels | toYaml) . }}
 {{- end }}
 {{- end -}}
 {{- define "kubecost.chartLabels" -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -467,21 +467,9 @@ Create the chart labels.
 {{- define "cost-analyzer.chartLabels" -}}
 helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if .Values.additionalChartLabels }}
-{{ toYaml .Values.additionalChartLabels }}
+{{- if .Values.chartLabels }}
+{{ toYaml .Values.chartLabels }}
 {{- end }}
-{{- end -}}
-{{- define "kubecost.chartLabels" -}}
-app.kubernetes.io/name: {{ include "cost-analyzer.name" . }}
-helm.sh/chart: {{ include "cost-analyzer.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-{{- define "kubecost.aggregator.chartLabels" -}}
-app.kubernetes.io/name: {{ include "aggregator.name" . }}
-helm.sh/chart: {{ include "cost-analyzer.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -468,7 +468,7 @@ Create the chart labels.
 helm.sh/chart: {{ include "cost-analyzer.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalChartLabels }}
-{{ tpl (.Values.additionalChartLabels | toYaml) . }}
+{{ toYaml .Values.additionalChartLabels }}
 {{- end }}
 {{- end -}}
 {{- define "kubecost.chartLabels" -}}

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   name: {{ template "cloudCost.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cloudCost.commonLabels" . | nindent 4 }}
+    {{- include "cloudCost.commonLabels" . | nindent 4 }}
     {{- with .Values.global.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -23,7 +23,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{ include "cloudCost.selectorLabels" . | nindent 6 }}
+      {{- include "cloudCost.selectorLabels" . | nindent 6 }}
   strategy:
     type: Recreate
   template:

--- a/cost-analyzer/templates/aggregator-cloud-cost-service-account.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-service-account.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ template "cloudCost.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cloudCost.commonLabels" . | nindent 4 }}
+    {{- include "cloudCost.commonLabels" . | nindent 4 }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/cost-analyzer/templates/aggregator-cloud-cost-service.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-service.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "cloudCost.serviceName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "cloudCost.commonLabels" . | nindent 4 }}
+    {{- include "cloudCost.commonLabels" . | nindent 4 }}
 spec:
   selector:
-{{ include "cloudCost.selectorLabels" . | nindent 4 }}
+    {{- include "cloudCost.selectorLabels" . | nindent 4 }}
   type: "ClusterIP"
   ports:
     - name: tcp-api

--- a/cost-analyzer/templates/aggregator-service.yaml
+++ b/cost-analyzer/templates/aggregator-service.yaml
@@ -5,13 +5,13 @@ metadata:
   name: {{ template "aggregator.serviceName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "aggregator.commonLabels" . | nindent 4 }}
-{{- if .Values.kubecostAggregator.service.labels }}
+    {{- include "aggregator.commonLabels" . | nindent 4 }}
+    {{- if .Values.kubecostAggregator.service.labels }}
     {{- toYaml .Values.kubecostAggregator.service.labels | nindent 4 }}
-{{- end }}
+    {{- end }}
 spec:
   selector:
-{{ include "aggregator.selectorLabels" . | nindent 4 }}
+    {{- include "aggregator.selectorLabels" . | nindent 4 }}
   type: "ClusterIP"
   ports:
     - name: tcp-api

--- a/cost-analyzer/templates/aggregator-servicemonitor.yaml
+++ b/cost-analyzer/templates/aggregator-servicemonitor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "aggregator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "aggregator.commonLabels" . | nindent 4 }}
+    {{- include "aggregator.commonLabels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.aggregatorMetrics.additionalLabels }}
     {{ toYaml .Values.serviceMonitor.aggregatorMetrics.additionalLabels | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/alibaba-service-key-secret.yaml
+++ b/cost-analyzer/templates/alibaba-service-key-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cloud-service-key
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque
 stringData:
   service-key.json: |-

--- a/cost-analyzer/templates/aws-service-key-secret.yaml
+++ b/cost-analyzer/templates/aws-service-key-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cloud-service-key
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque
 stringData:
   service-key.json: |-

--- a/cost-analyzer/templates/awsstore-service-account-template.yaml
+++ b/cost-analyzer/templates/awsstore-service-account-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: awsstore-serviceaccount
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 {{- with .Values.awsstore.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/cost-analyzer/templates/azure-service-key-secret.yaml
+++ b/cost-analyzer/templates/azure-service-key-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cloud-service-key
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque
 stringData:
   service-key.json: |-

--- a/cost-analyzer/templates/azure-storage-config-secret.yaml
+++ b/cost-analyzer/templates/azure-storage-config-secret.yaml
@@ -10,7 +10,7 @@ metadata:
   name: azure-storage-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque
 stringData:
   azure-storage-config.json: |-

--- a/cost-analyzer/templates/cost-analyzer-account-mapping-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-account-mapping-configmap.yaml
@@ -5,7 +5,8 @@ kind: ConfigMap
 metadata:
   name: "account-mapping"
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   account-map.json: '{{ toJson .Values.kubecostProductConfigs.cloudAccountMapping }}'
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-alerts-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-alerts-configmap.yaml
@@ -4,7 +4,8 @@ kind: ConfigMap
 metadata:
   name: {{ default "alert-configs" .Values.alertConfigmapName }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   alerts.json: '{{ toJson .Values.global.notifications.alertConfigs }}'
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-asset-reports-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-asset-reports-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ default "asset-report-configs" .Values.assetReportConfigmapName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   asset-reports.json: '{{ toJson .Values.global.assetReports.reports }}'
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-cloud-cost-reports-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cloud-cost-reports-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{default "cloud-cost-report-configs" .Values.cloudCostReportConfigmapName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   cloud-cost-reports.json: '{{ toJson .Values.global.cloudCostReports.reports }}'
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-cluster-role-binding-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-binding-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "cost-analyzer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -24,7 +24,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cost-analyzer.serviceAccountName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "cost-analyzer.serviceAccountName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 rules:
 - apiGroups: 
     - ''
@@ -32,7 +32,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "cost-analyzer.serviceAccountName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''

--- a/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-config-map-template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "cost-analyzer.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   {{- if .Values.global.prometheus.enabled }}
   {{- if .Values.global.zone }}

--- a/cost-analyzer/templates/cost-analyzer-db-pvc-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-db-pvc-template.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ template "cost-analyzer.fullname" . }}-db
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- with .Values.persistentVolume.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -12,7 +12,7 @@ metadata:
   name: nginx-conf
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   nginx.conf: |
     gzip_static  on;

--- a/cost-analyzer/templates/cost-analyzer-ingestion-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingestion-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ default "ingestion-configs" .Values.ingestionConfigmapName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   standardDiscount: "{{ .Values.kubecostProductConfigs.standardDiscount }}"
   helmConfig: "true"

--- a/cost-analyzer/templates/cost-analyzer-metrics-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-metrics-config-map-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ default "metrics-config" .Values.metricsConfigmapName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   metrics.json: '{{ toJson .Values.kubecostProductConfigs.metricsConfigs }}'
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-config-map-template.yaml
@@ -7,7 +7,7 @@ metadata:
   name: network-costs-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   config.yaml: |
 {{- toYaml .Values.networkCosts.config | nindent 4 }}

--- a/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-oidc-config-map-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "cost-analyzer.fullname" . }}-oidc
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
 {{- $root := . }}
     oidc.json: |-

--- a/cost-analyzer/templates/cost-analyzer-pkey-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pkey-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ default "product-configs" .Values.productConfigmapName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   {{- if .Values.kubecostProductConfigs.productKey.key }}
     key: {{  .Values.kubecostProductConfigs.productKey.key | quote }}

--- a/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pricing-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ default "pricing-configs" .Values.pricingConfigmapName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   {{- if .Values.kubecostProductConfigs.defaultModelPricing }}
   {{- if .Values.kubecostProductConfigs.defaultModelPricing.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-prometheusrule-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-prometheusrule-template.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ include "cost-analyzer.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.prometheusRule.additionalLabels }}
     {{ toYaml .Values.prometheusRule.additionalLabels | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-pvc-template.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "cost-analyzer.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- with .Values.persistentVolume.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-saml-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-saml-config-map-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "cost-analyzer.fullname" . }}-saml
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
 {{- $root := . }}
     saml.json: '{{ toJson .Values.saml }}'

--- a/cost-analyzer/templates/cost-analyzer-saved-reports-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-saved-reports-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{default "saved-report-configs" .Values.savedReportConfigmapName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   saved-reports.json: '{{ toJson .Values.global.savedReports.reports }}'
 {{- end -}}

--- a/cost-analyzer/templates/cost-analyzer-server-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-server-configmap.yaml
@@ -5,7 +5,8 @@ kind: ConfigMap
 metadata:
   name: {{ default "app-configs" .Values.appConfigmapName }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
 {{- if .Values.kubecostProductConfigs.labelMappingConfigs }}
 {{- if .Values.kubecostProductConfigs.labelMappingConfigs.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-service-account-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-service-account-template.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "cost-analyzer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-servicemonitor-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "cost-analyzer.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.additionalLabels }}
     {{ toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
@@ -29,6 +29,6 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{ include "cost-analyzer.selectorLabels" . | nindent 6 }}
+      {{- include "cost-analyzer.selectorLabels" . | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/etl-utils-service.yaml
+++ b/cost-analyzer/templates/etl-utils-service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: {{ template "etlUtils.serviceName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "etlUtils.commonLabels" . | nindent 4 }}
+    {{- include "etlUtils.commonLabels" . | nindent 4 }}
 spec:
   selector:
-{{ include "etlUtils.selectorLabels" . | nindent 4 }}
+    {{- include "etlUtils.selectorLabels" . | nindent 4 }}
   type: "ClusterIP"
   ports:
     - name: api

--- a/cost-analyzer/templates/external-grafana-config-map-template.yaml
+++ b/cost-analyzer/templates/external-grafana-config-map-template.yaml
@@ -5,7 +5,7 @@ metadata:
   name: external-grafana-config-map
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   grafanaURL: {{ .Values.global.grafana.scheme | default "http" }}://{{- .Values.global.grafana.domainName }}
 {{- end -}}

--- a/cost-analyzer/templates/grafana-dashboard-attached-disks.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-attached-disks.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-network-cloud-sevices.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-network-cloud-sevices.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-network-costs.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-network-costs.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-pod-utilization-multi-cluster.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-pod-utilization-multi-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-workload-aggregator.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-workload-aggregator.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/grafana-dashboard-workload-metrics.yaml
+++ b/cost-analyzer/templates/grafana-dashboard-workload-metrics.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Values.grafana.namespace_dashboards }}
   {{- end }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "{{ $.Values.grafana.sidecar.dashboards.labelValue }}"
     {{- else }}

--- a/cost-analyzer/templates/install-plugins.yaml
+++ b/cost-analyzer/templates/install-plugins.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-install-plugins
   labels:
-   {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   install_plugins.sh: |-
     {{- if .Values.kubecostModel.plugins.install.enabled }}

--- a/cost-analyzer/templates/integrations-postgres-queries-configmap.yaml
+++ b/cost-analyzer/templates/integrations-postgres-queries-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kubecost-integrations-postgres-queries
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
     kubecost-queries.json: |-
       {{- with .Values.global.integrations.postgres.queryConfigs }}

--- a/cost-analyzer/templates/integrations-postgres-secret.yaml
+++ b/cost-analyzer/templates/integrations-postgres-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kubecost-integrations-postgres
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 type: Opaque
 stringData:
   creds.json: |-

--- a/cost-analyzer/templates/kubecost-admission-controller-service-template.yaml
+++ b/cost-analyzer/templates/kubecost-admission-controller-service-template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{.Release.Namespace}}
 spec:
   selector:
-    {{ include "cost-analyzer.selectorLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.selectorLabels" . | nindent 4 }}
   ports:
     - port: 443
       targetPort: 8443

--- a/cost-analyzer/templates/kubecost-agent-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-agent-secret-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ .Values.agentKeySecretName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   object-store.yaml: {{ .Values.agentKey }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 ---
 #
 # NOTE: 
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 rules:
   - apiGroups:
       - kubecost.com
@@ -173,7 +173,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "kubecost.clusterControllerName" . }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -279,7 +279,7 @@ metadata:
   name: {{ template "kubecost.clusterControllerName" . }}-service
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-service-monitor-template.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ include "kubecost.kubeMetricsName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.kubecostMetrics.exporter.serviceMonitor.additionalLabels }}
     {{ toYaml .Values.kubecostMetrics.exporter.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-oidc-secret-template.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ .Values.oidc.secretName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 stringData:
   clientSecret: {{ .Values.oidc.clientSecret }}
 {{- end -}}

--- a/cost-analyzer/templates/kubecost-priority-class-template.yaml
+++ b/cost-analyzer/templates/kubecost-priority-class-template.yaml
@@ -6,7 +6,7 @@ kind: PriorityClass
 metadata:
   name: {{ template "cost-analyzer.fullname" . }}-priority
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 value: {{ .Values.priority.value | default "1000000" }}
 globalDefault: false
 description: "Priority class for scheduling the cost-analyzer pod"

--- a/cost-analyzer/templates/kubecost-saml-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-saml-secret-template.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ .Values.saml.authSecretName | default "kubecost-saml-secret" }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 stringData:
   clientSecret: {{ .Values.saml.authSecret | default (randAlphaNum 32 | quote) }}
 {{- end }}

--- a/cost-analyzer/templates/model-ingress-template.yaml
+++ b/cost-analyzer/templates/model-ingress-template.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ $fullName }}-model
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- with .Values.kubecostModel.ingress.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
+++ b/cost-analyzer/templates/network-costs-servicemonitor-template.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "cost-analyzer.networkCostsName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.networkCosts.additionalLabels }}
     {{ toYaml .Values.serviceMonitor.networkCosts.additionalLabels | nindent 4 }}
     {{- end }}

--- a/cost-analyzer/templates/plugins-config.yaml
+++ b/cost-analyzer/templates/plugins-config.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Values.kubecostModel.plugins.secretName }}
   labels:
-     {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   {{- range $key, $config := .Values.kubecostModel.plugins.configs }}
   {{ $key }}_config.json:

--- a/cost-analyzer/templates/savings-recommendations-allowlists-config-map-template.yaml
+++ b/cost-analyzer/templates/savings-recommendations-allowlists-config-map-template.yaml
@@ -5,7 +5,8 @@ kind: ConfigMap
 metadata:
   name: "savings-recommendations-instance-allow-lists"
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   allow-lists.json: '{{ toJson .Values.kubecostProductConfigs.savingsRecommendationsAllowLists }}'
 {{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3552,5 +3552,5 @@ extraObjects: []
 #               number: 80
 
 
-# Add your own custom labels to the cost model. 
+# Add your own custom labels to the cost model.
 additionalChartLabels: {}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -304,9 +304,9 @@ global:
 ## Provide a full name override option for the chart.
 # fullnameOverride: ""
 
-## Configure Chart Labels
+## Provide additional labels for the chart.
 # chartLabels:
-#   LabelKey: LabelValue
+#   app.kubernetes.io/name: kubecost-cost-analyzer
 
 ## This flag is only required for users upgrading to a new version of Kubecost.
 ## The flag is used to ensure users are aware of important

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -3550,3 +3550,7 @@ extraObjects: []
 #             host: kubecost.kubecost.svc.cluster.local
 #             port:
 #               number: 80
+
+
+# Add your own custom labels to the cost model. 
+additionalChartLabels: {}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -304,6 +304,10 @@ global:
 ## Provide a full name override option for the chart.
 # fullnameOverride: ""
 
+## Configure Chart Labels
+# chartLabels:
+#   LabelKey: LabelValue
+
 ## This flag is only required for users upgrading to a new version of Kubecost.
 ## The flag is used to ensure users are aware of important
 ## (potentially breaking) changes included in the new version.
@@ -3550,7 +3554,3 @@ extraObjects: []
 #             host: kubecost.kubecost.svc.cluster.local
 #             port:
 #               number: 80
-
-
-# Add your own custom labels to the cost model.
-additionalChartLabels: {}


### PR DESCRIPTION
## What does this PR change?
Allow users to add additional chart labels through values.yaml

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will now be able to add additional chart labels through values

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/ENG-2368
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
low risk as this will be empty object by default and will be only adding chart labels when defined by user.

## How was this PR tested?
rendered the helm chart template locally with and without additional chart labels
Ran the command 
```Shell
helm template cost-analyzer . > template.yaml
```
template.yaml had the following result for one of the manifest
```yaml
# Source: cost-analyzer/templates/aggregator-cloud-cost-service.yaml
kind: Service
apiVersion: v1
metadata:
  name: cost-analyzer-cloud-cost
  namespace: default
  labels:

    helm.sh/chart: cost-analyzer-2.3.3
    app.kubernetes.io/managed-by: Helm
    LabelKey: LabelValue
    app.kubernetes.io/name: cost-analyzer
    app.kubernetes.io/instance: cost-analyzer
    app: cost-analyzer
spec:
  selector:

    app.kubernetes.io/name: cost-analyzer
    app.kubernetes.io/instance: cost-analyzer
    app: cost-analyzer
  type: "ClusterIP"
  ports:
    - name: tcp-api
      port: 9005
      targetPort: 9005
```

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
