### PR TITLE
add cost model image tag as env var

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1526,3 +1526,26 @@ for more information
 {{- end -}}
 {{- $checksum | sha256sum -}}
 {{- end -}}
+
+{{- define "cost-model.image" }}
+{{- if .Values.kubecostModel }}
+  {{- if .Values.kubecostModel.fullImageName }}
+    {{ .Values.kubecostModel.fullImageName }}
+  {{- else if .Values.imageVersion }}
+    {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
+  {{- else if eq "development" .Chart.AppVersion }}
+    gcr.io/kubecost1/cost-model-nightly:latest
+  {{- else }}
+    {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+  {{- end }}
+{{- else }}
+  gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+{{- end }}
+{{- end }}
+
+{{- define "cost-model.imagetag" }}
+{{- $image := include "cost-model.image" . }}
+{{- $parts := splitList ":" $image }}
+{{- $tag := last $parts }}
+{{- $tag }}
+{{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -577,19 +577,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         {{- end }}
-        {{- if .Values.kubecostModel }}
-        {{- if .Values.kubecostModel.fullImageName }}
-        - image: {{ .Values.kubecostModel.fullImageName }}
-        {{- else if .Values.imageVersion }}
-        - image: {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
-        {{- else if eq "development" .Chart.AppVersion }}
-        - image: gcr.io/kubecost1/cost-model-nightly:latest
-        {{- else }}
-        - image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
-        {{- end }}
-        {{- else }}
-        - image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
-        {{- end }}
+        - image: {{ include "cost-model.image" . }}
           name: cost-model
         {{- if .Values.kubecostModel.extraArgs }}
           args:
@@ -746,6 +734,8 @@ spec:
             {{- end }}
             {{- end }}
           env:
+            - name: CONTAINER_IMAGE_TAG
+              value: {{ include "cost-model.imagetag" . }}
             {{- if .Values.global.grafana }}
             - name: GRAFANA_ENABLED
               value: "{{ template "cost-analyzer.grafanaEnabled" . }}"

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -577,7 +577,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         {{- end }}
-        - image: {{ include "cost-model.image" . }}
+        - image: {{ include "cost-model.image" . | trim | quote}}
           name: cost-model
         {{- if .Values.kubecostModel.extraArgs }}
           args:


### PR DESCRIPTION
## What does this PR change?
Adds cost model image tag as env var in the container

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Kubecost version in diagnostics page will not show cost-model image tag

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/ENG-2359

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
Tried all the scenarios that set the cost model image and checked the corresponding helm template. 
tried for the following scenarios along with the container image tag I got:
1. setting the fullImageName: e.g. `ishaanmittal/costmodel:test1` -> test1
2. setting imageVersion: e.g. `prod-2.4.0` -> prod-2.4.0
3. chart.Appversion is set to `development` -> latest
4. not setting anything(default) -> prod-2.4.1

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA