### PR TITLE
Create end point to support GPU aggregations other than pod and container

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -533,6 +533,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/savings/gpuRecommendation {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/savings/gpuRecommendation;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/cloudCost {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/cloudCost;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -525,6 +525,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location ~* /model/savings/gpuContainersDetails(.*) {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/savings/gpuContainersDetails$1$is_args$args;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location ~* /model/savings/gpuUtilization(.*) {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/savings/gpuUtilization$1$is_args$args;


### PR DESCRIPTION
## What does this PR change?
Adds other than pod and container aggregation 

## Does this PR rely on any other PRs?
https://github.com/kubecost/kubecost-cost-model/pull/2902

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No impact

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/ENG-3003
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
All permutations mentioned in method 1 of the [doc](https://docs.google.com/document/d/1GGDXBGsr0Uw5U-CJokOlx_El9FmLYh8ttOnYIJe271Q/edit?tab=t.0) was tried in the KCM install [alan-gpu-test](https://alan-gpu.qa-eks3.kubecost.xyz/model/savings/gpuContainersDetails?aggregate=cluster&nodeCount=true&gpuContainersCount=true)

## Have you made an update to documentation? If so, please provide the corresponding PR.

