### PR TITLE
docs: Add note for deprecated ingress annotation

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -686,9 +686,15 @@ ingress:
   enabled: false
   # className: nginx
   labels:
+    ## Starting in kubernetes v1.18, `kubernetes.io/ingress.class` annotation is deprecated.
+    ## Use `spec.ingressClassName` instead of this annotation.
+    ## See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   annotations:
+    ## Starting in kubernetes v1.18, `kubernetes.io/ingress.class` annotation is deprecated.
+    ## Use `spec.ingressClassName` instead of this annotation.
+    ## See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   paths: ["/"]  # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -693,9 +693,6 @@ ingress:
   enabled: false
   # className: nginx
   labels:
-    ## Starting in kubernetes v1.18, `kubernetes.io/ingress.class` annotation is deprecated.
-    ## Use `spec.ingressClassName` instead of this annotation.
-    ## See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   annotations:


### PR DESCRIPTION
## What does this PR change?

- Add helm note for deprecated annotation named `kubernetes.io/ingress.class`.

## Does this PR rely on any other PRs?

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Cluster administrators, such as DevOps engineers or SREs, can gain valuable tips during the Kubecost installation phase.

## Links to Issues or tickets this PR addresses or fixes

- [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/)
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?

- No PR testing is required.

## Have you made an update to documentation? If so, please provide the corresponding PR.

