### PR TITLE
Add logLevel as a helm value property under kubecostModel instead of extraEnv configuration

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1115,7 +1115,7 @@ Begin Kubecost 2.0 templates
       {{- end }}
     {{- end }}
     - name: LOG_LEVEL
-      value: {{ .Values.kubecostAggregator.logLevel | default "info" }}
+      value: {{ .Values.kubecostAggregator.logLevel }}
     - name: DB_READ_THREADS
       value: {{ .Values.kubecostAggregator.dbReadThreads | quote }}
     - name: DB_WRITE_THREADS

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1115,7 +1115,7 @@ Begin Kubecost 2.0 templates
       {{- end }}
     {{- end }}
     - name: LOG_LEVEL
-      value: {{ .Values.kubecostAggregator.logLevel }}
+      value: {{ .Values.kubecostAggregator.logLevel | default "info" }}
     - name: DB_READ_THREADS
       value: {{ .Values.kubecostAggregator.dbReadThreads | quote }}
     - name: DB_WRITE_THREADS

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -740,7 +740,7 @@ spec:
             - name: GRAFANA_ENABLED
               value: "{{ template "cost-analyzer.grafanaEnabled" . }}"
             - name: LOG_LEVEL
-              value: {{ .Values.kubecostAggregator.logLevel }}
+              value: {{ .Values.kubecostModel.logLevel }}
             {{- end}}
             {{- if .Values.kubecostModel.extraEnv -}}
             {{ toYaml .Values.kubecostModel.extraEnv | nindent 12 }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -739,9 +739,9 @@ spec:
             {{- if .Values.global.grafana }}
             - name: GRAFANA_ENABLED
               value: "{{ template "cost-analyzer.grafanaEnabled" . }}"
+            {{- end}}
             - name: LOG_LEVEL
               value: {{ .Values.kubecostModel.logLevel }}
-            {{- end}}
             {{- if .Values.kubecostModel.extraEnv -}}
             {{ toYaml .Values.kubecostModel.extraEnv | nindent 12 }}
             {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -739,6 +739,8 @@ spec:
             {{- if .Values.global.grafana }}
             - name: GRAFANA_ENABLED
               value: "{{ template "cost-analyzer.grafanaEnabled" . }}"
+            - name: LOG_LEVEL
+              value: {{ .Values.kubecostAggregator.logLevel }}
             {{- end}}
             {{- if .Values.kubecostModel.extraEnv -}}
             {{ toYaml .Values.kubecostModel.extraEnv | nindent 12 }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -740,7 +740,7 @@ spec:
             - name: GRAFANA_ENABLED
               value: "{{ template "cost-analyzer.grafanaEnabled" . }}"
             - name: LOG_LEVEL
-              value: {{ .Values.kubecostModel.logLevel }}
+              value: {{ .Values.kubecostModel.logLevel | default "info" }}
             {{- end}}
             {{- if .Values.kubecostModel.extraEnv -}}
             {{ toYaml .Values.kubecostModel.extraEnv | nindent 12 }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -740,7 +740,7 @@ spec:
             - name: GRAFANA_ENABLED
               value: "{{ template "cost-analyzer.grafanaEnabled" . }}"
             - name: LOG_LEVEL
-              value: {{ .Values.kubecostModel.logLevel | default "info" }}
+              value: {{ .Values.kubecostModel.logLevel }}
             {{- end}}
             {{- if .Values.kubecostModel.extraEnv -}}
             {{ toYaml .Values.kubecostModel.extraEnv | nindent 12 }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -79,7 +79,7 @@ spec:
         - name: TRAFFIC_LOGGING_ENABLED
           value: {{ (quote .Values.networkCosts.trafficLogging) | default (quote true) }}
         - name: LOG_LEVEL
-          value: {{ .Values.networkCosts.logLevel | default "info" }}
+          value: {{ .Values.networkCosts.logLevel }}
         {{- if .Values.networkCosts.softMemoryLimit }}
         - name: GOMEMLIMIT
           value: {{ .Values.networkCosts.softMemoryLimit }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -555,6 +555,7 @@ kubecostModel:
   # image provided (registry, image, tag) will be used for cost-model.
   # fullImageName:
 
+  # Log level for the cost model container. Options are "trace", "debug", "info", "warn", "error", "fatal", "panic"
   logLevel: info
 
   # securityContext:
@@ -2307,6 +2308,7 @@ networkCosts:
   # every 30 minutes.
   trafficLogging: true
 
+  # Log level for the network cost containers. Options are "trace", "debug", "info", "warn", "error", "fatal", "panic"
   logLevel: info
 
   # Port will set both the containerPort and hostPort to this value.
@@ -2524,6 +2526,7 @@ kubecostAggregator:
   # `deployMethod: "statefulset"`
   replicas: 1
 
+  # Log level for the aggregator container. Options are "trace", "debug", "info", "warn", "error", "fatal", "panic"
   logLevel: info
 
   # stagingEmptyDirSizeLimit changes how large the "staging"

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -555,6 +555,8 @@ kubecostModel:
   # image provided (registry, image, tag) will be used for cost-model.
   # fullImageName:
 
+  logLevel: info
+
   # securityContext:
   #   readOnlyRootFilesystem: true
 
@@ -708,8 +710,6 @@ kubecostModel:
 
   # Optional. A list of extra environment variables to be added to the cost-model container.
   # extraEnv:
-  #   - name: LOG_LEVEL
-  #     value: trace
   #   - name: LOG_FORMAT
   #     value: json
   #   # When false, Kubecost will not show Asset costs for local disks physically


### PR DESCRIPTION
## What does this PR change?
Adds log level as a helm value property for kubecostModel to make it easier to be configured by the user. 

## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds log level as a helm value property for kubecostModel to make it easier to be configured by the user. Right now the user has to add an extraEnv for log level to make it work out.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
deployed kubecost by setting the helm values as
```yaml
kubecostModel:
  logLevel: "debug"
```
I was able to see debug logs in cost-model container

## Have you made an update to documentation? If so, please provide the corresponding PR.
Not yet but will do
