### PR TITLE
[CI] Test with K8s 1.31

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -54,8 +54,6 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - name: v1.21
-            version: v1.21.14
           - name: v1.22
             version: v1.22.17
           - name: v1.23
@@ -67,13 +65,15 @@ jobs:
           - name: v1.26
             version: v1.26.15
           - name: v1.27
-            version: v1.27.13
+            version: v1.27.16
           - name: v1.28
-            version: v1.28.9
+            version: v1.28.13
           - name: v1.29
-            version: v1.29.4
+            version: v1.29.8
           - name: v1.30
-            version: v1.30.0
+            version: v1.30.4
+          - name: v1.31
+            version: v1.31.0
     needs: test-chart
     name: ${{ matrix.k8s-version.name }} test
     steps:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Kubecost strives to support as many versions of Kubernetes as possible. Below is
 | 2.1                            | 1.20           | 1.29           |
 | 2.2                            | 1.21           | 1.29           |
 | 2.3                            | 1.21           | 1.30           |
-| 2.4                            | 1.21           | 1.30           |
+| 2.4                            | 1.22           | 1.31           |
 
 ## Installation
 


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

## What does this PR change?

Begins CI testing with K8s 1.31. Bumps patches for all other versions in the matrix. Rolls forward for compatibility of 2.4 by one version.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

None, but informs K8s 1.21 is no longer supported officially and declares support for 1.31.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?

CI only.

## How was this PR tested?

Will be tested manually once merged. (CI cannot run on PR modifications to workflows due to current settings.)

## Have you made an update to documentation? If so, please provide the corresponding PR.

Docs updates captured by README