### PR TITLE
bump to kiwigrid 1.28.1

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2064,7 +2064,7 @@ grafana:
   sidecar:
     image:
       repository: ghcr.io/kiwigrid/k8s-sidecar
-      tag: 1.28.0
+      tag: 1.28.1
       pullPolicy: IfNotPresent
     resources: {}
     dashboards:

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -23657,7 +23657,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: grafana-sc-dashboard
-          image: "ghcr.io/kiwigrid/k8s-sidecar:1.28.0"
+          image: "ghcr.io/kiwigrid/k8s-sidecar:1.28.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## What does this PR change?
update ghcr.io/kiwigrid/k8s-sidecar from 1.28.0 to 1.28.1

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
update ghcr.io/kiwigrid/k8s-sidecar from 1.28.0 to 1.28.1



## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
upgraded test deployment and verified logs:
```
>kl deployments/kubecost243-grafana grafana-sc-dashboard 
{"time": "2024-12-05T16:22:50.327559+00:00", "taskName": null, "msg": "Starting collector", "level": "INFO"}
{"time": "2024-12-05T16:22:50.327840+00:00", "taskName": null, "msg": "No folder annotation was provided, defaulting to k8s-sidecar-target-directory", "level": "WARNING"}
{"time": "2024-12-05T16:22:50.328080+00:00", "taskName": null, "msg": "Loading incluster config ...", "level": "INFO"}
{"time": "2024-12-05T16:22:50.328834+00:00", "taskName": null, "msg": "Config for cluster api at 'https://10.0.0.1:443' loaded...", "level": "INFO"}
{"time": "2024-12-05T16:22:50.328991+00:00", "taskName": null, "msg": "Unique filenames will not be enforced.", "level": "INFO"}
{"time": "2024-12-05T16:22:50.329121+00:00", "taskName": null, "msg": "5xx response content will not be enabled.", "level": "INFO"}
{"time": "2024-12-05T16:22:50.469570+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/attached-disks.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.472723+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/cluster-metrics.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.479205+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/cluster-utilization.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.482017+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/deployment-utilization.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.483702+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/kubernetes-resource-efficiency.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.485934+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/label-cost-utilization.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.487983+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/namespace-utilization.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.490102+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/grafana-network-cloud-services.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.492062+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/networkCosts-metrics.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.494271+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/node-utilization.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.496207+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/pod-utilization.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.498112+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/pod-utilization-multi-cluster.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.503057+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/prom-benchmark.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.505228+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/workload-metrics-aggregator.json (ascii)", "level": "INFO"}
{"time": "2024-12-05T16:22:50.507191+00:00", "taskName": null, "msg": "Writing /tmp/dashboards/grafana-workload-metrics.json (ascii)", "level": "INFO"}
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

NA