### PR TITLE
add helm config option to mount ca certs to cost model container (#3760)

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -126,6 +126,12 @@ spec:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
+        {{- if .Values.kubecostModel.caCertsSecret }}
+        - name: ca-certs-secret
+          secret:
+           defaultMode: 420
+           secretName: {{ .Values.kubecostModel.caCertsSecret}}
+        {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname }}
         - name: productkey-secret
@@ -614,6 +620,10 @@ spec:
             - name: federated-storage-config
               mountPath: /var/configs/etl/federated
               readOnly: true
+            {{- end }}
+            {{- if .Values.kubecostModel.caCertsSecret }}
+            - name: ca-certs-secret
+              mountPath: /etc/pki/ca-trust/source/anchors
             {{- end }}
             {{- if .Values.kubecostAdmissionController }}
             {{- if .Values.kubecostAdmissionController.enabled }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -575,6 +575,9 @@ kubecostModel:
   #         "client_x509_cert_url": ""
   #       }
 
+  # the name of the Secret containing custom CA certs to mount to cost model container
+  # caCertsSecret: ca-certs-secret
+
   # Installs Kubecost/OpenCost plugins
   plugins:
     enabled: false


### PR DESCRIPTION
* add helm config option to mount ca certs to cost model container

* update it to be configmap

* shift from config map tp secret

* nit fix

## What does this PR change?


## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

