### PR TITLE
change savings/gpuUtilization to savings/gpuWorkloadUtilization

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -533,9 +533,9 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        location ~* /model/savings/gpuUtilization(.*) {
+        location ~* /model/savings/gpuWorkloadUtilization(.*) {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/gpuUtilization$1$is_args$args;
+            proxy_pass http://aggregator/savings/gpuWorkloadUtilization$1$is_args$args;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;


### PR DESCRIPTION
## What does this PR change?
Just the NGINX route end point change 

## Does this PR rely on any other PRs?
KCM PR: https://github.com/kubecost/kubecost-cost-model/pull/2940

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
None only FE needs to update calls in nightly

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
It is fully tested.

## How was this PR tested?
Refer KCM PR.

## Have you made an update to documentation? If so, please provide the corresponding PR.
No
