### PR TITLE
Allow defining resources for Cluster Controller

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -257,14 +257,14 @@ spec:
         - name: http-server
           containerPort: 9731
           hostPort: 9731
+        resources:
+          {{- toYaml .Values.clusterController.resources | nindent 12 }}
       serviceAccount: {{ template "kubecost.clusterControllerName" . }}
       serviceAccountName: {{ template "kubecost.clusterControllerName" . }}
       {{- with .Values.clusterController.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      resources:
-        {{- toYaml .Values.clusterController.resources | nindent 12 }}
       volumes:
       - name: cluster-controller-keys
         secret:

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -263,6 +263,8 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      resources:
+        {{- toYaml .Values.clusterController.resources | nindent 12 }}
       volumes:
       - name: cluster-controller-keys
         secret:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2803,6 +2803,7 @@ clusterController:
   priorityClassName: ""
   # Set custom tolerations for the cluster controller.
   tolerations: []
+  resources: {}
   actionConfigs:
     # this configures the Kubecost Cluster Turndown action
     # for more details, see documentation at https://github.com/kubecost/cluster-turndown/tree/develop?tab=readme-ov-file#setting-a-turndown-schedule


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

## What does this PR change?

Allows users to define resources for Cluster Controller.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Allows users to define custom resource requests and limits for Cluster Controller.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

Closes #3641

## What risks are associated with merging this PR? What is required to fully test this PR?

CC may be broken.

## How was this PR tested?

Templated the CC resource with it both enabled and disabled; and with enabled both as empty object and defined.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A
