### PR TITLE
Improve comment in extraScrapeConfigs

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -800,7 +800,7 @@ prometheus:
     ## Enables scraping of NVIDIA GPU metrics via dcgm-exporter. Scrapes all
     ## endpoints which contain "dcgm-exporter" in labels "app",
     ## "app.kubernetes.io/component", or "app.kubernetes.io/name" with a case
-    ## insensitive match.
+    ## insensitive match. The label must be present on the K8s service endpoints and not just pods.
     ## Refs:
     ## https://github.com/NVIDIA/gpu-operator/blob/d4316a415bbd684ce8416a88042305fc1a093aa4/assets/state-dcgm-exporter/0600_service.yaml#L7
     ## https://github.com/NVIDIA/dcgm-exporter/blob/54fd1ca137c66511a87a720390613680b9bdabdd/deployment/templates/service.yaml#L23


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

## What does this PR change?

Improves a comment on the "kubecost-dcgm-exporter" job for the Prometheus extraScrapeConfigs. This comment is designed to further explain to users where the appropriate label should go.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Docs only, in effect.


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

None, comment change only.

## How was this PR tested?

No testing required.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A