### PR TITLE
Update issue guidelines

### DIFF
--- a/ISSUE_GUIDELINES.md
+++ b/ISSUE_GUIDELINES.md
@@ -1,16 +1,16 @@
 # Issue Guidelines
 
-Issues filed in this repository are specific to the Kubecost Helm chart only. If your issue pertains to the Kubecost application and not the Helm chart, follow the guidance below.
+Issues filed in this repository are specific to the Kubecost Helm chart only. If your issue pertains to the Kubecost application and not the Helm chart, please raise a request at https://support.kubecost.com.
 
 To help route you to the best location, see some examples of feature requests and bug reports [below](#examples-of-helm-requests).
 
 ## Kubecost Feature Requests
 
-For all feature requests to Kubecost, please create an enhancement request in the [feature requests and bugs repository](https://github.com/kubecost/features-bugs).
+For all feature requests to Kubecost, please create an enhancement request at https://support.kubecost.com.
 
 ## Kubecost Bug Reports
 
-Bug reports for the Kubecost application stack should be directed to the [feature requests and bugs repository](https://github.com/kubecost/features-bugs).
+Bug reports for the Kubecost application stack should be directed to https://support.kubecost.com.
 
 ## Examples of Helm Requests
 


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Updates to the ISSUE_GUIDELINES.md file which now directs users who wish to file bugs and feature requests about the Kubecost application itself (not the Helm chart) to the portal at https://support.kubecost.com.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Directs them to the current portal for all application issues.

## Links to Issues or tickets this PR addresses or fixes

N/A



## What risks are associated with merging this PR? What is required to fully test this PR?

None

## How was this PR tested?

N/A

## Have you made an update to documentation? If so, please provide the corresponding PR.

This is a docs update only.
