### PR TITLE
add helm config option to mount ca certs to cost model container

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -128,9 +128,8 @@ spec:
         {{- end }}
         {{- if or .Values.kubecostModel.caCertsConfigMap }}
         - name: ca-certs-config
-          secret:
-           defaultMode: 420
-           secretName: {{ .Values.kubecostModel.caCertsConfigMap}}
+          configMap:
+           name: {{ .Values.kubecostModel.caCertsConfigMap}}
         {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -126,7 +126,7 @@ spec:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
-        {{- if or .Values.kubecostModel.caCertsSecret }}
+        {{- if .Values.kubecostModel.caCertsSecret }}
         - name: ca-certs-secret
           secret:
            defaultMode: 420
@@ -621,7 +621,7 @@ spec:
               mountPath: /var/configs/etl/federated
               readOnly: true
             {{- end }}
-            {{- if or .Values.kubecostModel.caCertsSecret }}
+            {{- if .Values.kubecostModel.caCertsSecret }}
             - name: ca-certs-secret
               mountPath: /etc/pki/ca-trust/source/anchors
             {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -126,10 +126,11 @@ spec:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
-        {{- if or .Values.kubecostModel.caCertsConfigMap }}
-        - name: ca-certs-config
-          configMap:
-           name: {{ .Values.kubecostModel.caCertsConfigMap}}
+        {{- if or .Values.kubecostModel.caCertsSecret }}
+        - name: ca-certs-secret
+          secret:
+           defaultMode: 420
+           secretName: {{ .Values.kubecostModel.caCertsSecret}}
         {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname }}
@@ -620,10 +621,9 @@ spec:
               mountPath: /var/configs/etl/federated
               readOnly: true
             {{- end }}
-            {{- if or .Values.kubecostModel.caCertsConfigMap }}
-            - name: ca-certs-config
+            {{- if or .Values.kubecostModel.caCertsSecret }}
+            - name: ca-certs-secret
               mountPath: /etc/pki/ca-trust/source/anchors
-              readOnly: true
             {{- end }}
             {{- if .Values.kubecostAdmissionController }}
             {{- if .Values.kubecostAdmissionController.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -126,6 +126,12 @@ spec:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
+        {{- if or .Values.kubecostModel.caCertsConfigMap }}
+        - name: ca-certs-config
+          secret:
+           defaultMode: 420
+           secretName: {{ .Values.kubecostModel.caCertsConfigMap}}
+        {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname }}
         - name: productkey-secret
@@ -613,6 +619,11 @@ spec:
             {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig }}
             - name: federated-storage-config
               mountPath: /var/configs/etl/federated
+              readOnly: true
+            {{- end }}
+            {{- if or .Values.kubecostModel.caCertsConfigMap }}
+            - name: ca-certs-config
+              mountPath: /etc/pki/ca-trust/source/anchors
               readOnly: true
             {{- end }}
             {{- if .Values.kubecostAdmissionController }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -575,8 +575,8 @@ kubecostModel:
   #         "client_x509_cert_url": ""
   #       }
 
-  # the name of the ConfigMap containing custom CA certs to mount to cost model container
-  caCertsConfigMap: ca-certs-config
+  # the name of the Secret containing custom CA certs to mount to cost model container
+  # caCertsSecret: ca-certs-secret
 
   # Installs Kubecost/OpenCost plugins
   plugins:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -575,6 +575,9 @@ kubecostModel:
   #         "client_x509_cert_url": ""
   #       }
 
+  # the name of the ConfigMap containing custom CA certs to mount to cost model container
+  caCertsConfigMap: ca-certs-config
+
   # Installs Kubecost/OpenCost plugins
   plugins:
     enabled: false


### PR DESCRIPTION
## What does this PR change?
Adds help config option to mount custom cacerts config map to `/etc/pki/ca-trust/source/anchors` inside the cost model container. 
reference 
https://docs.fedoraproject.org/en-US/quick-docs/using-shared-system-certificates/#_adding_new_certificates
https://jfrog.com/help/r/artifactory-how-to-add-custom-ssl-certificates-to-an-artifactory-pod-using-helm-charts/general-steps-to-fix-the-ssl-certificate-error

The user will need to have a secret in the release namespace before using this configuration.
you might want to create a secret with a command like:
```sh
kubectl create secret generic ca-certs-secret --from-file=./cert-trust-test-ca.pem -n kubecost
```

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will now be able to add their custom ca certs to the cost model container

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/SUP-6432?focusedCommentId=136102
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
No

## How was this PR tested?
Added a ca cert secret and configured the added helm values. ca cert secret was mounted inside the cost-model container.
![image](https://github.com/user-attachments/assets/e20aa2d3-8fa4-44b8-88ce-fa78ce2350df)

## Have you made an update to documentation? If so, please provide the corresponding PR.

