### PR TITLE
Nginx config for /savings/gpuUtilization/topline 

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -525,9 +525,9 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location = /model/savings/gpuUtilization {
+        location ~* /model/savings/gpuUtilization(.*) {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/gpuUtilization;
+            proxy_pass http://aggregator/savings/gpuUtilization$1$is_args$args;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;


### PR DESCRIPTION
## What does this PR change?
Modified the existing nginx route [PR](https://github.com/kubecost/cost-analyzer-helm-chart/pull/3704) to apply for both new end point /savings/gpuUtilization and /savings/gpuUtilization/topline

## Does this PR rely on any other PRs?
Uses [PR](https://github.com/kubecost/cost-analyzer-helm-chart/pull/3704) 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
None

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
https://kubecost.atlassian.net/browse/ENG-2980


## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
Applying it in my cluster and checking both end points

## Have you made an update to documentation? If so, please provide the corresponding PR.
No
