### PR TITLE
add init container for updating ca trust and shift getting ca cert from secret to config map

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -10,6 +10,7 @@
 {{- include "prometheusRetentionCheck" . -}}
 {{- include "clusterIDCheck" . -}}
 {{- include "kubeRBACProxyBearerTokenCheck" . -}}
+{{- include "caCertsSecretConfigCheck" . -}}
 
 {{- $servicePort := .Values.service.port | default 9090 }}
 Kubecost {{ .Chart.Version }} has been successfully installed.

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1447,6 +1447,16 @@ for more information
 {{- end }}
 {{- end }}
 
+{{- define "caCertsSecretConfigCheck" }}
+  {{- if .Values.kubecostModel.updateCaTrust.enabled }}
+    {{- if and .Values.kubecostModel.updateCaTrust.caCertsSecret .Values.kubecostModel.updateCaTrust.caCertsConfig }}
+      {{- fail "Both caCertsSecret and caCertsConfig are defined. Please specify only one." }}
+    {{- else if and (not .Values.kubecostModel.updateCaTrust.caCertsSecret) (not .Values.kubecostModel.updateCaTrust.caCertsConfig) }}
+      {{- fail "Neither caCertsSecret nor caCertsConfig is defined, but updateCaTrust is enabled. Please specify one." }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- define "clusterControllerEnabled" }}
 {{- if (.Values.clusterController).enabled }}
 {{- printf "true" -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1448,10 +1448,10 @@ for more information
 {{- end }}
 
 {{- define "caCertsSecretConfigCheck" }}
-  {{- if .Values.kubecostModel.updateCaTrust.enabled }}
-    {{- if and .Values.kubecostModel.updateCaTrust.caCertsSecret .Values.kubecostModel.updateCaTrust.caCertsConfig }}
+  {{- if .Values.global.updateCaTrust.enabled }}
+    {{- if and .Values.global.updateCaTrust.caCertsSecret .Values.global.updateCaTrust.caCertsConfig }}
       {{- fail "Both caCertsSecret and caCertsConfig are defined. Please specify only one." }}
-    {{- else if and (not .Values.kubecostModel.updateCaTrust.caCertsSecret) (not .Values.kubecostModel.updateCaTrust.caCertsConfig) }}
+    {{- else if and (not .Values.global.updateCaTrust.caCertsSecret) (not .Values.global.updateCaTrust.caCertsConfig) }}
       {{- fail "Neither caCertsSecret nor caCertsConfig is defined, but updateCaTrust is enabled. Please specify one." }}
     {{- end }}
   {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -126,11 +126,12 @@ spec:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
-        {{- if .Values.kubecostModel.caCertsSecret }}
-        - name: ca-certs-secret
-          secret:
-           defaultMode: 420
-           secretName: {{ .Values.kubecostModel.caCertsSecret}}
+        {{- if .Values.kubecostModel.caCertsConfig }}
+        - name: ca-certs-config
+          configMap:
+            name: {{ .Values.kubecostModel.caCertsConfig}}
+        - name: ssl-path
+          emptyDir: {}
         {{- end }}
         {{- if .Values.kubecostProductConfigs }}
         {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname }}
@@ -351,6 +352,28 @@ spec:
           securityContext:
             runAsUser: 0
 {{ end }}
+        {{- if .Values.kubecostModel.caCertsConfig }}
+        - name: "sslsetup"
+          image: redhat/ubi9-minimal:latest
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+          command:
+            - 'sh'
+            - '-c'
+            - >
+              mkdir -p /etc/pki/ca-trust/extracted/{edk2,java,openssl,pem};
+              /usr/bin/update-ca-trust extract;
+          volumeMounts:
+            - name: ca-certs-config
+              mountPath: "/etc/pki/ca-trust/source/anchors"
+            - name: ssl-path
+              mountPath: "/etc/pki/ca-trust/extracted"
+              readOnly: false
+              {{- end}}
       containers:
         {{- if .Values.global.gmp.enabled }}
         - name: {{ .Values.global.gmp.gmpProxy.name }}
@@ -621,9 +644,12 @@ spec:
               mountPath: /var/configs/etl/federated
               readOnly: true
             {{- end }}
-            {{- if .Values.kubecostModel.caCertsSecret }}
-            - name: ca-certs-secret
-              mountPath: /etc/pki/ca-trust/source/anchors
+            {{- if .Values.kubecostModel.caCertsConfig }}
+            - name: ca-certs-config
+              mountPath: "/etc/pki/ca-trust/source/anchors"
+            - name: ssl-path
+              mountPath: "/etc/pki/ca-trust/extracted"
+              readOnly: false
             {{- end }}
             {{- if .Values.kubecostAdmissionController }}
             {{- if .Values.kubecostAdmissionController.enabled }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -126,15 +126,15 @@ spec:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
-        {{- if .Values.kubecostModel.updateCaTrust.enabled }}
+        {{- if .Values.global.updateCaTrust.enabled }}
         - name: ca-certs-secret
-          {{- if .Values.kubecostModel.updateCaTrust.caCertsSecret }}
+          {{- if .Values.global.updateCaTrust.caCertsSecret }}
           secret:
             defaultMode: 420
-            secretName: {{ .Values.kubecostModel.updateCaTrust.caCertsSecret }}
+            secretName: {{ .Values.global.updateCaTrust.caCertsSecret }}
           {{- else }}
           configMap:
-            name: {{ .Values.kubecostModel.updateCaTrust.caCertsConfig }}
+            name: {{ .Values.global.updateCaTrust.caCertsConfig }}
           {{- end }}
         - name: ssl-path
           emptyDir: {}
@@ -358,7 +358,7 @@ spec:
           securityContext:
             runAsUser: 0
 {{ end }}
-        {{- if .Values.kubecostModel.updateCaTrust.enabled }}
+        {{- if .Values.global.updateCaTrust.enabled }}
         - name: update-ca-trust
           image: {{ include "cost-model.image" . | trim | quote}}
           {{- if .Values.kubecostModel.imagePullPolicy }}
@@ -366,10 +366,10 @@ spec:
           {{- else }}
           imagePullPolicy: Always
           {{- end }}
-          {{- with .Values.kubecostModel.updateCaTrust.securityContext }}
+          {{- with .Values.global.updateCaTrust.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.kubecostModel.updateCaTrust.resources }}
+          {{- with .Values.global.updateCaTrust.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -381,7 +381,7 @@ spec:
               /usr/bin/update-ca-trust extract;
           volumeMounts:
             - name: ca-certs-secret
-              mountPath: {{ .Values.kubecostModel.updateCaTrust.caCertsMountPath | quote }}
+              mountPath: {{ .Values.global.updateCaTrust.caCertsMountPath | quote }}
             - name: ssl-path
               mountPath: "/etc/pki/ca-trust/extracted"
               readOnly: false
@@ -656,9 +656,9 @@ spec:
               mountPath: /var/configs/etl/federated
               readOnly: true
             {{- end }}
-            {{- if .Values.kubecostModel.updateCaTrust.enabled }}
+            {{- if .Values.global.updateCaTrust.enabled }}
             - name: ca-certs-secret
-              mountPath: {{ .Values.kubecostModel.updateCaTrust.caCertsMountPath | quote }}
+              mountPath: {{ .Values.global.updateCaTrust.caCertsMountPath | quote }}
             - name: ssl-path
               mountPath: "/etc/pki/ca-trust/extracted"
               readOnly: false

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -126,11 +126,11 @@ spec:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
-        {{- if .Values.kubecostModel.caCertsSecret }}
+        {{- if .Values.kubecostModel.updateCaTrust.enabled }}
         - name: ca-certs-secret
           secret:
-           defaultMode: 420
-           secretName: {{ .Values.kubecostModel.caCertsSecret}}
+            defaultMode: 420
+            secretName: {{ .Values.kubecostModel.updateCaTrust.caCertsSecret }}
         - name: ssl-path
           emptyDir: {}
         {{- end }}
@@ -353,15 +353,17 @@ spec:
           securityContext:
             runAsUser: 0
 {{ end }}
-        {{- if .Values.kubecostModel.caCertsSecret }}
-        - name: "sslsetup"
+        {{- if .Values.kubecostModel.updateCaTrust.enabled }}
+        - name: "update-ca-trust"
           image: {{ include "cost-model.image" . | trim | quote}}
           imagePullPolicy: Always
-          securityContext:
-            privileged: true
-            runAsUser: 0
-            runAsGroup: 0
-            runAsNonRoot: false
+          {{- with .Values.kubecostModel.updateCaTrust.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.kubecostModel.updateCaTrust.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - 'sh'
             - '-c'
@@ -370,11 +372,11 @@ spec:
               /usr/bin/update-ca-trust extract;
           volumeMounts:
             - name: ca-certs-secret
-              mountPath: "/etc/pki/ca-trust/source/anchors"
+              mountPath: {{ .Values.kubecostModel.updateCaTrust.caCertsMountPath | quote }}
             - name: ssl-path
               mountPath: "/etc/pki/ca-trust/extracted"
               readOnly: false
-              {{- end}}
+        {{- end}}
       containers:
         {{- if .Values.global.gmp.enabled }}
         - name: {{ .Values.global.gmp.gmpProxy.name }}
@@ -645,9 +647,9 @@ spec:
               mountPath: /var/configs/etl/federated
               readOnly: true
             {{- end }}
-            {{- if .Values.kubecostModel.caCertsSecret }}
+            {{- if .Values.kubecostModel.updateCaTrust.enabled }}
             - name: ca-certs-secret
-              mountPath: "/etc/pki/ca-trust/source/anchors"
+              mountPath: {{ .Values.kubecostModel.updateCaTrust.caCertsMountPath | quote }}
             - name: ssl-path
               mountPath: "/etc/pki/ca-trust/extracted"
               readOnly: false

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -128,9 +128,14 @@ spec:
         {{- end }}
         {{- if .Values.kubecostModel.updateCaTrust.enabled }}
         - name: ca-certs-secret
+          {{- if .Values.kubecostModel.updateCaTrust.caCertsSecret }}
           secret:
             defaultMode: 420
             secretName: {{ .Values.kubecostModel.updateCaTrust.caCertsSecret }}
+          {{- else }}
+          configMap:
+            name: {{ .Values.kubecostModel.updateCaTrust.caCertsConfig }}
+          {{- end }}
         - name: ssl-path
           emptyDir: {}
         {{- end }}
@@ -356,7 +361,11 @@ spec:
         {{- if .Values.kubecostModel.updateCaTrust.enabled }}
         - name: update-ca-trust
           image: {{ include "cost-model.image" . | trim | quote}}
-          imagePullPolicy: IfNotPresent
+          {{- if .Values.kubecostModel.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}
+          {{- else }}
+          imagePullPolicy: Always
+          {{- end }}
           {{- with .Values.kubecostModel.updateCaTrust.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -126,10 +126,11 @@ spec:
            defaultMode: 420
            secretName: {{ .Values.kubecostModel.federatedStorageConfigSecret | default "federated-store" }}
         {{- end }}
-        {{- if .Values.kubecostModel.caCertsConfig }}
-        - name: ca-certs-config
-          configMap:
-            name: {{ .Values.kubecostModel.caCertsConfig}}
+        {{- if .Values.kubecostModel.caCertsSecret }}
+        - name: ca-certs-secret
+          secret:
+           defaultMode: 420
+           secretName: {{ .Values.kubecostModel.caCertsSecret}}
         - name: ssl-path
           emptyDir: {}
         {{- end }}
@@ -352,9 +353,9 @@ spec:
           securityContext:
             runAsUser: 0
 {{ end }}
-        {{- if .Values.kubecostModel.caCertsConfig }}
+        {{- if .Values.kubecostModel.caCertsSecret }}
         - name: "sslsetup"
-          image: redhat/ubi9-minimal:latest
+          image: {{ include "cost-model.image" . | trim | quote}}
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -368,7 +369,7 @@ spec:
               mkdir -p /etc/pki/ca-trust/extracted/{edk2,java,openssl,pem};
               /usr/bin/update-ca-trust extract;
           volumeMounts:
-            - name: ca-certs-config
+            - name: ca-certs-secret
               mountPath: "/etc/pki/ca-trust/source/anchors"
             - name: ssl-path
               mountPath: "/etc/pki/ca-trust/extracted"
@@ -644,8 +645,8 @@ spec:
               mountPath: /var/configs/etl/federated
               readOnly: true
             {{- end }}
-            {{- if .Values.kubecostModel.caCertsConfig }}
-            - name: ca-certs-config
+            {{- if .Values.kubecostModel.caCertsSecret }}
+            - name: ca-certs-secret
               mountPath: "/etc/pki/ca-trust/source/anchors"
             - name: ssl-path
               mountPath: "/etc/pki/ca-trust/extracted"

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -354,7 +354,7 @@ spec:
             runAsUser: 0
 {{ end }}
         {{- if .Values.kubecostModel.updateCaTrust.enabled }}
-        - name: "update-ca-trust"
+        - name: update-ca-trust
           image: {{ include "cost-model.image" . | trim | quote}}
           imagePullPolicy: IfNotPresent
           {{- with .Values.kubecostModel.updateCaTrust.securityContext }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -356,7 +356,7 @@ spec:
         {{- if .Values.kubecostModel.updateCaTrust.enabled }}
         - name: "update-ca-trust"
           image: {{ include "cost-model.image" . | trim | quote}}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           {{- with .Values.kubecostModel.updateCaTrust.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -581,10 +581,13 @@ kubecostModel:
     enabled: false  # Set to true to enable the init container for updating CA trust
     # Security context settings for the init container.
     securityContext:
-      privileged: true
       runAsUser: 0
       runAsGroup: 0
       runAsNonRoot: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
     caCertsSecret: ca-certs-secret  # The name of the Secret containing custom CA certificates to mount to the cost-model container.
     resources: {}  # Resource requests and limits for the init container.
     caCertsMountPath: /etc/pki/ca-trust/source/anchors  # The path where the custom CA certificates will be mounted in the init container

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -575,8 +575,8 @@ kubecostModel:
   #         "client_x509_cert_url": ""
   #       }
 
-  # the name of the ConfigMap containing custom CA certs to mount to cost model container
-  # caCertsConfig: ca-certs-config
+  # the name of the Secret containing custom CA certs to mount to cost model container
+  # caCertsSecret: ca-certs-secret
 
   # Installs Kubecost/OpenCost plugins
   plugins:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -575,7 +575,7 @@ kubecostModel:
   #         "client_x509_cert_url": ""
   #       }
 
-  # Install the cost-model with a custom CA certificate. 
+  # Install the cost-model with a custom CA certs. 
   # The following configuration is for an init container to update the CA trust.  
   updateCaTrust:
     enabled: false # Set to true to enable the init container for updating CA trust
@@ -586,7 +586,7 @@ kubecostModel:
       runAsGroup: 0
       runAsNonRoot: false
     caCertsSecret: ca-certs-secret  # The name of the Secret containing custom CA certificates to mount to the cost-model container.
-    resources: {}
+    resources: {} # Resource requests and limits for the init container.
     caCertsMountPath: /etc/pki/ca-trust/source/anchors # The path where the custom CA certificates will be mounted in the init container
 
   # Installs Kubecost/OpenCost plugins

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -575,8 +575,8 @@ kubecostModel:
   #         "client_x509_cert_url": ""
   #       }
 
-  # the name of the Secret containing custom CA certs to mount to cost model container
-  # caCertsSecret: ca-certs-secret
+  # the name of the ConfigMap containing custom CA certs to mount to cost model container
+  # caCertsConfig: ca-certs-config
 
   # Installs Kubecost/OpenCost plugins
   plugins:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -575,10 +575,10 @@ kubecostModel:
   #         "client_x509_cert_url": ""
   #       }
 
-  # Install the cost-model with a custom CA certs. 
-  # The following configuration is for an init container to update the CA trust.  
+  # Install the cost-model with a custom CA certs.
+  # The following configuration is for an init container to update the CA trust.
   updateCaTrust:
-    enabled: false # Set to true to enable the init container for updating CA trust
+    enabled: false  # Set to true to enable the init container for updating CA trust
     # Security context settings for the init container.
     securityContext:
       privileged: true
@@ -586,8 +586,8 @@ kubecostModel:
       runAsGroup: 0
       runAsNonRoot: false
     caCertsSecret: ca-certs-secret  # The name of the Secret containing custom CA certificates to mount to the cost-model container.
-    resources: {} # Resource requests and limits for the init container.
-    caCertsMountPath: /etc/pki/ca-trust/source/anchors # The path where the custom CA certificates will be mounted in the init container
+    resources: {}  # Resource requests and limits for the init container.
+    caCertsMountPath: /etc/pki/ca-trust/source/anchors  # The path where the custom CA certificates will be mounted in the init container
 
   # Installs Kubecost/OpenCost plugins
   plugins:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -589,6 +589,7 @@ kubecostModel:
       seccompProfile:
         type: RuntimeDefault
     caCertsSecret: ca-certs-secret  # The name of the Secret containing custom CA certificates to mount to the cost-model container.
+    # caCertsConfig: ca-certs-config  # The name of the ConfigMap containing the CA trust configuration.
     resources: {}  # Resource requests and limits for the init container.
     caCertsMountPath: /etc/pki/ca-trust/source/anchors  # The path where the custom CA certificates will be mounted in the init container
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -226,6 +226,24 @@ global:
       drop:
       - ALL
 
+  # Install the cost-model with a custom CA certs.
+  # The following configuration is for an init container to update the CA trust.
+  updateCaTrust:
+    enabled: false  # Set to true to enable the init container for updating CA trust
+    # Security context settings for the init container.
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      runAsNonRoot: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+    caCertsSecret: ca-certs-secret  # The name of the Secret containing custom CA certificates to mount to the cost-model container.
+    # caCertsConfig: ca-certs-config  # The name of the ConfigMap containing the CA trust configuration.
+    resources: {}  # Resource requests and limits for the init container.
+    caCertsMountPath: /etc/pki/ca-trust/source/anchors  # The path where the custom CA certificates will be mounted in the init container
+
   # Platforms is a higher-level abstraction for platform-specific values and settings.
   platforms:
     # Deploying to OpenShift (OCP) requires enabling this option.
@@ -574,24 +592,6 @@ kubecostModel:
   #         "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
   #         "client_x509_cert_url": ""
   #       }
-
-  # Install the cost-model with a custom CA certs.
-  # The following configuration is for an init container to update the CA trust.
-  updateCaTrust:
-    enabled: false  # Set to true to enable the init container for updating CA trust
-    # Security context settings for the init container.
-    securityContext:
-      runAsUser: 0
-      runAsGroup: 0
-      runAsNonRoot: false
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-      seccompProfile:
-        type: RuntimeDefault
-    caCertsSecret: ca-certs-secret  # The name of the Secret containing custom CA certificates to mount to the cost-model container.
-    # caCertsConfig: ca-certs-config  # The name of the ConfigMap containing the CA trust configuration.
-    resources: {}  # Resource requests and limits for the init container.
-    caCertsMountPath: /etc/pki/ca-trust/source/anchors  # The path where the custom CA certificates will be mounted in the init container
 
   # Installs Kubecost/OpenCost plugins
   plugins:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -575,8 +575,19 @@ kubecostModel:
   #         "client_x509_cert_url": ""
   #       }
 
-  # the name of the Secret containing custom CA certs to mount to cost model container
-  # caCertsSecret: ca-certs-secret
+  # Install the cost-model with a custom CA certificate. 
+  # The following configuration is for an init container to update the CA trust.  
+  updateCaTrust:
+    enabled: false # Set to true to enable the init container for updating CA trust
+    # Security context settings for the init container.
+    securityContext:
+      privileged: true
+      runAsUser: 0
+      runAsGroup: 0
+      runAsNonRoot: false
+    caCertsSecret: ca-certs-secret  # The name of the Secret containing custom CA certificates to mount to the cost-model container.
+    resources: {}
+    caCertsMountPath: /etc/pki/ca-trust/source/anchors # The path where the custom CA certificates will be mounted in the init container
 
   # Installs Kubecost/OpenCost plugins
   plugins:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -226,8 +226,7 @@ global:
       drop:
       - ALL
 
-  # Install the cost-model with a custom CA certs.
-  # The following configuration is for an init container to update the CA trust.
+  # Installs custom CA certificates onto Kubecost pods
   updateCaTrust:
     enabled: false  # Set to true to enable the init container for updating CA trust
     # Security context settings for the init container.


### PR DESCRIPTION
## What does this PR change?
* Create a init container to update ca trust which we earlier expected the user to do inside the container itself.
Taken reference from https://jfrog.com/help/r/artifactory-how-to-add-custom-ssl-certificates-to-an-artifactory-pod-using-helm-charts/artifactory-how-to-add-custom-ssl-certificates-to-an-artifactory-pod-using-helm-charts

## Does this PR rely on any other PRs?
https://github.com/kubecost/cost-analyzer-helm-chart/pull/3760

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will now not need to run update-ca-trust command inside the container. The init container will do it.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
Deployed the kubecost deployment with `caCertsSecret` helm value set and ca cert as Secret created.
reading through `/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt` we see it updated with the given ca cert in Secret.

helm values:

```yaml
global:
  updateCaTrust:
    enabled: false  # Set to true to enable the init container for updating CA trust
    # Security context settings for the init container.
    securityContext:
      runAsUser: 0
      runAsGroup: 0
      runAsNonRoot: false
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: true
      seccompProfile:
        type: RuntimeDefault
    caCertsSecret: ca-certs-secret  # The name of the Secret containing custom CA certificates to mount to the cost-model container.
    # caCertsConfig: ca-certs-config  # The name of the ConfigMap containing the CA trust configuration.
    resources: {}  # Resource requests and limits for the init container.
    caCertsMountPath: /etc/pki/ca-trust/source/anchors  # The path where the custom CA certificates will be mounted in the init container

```


## Have you made an update to documentation? If so, please provide the corresponding PR.

