### PR TITLE
ENG-2851 - Add `/diagnostic/nodeCount` endpoint

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -952,6 +952,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/diagnostic/nodeCount {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/diagnostic/nodeCount;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/diagnostic/tableWindowCount {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/diagnostic/tableWindowCount;


### PR DESCRIPTION
## What does this PR change?
* Routes the `/diagnostics/nodeCount` to Aggregator.

## Does this PR rely on any other PRs?
* [KCM](https://github.com/kubecost/kubecost-cost-model/pull/2837).

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Users will now have access to an Aggregator-backed node count query.

## What risks are associated with merging this PR? What is required to fully test this PR?
* Minimal risk for this PR. The KCM PR is where the risk lies.

## How was this PR tested?
* Need to test in-cluster.

## Have you made an update to documentation? If so, please provide the corresponding PR.
* I have not.