### PR TITLE
Fix proper handling of a list of values for imagePullSecrets

### DIFF
--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -149,10 +149,19 @@ spec:
       {{- end }}
       containers:
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
+<<<<<<< Updated upstream
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
       {{- if .Values.kubecostAggregator.priority }}
       {{- if .Values.kubecostAggregator.priority.enabled }}
       {{- if .Values.kubecostAggregator.priority.name }}

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -149,10 +149,10 @@ spec:
       {{- end }}
       containers:
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
-    {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
       {{- if .Values.kubecostAggregator.priority }}
       {{- if .Values.kubecostAggregator.priority.enabled }}
       {{- if .Values.kubecostAggregator.priority.name }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -186,10 +186,10 @@ spec:
         {{ include "aggregator.jaeger.sidecarContainerTemplate" . | nindent 8 }}
         {{- end }}
 
-    {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
       {{- if .Values.kubecostAggregator.priority }}
       {{- if .Values.kubecostAggregator.priority.enabled }}
       {{- if .Values.kubecostAggregator.priority.name }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -186,10 +186,19 @@ spec:
         {{ include "aggregator.jaeger.sidecarContainerTemplate" . | nindent 8 }}
         {{- end }}
 
+<<<<<<< Updated upstream
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
       {{- if .Values.kubecostAggregator.priority }}
       {{- if .Values.kubecostAggregator.priority.enabled }}
       {{- if .Values.kubecostAggregator.priority.name }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -1227,11 +1227,10 @@ spec:
         {{- end }}
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
         {{- end }}
-
-    {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}    
       {{- if .Values.priority }}
       {{- if .Values.priority.enabled }}
       {{- if gt (len .Values.priority.name) 0 }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -1229,11 +1229,20 @@ spec:
         {{- end }}
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
         {{- end }}
+<<<<<<< Updated upstream
 
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
       {{- if .Values.priority }}
       {{- if .Values.priority.enabled }}
       {{- if gt (len .Values.priority.name) 0 }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -40,10 +40,10 @@ spec:
         {{- toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
         {{- end }}
     spec:
-    {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
       hostNetwork: true
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       containers:

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -40,10 +40,19 @@ spec:
         {{- toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
         {{- end }}
     spec:
+<<<<<<< Updated upstream
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
       hostNetwork: true
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       containers:

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -83,9 +83,9 @@ spec:
           {{- else }}
           imagePullPolicy: Always
           {{- end }}
-          {{- if .Values.imagePullSecrets }}
           imagePullSecrets:
-          {{ toYaml .Values.imagePullSecrets | indent 2 }}
+          {{- range $.Values.imagePullSecrets }}
+            - name: {{ .name }}
           {{- end }}
           {{- if .Values.diagnostics.deployment.containerSecurityContext }}
           securityContext:

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -83,10 +83,11 @@ spec:
           {{- else }}
           imagePullPolicy: Always
           {{- end }}
+          {{- if .Values.imagePullSecrets }}
           imagePullSecrets:
-          {{- range $.Values.imagePullSecrets }}
+            {{- range $.Values.imagePullSecrets }}
             - name: {{ .name }}
-          {{- end }}
+            {{- end }}
           {{- end }}
           {{- if .Values.diagnostics.deployment.containerSecurityContext }}
           securityContext:

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -87,6 +87,7 @@ spec:
           imagePullSecrets:
           {{ toYaml .Values.imagePullSecrets | indent 2 }}
           {{- end }}
+          {{- end }}
           {{- if .Values.diagnostics.deployment.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.diagnostics.deployment.containerSecurityContext | nindent 12 }}

--- a/cost-analyzer/templates/etl-utils-deployment.yaml
+++ b/cost-analyzer/templates/etl-utils-deployment.yaml
@@ -110,11 +110,10 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
             {{- end }}
-
-    {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
       {{- with .Values.etlUtils.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cost-analyzer/templates/etl-utils-deployment.yaml
+++ b/cost-analyzer/templates/etl-utils-deployment.yaml
@@ -110,11 +110,20 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
             {{- end }}
+<<<<<<< Updated upstream
 
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
       {{- with .Values.etlUtils.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -113,9 +113,9 @@ spec:
             periodSeconds: {{ .Values.forecasting.livenessProbe.periodSeconds  }}
             failureThreshold: {{ .Values.forecasting.livenessProbe.failureThreshold  }}
           {{- end }}
-      {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
       {{- end }}
       {{- if .Values.forecasting.priority }}
       {{- if .Values.forecasting.priority.enabled }}

--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -113,10 +113,11 @@ spec:
             periodSeconds: {{ .Values.forecasting.livenessProbe.periodSeconds  }}
             failureThreshold: {{ .Values.forecasting.livenessProbe.failureThreshold  }}
           {{- end }}
+      {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
+        {{- range $.Values.imagePullSecrets }}
         - name: {{ .name }}
-      {{- end }}
+        {{- end }}
       {{- end }}
       {{- if .Values.forecasting.priority }}
       {{- if .Values.forecasting.priority.enabled }}

--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -117,6 +117,7 @@ spec:
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}
       {{- end }}
+      {{- end }}
       {{- if .Values.forecasting.priority }}
       {{- if .Values.forecasting.priority.enabled }}
       {{- if .Values.forecasting.priority.name }}

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -188,10 +188,10 @@ spec:
           securityContext:
           {{- toYaml .Values.global.containerSecuritycontext | nindent 12 }}
           {{- end }}
-    {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
       {{- if .Values.priority }}
       {{- if .Values.priority.enabled }}
       {{- if gt (len .Values.priority.name) 0 }}

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -188,10 +188,19 @@ spec:
           securityContext:
           {{- toYaml .Values.global.containerSecuritycontext | nindent 12 }}
           {{- end }}
+<<<<<<< Updated upstream
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
       {{- if .Values.priority }}
       {{- if .Values.priority.enabled }}
       {{- if gt (len .Values.priority.name) 0 }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -324,10 +324,19 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: kubecost-token
+<<<<<<< Updated upstream
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
       {{- if .Values.kubecostMetrics.exporter.priorityClassName }}
       priorityClassName: {{ .Values.kubecostMetrics.exporter.priorityClassName }}
       {{- end }}

--- a/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
+++ b/cost-analyzer/templates/kubecost-metrics-deployment-template.yaml
@@ -324,10 +324,10 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: kubecost-token
-    {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
       {{- if .Values.kubecostMetrics.exporter.priorityClassName }}
       priorityClassName: {{ .Values.kubecostMetrics.exporter.priorityClassName }}
       {{- end }}

--- a/cost-analyzer/templates/prometheus-alertmanager-deployment.yaml
+++ b/cost-analyzer/templates/prometheus-alertmanager-deployment.yaml
@@ -113,10 +113,10 @@ spec:
               mountPath: /etc/config
               readOnly: true
         {{- end }}
-    {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
     {{- if .Values.prometheus.alertmanager.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.prometheus.alertmanager.nodeSelector | indent 8 }}

--- a/cost-analyzer/templates/prometheus-alertmanager-deployment.yaml
+++ b/cost-analyzer/templates/prometheus-alertmanager-deployment.yaml
@@ -113,10 +113,19 @@ spec:
               mountPath: /etc/config
               readOnly: true
         {{- end }}
+<<<<<<< Updated upstream
     {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.prometheus.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
     {{- if .Values.prometheus.alertmanager.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.prometheus.alertmanager.nodeSelector | indent 8 }}

--- a/cost-analyzer/templates/prometheus-alertmanager-statefulset.yaml
+++ b/cost-analyzer/templates/prometheus-alertmanager-statefulset.yaml
@@ -111,10 +111,10 @@ spec:
               mountPath: /etc/config
               readOnly: true
         {{- end }}
-    {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
     {{- if .Values.prometheus.alertmanager.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.prometheus.alertmanager.nodeSelector | indent 8 }}

--- a/cost-analyzer/templates/prometheus-alertmanager-statefulset.yaml
+++ b/cost-analyzer/templates/prometheus-alertmanager-statefulset.yaml
@@ -111,10 +111,19 @@ spec:
               mountPath: /etc/config
               readOnly: true
         {{- end }}
+<<<<<<< Updated upstream
     {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.prometheus.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
     {{- if .Values.prometheus.alertmanager.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.prometheus.alertmanager.nodeSelector | indent 8 }}

--- a/cost-analyzer/templates/prometheus-node-exporter-daemonset.yaml
+++ b/cost-analyzer/templates/prometheus-node-exporter-daemonset.yaml
@@ -101,10 +101,19 @@ spec:
               mountPath: {{ .mountPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+<<<<<<< Updated upstream
     {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.prometheus.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
     {{- if .Values.prometheus.nodeExporter.hostNetwork }}
       hostNetwork: true
     {{- end }}

--- a/cost-analyzer/templates/prometheus-node-exporter-daemonset.yaml
+++ b/cost-analyzer/templates/prometheus-node-exporter-daemonset.yaml
@@ -101,10 +101,10 @@ spec:
               mountPath: {{ .mountPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
-    {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
     {{- if .Values.prometheus.nodeExporter.hostNetwork }}
       hostNetwork: true
     {{- end }}

--- a/cost-analyzer/templates/prometheus-pushgateway-deployment.yaml
+++ b/cost-analyzer/templates/prometheus-pushgateway-deployment.yaml
@@ -86,10 +86,10 @@ spec:
               mountPath: "{{ .Values.prometheus.pushgateway.persistentVolume.mountPath }}"
               subPath: "{{ .Values.prometheus.pushgateway.persistentVolume.subPath }}"
           {{- end }}
-    {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
     {{- if .Values.prometheus.pushgateway.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.prometheus.pushgateway.nodeSelector | indent 8 }}

--- a/cost-analyzer/templates/prometheus-pushgateway-deployment.yaml
+++ b/cost-analyzer/templates/prometheus-pushgateway-deployment.yaml
@@ -86,10 +86,19 @@ spec:
               mountPath: "{{ .Values.prometheus.pushgateway.persistentVolume.mountPath }}"
               subPath: "{{ .Values.prometheus.pushgateway.persistentVolume.subPath }}"
           {{- end }}
+<<<<<<< Updated upstream
     {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.prometheus.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
     {{- if .Values.prometheus.pushgateway.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.prometheus.pushgateway.nodeSelector | indent 8 }}

--- a/cost-analyzer/templates/prometheus-server-deployment.yaml
+++ b/cost-analyzer/templates/prometheus-server-deployment.yaml
@@ -181,10 +181,10 @@ spec:
       {{- if .Values.prometheus.server.sidecarContainers }}
       {{- toYaml .Values.prometheus.server.sidecarContainers | nindent 8 }}
       {{- end }}
-    {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
-        {{ toYaml .Values.prometheus.imagePullSecrets | indent 0 }}
-    {{- end }}
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
     {{- if .Values.prometheus.server.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.prometheus.server.nodeSelector | nindent 8 }}

--- a/cost-analyzer/templates/prometheus-server-deployment.yaml
+++ b/cost-analyzer/templates/prometheus-server-deployment.yaml
@@ -181,10 +181,19 @@ spec:
       {{- if .Values.prometheus.server.sidecarContainers }}
       {{- toYaml .Values.prometheus.server.sidecarContainers | nindent 8 }}
       {{- end }}
+<<<<<<< Updated upstream
     {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
         {{ toYaml .Values.prometheus.imagePullSecrets | indent 0 }}
     {{- end }}
+=======
+      {{- if .Values.prometheus.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
     {{- if .Values.prometheus.server.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.prometheus.server.nodeSelector | nindent 8 }}

--- a/cost-analyzer/templates/prometheus-server-statefulset.yaml
+++ b/cost-analyzer/templates/prometheus-server-statefulset.yaml
@@ -156,7 +156,6 @@ spec:
        {{- if .Values.prometheus.server.sidecarContainers }}
        {{- toYaml .Values.prometheus.server.sidecarContainers | nindent 8 }}
        {{- end }}
-<<<<<<< Updated upstream
     {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
       {{- range $.Values.prometheus.imagePullSecrets}}

--- a/cost-analyzer/templates/prometheus-server-statefulset.yaml
+++ b/cost-analyzer/templates/prometheus-server-statefulset.yaml
@@ -156,10 +156,10 @@ spec:
        {{- if .Values.prometheus.server.sidecarContainers }}
        {{- toYaml .Values.prometheus.server.sidecarContainers | nindent 8 }}
        {{- end }}
-    {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
-       {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
-    {{- end }}
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
     {{- if .Values.prometheus.server.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.prometheus.server.nodeSelector | indent 8 }}

--- a/cost-analyzer/templates/prometheus-server-statefulset.yaml
+++ b/cost-analyzer/templates/prometheus-server-statefulset.yaml
@@ -156,10 +156,19 @@ spec:
        {{- if .Values.prometheus.server.sidecarContainers }}
        {{- toYaml .Values.prometheus.server.sidecarContainers | nindent 8 }}
        {{- end }}
+<<<<<<< Updated upstream
     {{- if .Values.prometheus.imagePullSecrets }}
       imagePullSecrets:
        {{ toYaml .Values.prometheus.imagePullSecrets | indent 2 }}
     {{- end }}
+=======
+      {{- if .Values.prometheus.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.prometheus.imagePullSecrets}}
+        - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+>>>>>>> Stashed changes
     {{- if .Values.prometheus.server.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.prometheus.server.nodeSelector | indent 8 }}


### PR DESCRIPTION
## What does this PR change?
Adds proper helm chart handling for `.Values.imagePullSecrets` and `.Values.prometheus.imagePullSecrets` for more than a single item.


## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
This PR will allow users to specify multiple entries for `imagePullSecrets`.

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/ENG-3005


## What risks are associated with merging this PR? What is required to fully test this PR?
Helm installations could possibly fail if the YAML manifests are generated incorrectly (this is what actually happens today if you try to specify multiple values for `imagePullSecrets`)

## How was this PR tested?
This PR was tested by verifying that the correct YAML syntax was generated from a `helm template` command and that the installation completed successfully.

## Have you made an update to documentation? If so, please provide the corresponding PR.
No updates to docs.

