### PR TITLE
Update ca cert in cloud cost and aggregator container too

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1011,6 +1011,13 @@ Begin Kubecost 2.0 templates
     - name: postgres-queries
       mountPath: /var/configs/integrations/postgres-queries
     {{- end }}
+    {{- if .Values.global.updateCaTrust.enabled }}
+    - name: ca-certs-secret
+      mountPath: {{ .Values.global.updateCaTrust.caCertsMountPath | quote }}
+    - name: ssl-path
+      mountPath: "/etc/pki/ca-trust/extracted"
+      readOnly: false
+    {{- end }}
     {{- /* Only adds extraVolumeMounts if aggregator is running as its own pod */}}
     {{- if and .Values.kubecostAggregator.extraVolumeMounts (eq (include "aggregator.deployMethod" .) "statefulset") }}
     {{- toYaml .Values.kubecostAggregator.extraVolumeMounts | nindent 4 }}
@@ -1287,6 +1294,13 @@ Begin Kubecost 2.0 templates
     - mountPath: {{ $.Values.kubecostModel.plugins.folder }}/config
       name: plugins-config
       readOnly: true
+    {{- end }}
+    {{- if .Values.global.updateCaTrust.enabled }}
+    - name: ca-certs-secret
+      mountPath: {{ .Values.global.updateCaTrust.caCertsMountPath | quote }}
+    - name: ssl-path
+      mountPath: "/etc/pki/ca-trust/extracted"
+      readOnly: false
     {{- end }}
   {{- /* Only adds extraVolumeMounts when cloudcosts is running as its own pod */}}
   {{- if and .Values.kubecostAggregator.cloudCost.extraVolumeMounts (eq (include "aggregator.deployMethod" .) "statefulset") }}

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -124,6 +124,19 @@ spec:
         - name: tmp
           emptyDir: {}
         {{- end }}
+        {{- if .Values.global.updateCaTrust.enabled }}
+        - name: ca-certs-secret
+          {{- if .Values.global.updateCaTrust.caCertsSecret }}
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.global.updateCaTrust.caCertsSecret }}
+          {{- else }}
+          configMap:
+            name: {{ .Values.global.updateCaTrust.caCertsConfig }}
+          {{- end }}
+        - name: ssl-path
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.kubecostAggregator.cloudCost.extraVolumes }}
         {{- toYaml .Values.kubecostAggregator.cloudCost.extraVolumes | nindent 8 }}
         {{- end }}
@@ -141,6 +154,34 @@ spec:
           - name: plugins-dir
             mountPath: {{ .Values.kubecostModel.plugins.folder }}
       {{- end }}
+      {{- if .Values.global.updateCaTrust.enabled }}
+      - name: update-ca-trust
+        image: {{ include "cost-model.image" . | trim | quote}}
+        {{- if .Values.kubecostModel.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}
+        {{- else }}
+        imagePullPolicy: Always
+        {{- end }}
+        {{- with .Values.global.updateCaTrust.securityContext }}
+        securityContext: {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.global.updateCaTrust.resources }}
+        resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            mkdir -p /etc/pki/ca-trust/extracted/{edk2,java,openssl,pem};
+            /usr/bin/update-ca-trust extract;
+        volumeMounts:
+          - name: ca-certs-secret
+            mountPath: {{ .Values.global.updateCaTrust.caCertsMountPath | quote }}
+          - name: ssl-path
+            mountPath: "/etc/pki/ca-trust/extracted"
+            readOnly: false
+      {{- end}}
       containers:
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
     {{- if .Values.imagePullSecrets }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -181,9 +181,51 @@ spec:
           secret:
             secretName: kubecost-integrations-turbonomic
         {{- end }}
+        {{- if .Values.global.updateCaTrust.enabled }}
+        - name: ca-certs-secret
+          {{- if .Values.global.updateCaTrust.caCertsSecret }}
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.global.updateCaTrust.caCertsSecret }}
+          {{- else }}
+          configMap:
+            name: {{ .Values.global.updateCaTrust.caCertsConfig }}
+          {{- end }}
+        - name: ssl-path
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.kubecostAggregator.extraVolumes }}
         {{- toYaml .Values.kubecostAggregator.extraVolumes | nindent 8 }}
         {{- end }}
+      initContainers:
+      {{- if .Values.global.updateCaTrust.enabled }}
+        - name: update-ca-trust
+          image: {{ include "cost-model.image" . | trim | quote}}
+          {{- if .Values.kubecostModel.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}
+          {{- else }}
+          imagePullPolicy: Always
+          {{- end }}
+          {{- with .Values.global.updateCaTrust.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.global.updateCaTrust.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - 'sh'
+            - '-c'
+            - >
+              mkdir -p /etc/pki/ca-trust/extracted/{edk2,java,openssl,pem};
+              /usr/bin/update-ca-trust extract;
+          volumeMounts:
+            - name: ca-certs-secret
+              mountPath: {{ .Values.global.updateCaTrust.caCertsMountPath | quote }}
+            - name: ssl-path
+              mountPath: "/etc/pki/ca-trust/extracted"
+              readOnly: false
+        {{- end}}
       containers:
         {{- include "aggregator.containerTemplate" . | nindent 8 }}
 


### PR DESCRIPTION
## What does this PR change?
Update ca cert in cloud cost and aggregator container too

## Does this PR rely on any other PRs?
https://github.com/kubecost/cost-analyzer-helm-chart/pull/3763

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will now be able update or add custom ca certs in aggregator and cloud cost containers too as they were able to do it for cost-model container.

## Links to Issues or tickets this PR addresses or fixes
https://github.com/kubecost/cost-analyzer-helm-chart/pull/3763#issuecomment-2532286874
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
1. For single Pod deploy method checked in Aggregator, Cloud cost and cost model container if the custom ca cert was added
2. For statefulSet deploy method checked in all three pods containers if the custom ca cert was added
## Have you made an update to documentation? If so, please provide the corresponding PR.
v2.6
