### PR TITLE
Remove-old-api-port

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -216,17 +216,7 @@ data:
         listen [::]:{{ .Values.service.targetPort }};
 {{- end }}
 {{- end }}
-        location /api/ {
-            {{- if or .Values.saml.enabled .Values.oidc.enabled }}
-            auth_request /auth;
-            {{- end }}
-            proxy_pass http://api/;
-            proxy_redirect off;
-            proxy_http_version 1.1;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
+        
         location /model/ {
             proxy_connect_timeout       {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_send_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -51,16 +51,6 @@ data:
         text/x-component
         text/x-cross-domain-policy;
 
-    upstream api {
-{{- if .Values.kubecostFrontend.useDefaultFqdn }}
-        server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9001;
-{{- else if (.Values.kubecostFrontend.api).fqdn }}
-        server {{ .Values.kubecostFrontend.api.fqdn }};
-{{- else }}
-        server {{ $serviceName }}.{{ .Release.Namespace }}:9001;
-{{- end }}
-    }
-
     upstream model {
 {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9003;

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -485,8 +485,6 @@ kubecostFrontend:
 
   # set to true to set all upstreams to use <service>.<namespace>.svc.cluster.local instead of just <service>.<namespace>
   useDefaultFqdn: false
-#  api:
-#    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
 #  model:
 #    fqdn: kubecost-model.kubecost.svc.cluster.local:9003
 #  forecasting:


### PR DESCRIPTION
## What does this PR change?
Removes reference to old /api nginx config pointing to port 9001 that was removed in 2.0

## Does this PR rely on any other PRs?
NO

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Removes reference to old /api nginx config pointing to port 9001 that was removed in 2.0


## Links to Issues or tickets this PR addresses or fixes

https://github.com/kubecost/cost-analyzer-helm-chart/issues/3727



## What risks are associated with merging this PR? What is required to fully test this PR?
No risk from what I can find. Also confirmed with Bianca

## How was this PR tested?
QA test on both sts and single pod aggregator. 

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
