### PR TITLE
topline endpoint nginx

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -575,9 +575,9 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         {{- end }}
-        location = /model/savings/gpuRecommendation {
+        location ~* /model/savings/gpuRecommendation(.*) {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/gpuRecommendation;
+            proxy_pass http://aggregator/savings/gpuRecommendation$1$is_args$args;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;


### PR DESCRIPTION
## What does this PR change?
* Adds `gpuRecommendation/topline` endpoint to nginx

## Does this PR rely on any other PRs?
https://github.com/kubecost/kubecost-cost-model/pull/2916

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
GPU recommendation topline endpoint

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
https://kubecost.atlassian.net/browse/ENG-2981


## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
Endpoint is reachable on https://alan-gpu.qa-eks3.kubecost.xyz/model/savings/gpuRecommendation/topline

## Have you made an update to documentation? If so, please provide the corresponding PR.

