### PR TITLE
Update comments about OIDC RBAC groups.

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -374,19 +374,19 @@ oidc:
   rbac:
     enabled: false
     # groups:
-    #   - name: admin
-    #     enabled: false  # If admin is disabled, all authenticated users will be able to make configuration changes to the kubecost frontend
+    #   - name: admin  # Admins have permissions to edit Kubecost settings and save reports
+    #     enabled: false
     #     claimName: "roles"  # Kubecost matches this string against the JWT's payload key containing RBAC info (this value is unique across identity providers)
     #     claimValues:  # Kubecost matches these strings with the roles created in your identity provider
     #       - "admin"
     #       - "superusers"
-    #   - name: readonly
-    #     enabled: false  # If readonly is disabled, all authenticated users will default to readonly
+    #   - name: readonly  # Readonly users do not have permissions to edit Kubecost settings or save reports.
+    #     enabled: false
     #     claimName: "roles"
     #     claimValues:
     #       - "readonly"
-    #   - name: editor
-    #     enabled: false  # If editor is enabled, editors will be allowed to edit reports/alerts scoped to them, and act as readers otherwise. Users will never default to editor.
+    #   - name: editor  # Editors have permissions to edit reports/alerts and act as readers otherwise
+    #     enabled: false
     #     claimName: "roles"
     #     claimValues:
     #       - "editor"


### PR DESCRIPTION
## What does this PR change?

More accurate comments regarding OIDC RBAC groups. Previously, the comments were identical to those in SAML RBAC. However, the underlying implementations differ.

SAML allows all authenticated users through on read routes even if they don't belong to a group. It will only enforce groups if the `readonly` group is enabled ([code ref](https://github.com/kubecost/kubecost-cost-model/blob/0d344ebbad1fdd0654996fcdb87d36249a2e8465/pkg/auth/samlauth.go#L184-L197)).

OIDC blocks users from entry to the application if they do not belong to a valid group ([code ref](https://github.com/kubecost/kubecost-cost-model/blob/0d344ebbad1fdd0654996fcdb87d36249a2e8465/pkg/auth/oidcauth.go#L210-L213)).

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

N/A

## How was this PR tested?

N/A

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A
