### PR TITLE
teams rewrite secret/env functionality

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1018,6 +1018,10 @@ Begin Kubecost 2.0 templates
     - name: kubecost-rbac-secret
       mountPath: /var/configs/kubecost-rbac-secret
     {{- end }}
+    {{- if eq (include "rbacTeamsConfig" .) "true" }}
+    - name: kubecost-rbac-teams-config
+      mountPath: /var/configs/rbac-teams-configs
+    {{- end }}
     {{- if .Values.global.integrations.postgres.enabled }}
     - name: postgres-creds
       mountPath: /var/configs/integrations/postgres-creds
@@ -1178,6 +1182,10 @@ Begin Kubecost 2.0 templates
       value: "true"
     {{- end }}
     {{- end}}
+    {{- if eq (include "rbacTeamsConfig" .) "true" }}
+    - name: RBAC_TEAMS_HELM_CONFIG_PATH
+      value: "/var/configs/rbac-teams-configs/rbac-teams-configs.json"
+    {{- end }}
     {{- if .Values.kubecostAggregator }}
     {{- if .Values.kubecostAggregator.collections }}
     {{- if (((.Values.kubecostAggregator).collections).cache) }}
@@ -1396,6 +1404,14 @@ Groups is only used when using external RBAC.
     {{- printf "false" -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "rbacTeamsConfig" -}}
+  {{- if (.Values.rbac).teamsConfig -}}
+    {{- printf "true" -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end }}
+{{- end }}
 
 {{/*
 Backups configured flag for nginx configmap

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -158,10 +158,10 @@ will result in failure. Users are asked to select one of the two presently-avail
 {{- end -}}
 
 {{/*
-RBAC exclusivity check: make sure either RBAC or RBAC Teams is enabled, not both
+RBAC exclusivity check: make sure either simple RBAC or RBAC Teams is configured, not both
 */}}
 {{- define "rbacCheck" -}}
-  {{- if and (or ((.Values.saml).rbac).enabled ((.Values.oidc).rbac).enabled) (.Values.rbacTeams).enabled  -}}
+  {{- if and (or (.Values.saml).groups (.Values.oidc).groups) (.Values.teams).teamsConfig  -}}
     {{- fail "\nSimple RBAC and RBAC Teams are mutually exclusive. Please specify only one." -}}
   {{- end -}}
 {{- end -}}
@@ -1233,8 +1233,10 @@ Begin Kubecost 2.0 templates
       value: {{ .Values.saml.redirectURL }}
     {{- end}}
     {{- if .Values.saml.rbac.enabled }}
+    {{- if eq (include "rbacTeamsEnabled" .) "false" }}
     - name: SAML_RBAC_ENABLED
       value: "true"
+    {{- end }}
     {{- end }}
     {{- if and .Values.saml.encryptionCertSecret .Values.saml.decryptionKeySecret }}
     - name: SAML_RESPONSE_ENCRYPTED
@@ -1388,10 +1390,10 @@ SSO enabled flag for nginx configmap
 {{- end -}}
 
 {{/*
-To use the Kubecost built-in Teams UI RBAC< you must enable SSO and RBAC and not specify any groups.
-Groups is only used when using external RBAC.
+To use the Kubecost built-in RBAC Teams UI, you must enable SSO and RBAC and not specify any groups.
+Groups is only used when using simple RBAC.
 */}}
-{{- define "rbacTeamsLegacyEnabled" -}}
+{{- define "rbacTeamsEnabled" -}}
   {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
     {{- if or ((.Values.saml).rbac).enabled ((.Values.oidc).rbac).enabled -}}
       {{- if not (or (.Values.saml).groups (.Values.oidc).groups) -}}
@@ -1407,29 +1409,9 @@ Groups is only used when using external RBAC.
   {{- end -}}
 {{- end -}}
 
-{{/*
-RBAC teams enabled requires that it be explicitly enabled in addition to SAML or OIDC being enabled
-and legacy RBAC being disabled.
-*/}}
-{{- define "rbacTeamsEnabled" -}}
-    {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
-        {{- if and (not ((.Values.saml).rbac).enabled) (not ((.Values.oidc).rbac).enabled) -}}
-            {{- if (.Values.rbacTeams).enabled -}}
-                {{- printf "true" -}}
-            {{- else -}}
-                {{- printf "false" -}}
-            {{- end -}}
-        {{- else -}}
-            {{- printf "false" -}}
-        {{- end -}}
-    {{- else -}}
-        {{- printf "false" -}}
-    {{- end -}}
-{{- end }}
-
 {{- define "rbacTeamsConfigEnabled" -}}
     {{- if  eq (include "rbacTeamsEnabled" .) "true" -}}
-        {{- if (.Values.rbacTeams).teamsConfig -}}
+        {{- if or (.Values.teams).teamsConfig  (.Values.teams).teamsConfigMapName -}}
             {{- printf "true" -}}
         {{- else -}}
             {{- printf "false" -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -158,6 +158,15 @@ will result in failure. Users are asked to select one of the two presently-avail
 {{- end -}}
 
 {{/*
+RBAC exclusivity check: make sure either RBAC or RBAC Teams is enabled, not both
+*/}}
+{{- define "rbacCheck" -}}
+  {{- if or (and ((.Values.saml).rbac).teamsEnabled ((.Values.saml).rbac).enabled) (and ((.Values.oidc).rbac).teamsEnabled ((.Values.oidc).rbac).enabled) -}}
+    {{- fail "\nSimple RBAC and RBAC Teams are mutually exclusive. Please specify only one." -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Federated Storage source contents check. Either the Secret must be specified or the JSON, not both.
 */}}
 {{- define "federatedStorageSourceCheck" -}}
@@ -1005,6 +1014,10 @@ Begin Kubecost 2.0 templates
     {{- end }}
     {{- end }}
     {{- end }}
+    {{- if or .Values.oidc.rbac.teamsEnabled .Values.saml.rbac.teamsEnabled }}
+    - name: kubecost-rbac-secret
+      mountPath: /var/configs/kubecost-rbac-secret
+    {{- end }}
     {{- if .Values.global.integrations.postgres.enabled }}
     - name: postgres-creds
       mountPath: /var/configs/integrations/postgres-creds
@@ -1160,6 +1173,10 @@ Begin Kubecost 2.0 templates
       value: "true"
     - name: OIDC_SKIP_ONLINE_VALIDATION
       value: {{ (quote .Values.oidc.skipOnlineTokenValidation) | default (quote false) }}
+    {{- if .Values.oidc.rbac.teamsEnabled }}
+    - name: OIDC_RBAC_TEAMS_ENABLED
+      value: "true"
+    {{- end }}
     {{- end}}
     {{- if .Values.kubecostAggregator }}
     {{- if .Values.kubecostAggregator.collections }}
@@ -1203,6 +1220,10 @@ Begin Kubecost 2.0 templates
     {{- end}}
     {{- if .Values.saml.rbac.enabled }}
     - name: SAML_RBAC_ENABLED
+      value: "true"
+    {{- end }}
+    {{- if .Values.saml.rbac.teamsEnabled }}
+    - name: SAML_RBAC_TEAMS_ENABLED
       value: "true"
     {{- end }}
     {{- if and .Values.saml.encryptionCertSecret .Values.saml.decryptionKeySecret }}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -161,7 +161,7 @@ will result in failure. Users are asked to select one of the two presently-avail
 RBAC exclusivity check: make sure either RBAC or RBAC Teams is enabled, not both
 */}}
 {{- define "rbacCheck" -}}
-  {{- if or (and ((.Values.saml).rbac).teamsEnabled ((.Values.saml).rbac).enabled) (and ((.Values.oidc).rbac).teamsEnabled ((.Values.oidc).rbac).enabled) -}}
+  {{- if and (or ((.Values.saml).rbac).enabled ((.Values.oidc).rbac).enabled) (.Values.rbacTeams).enabled  -}}
     {{- fail "\nSimple RBAC and RBAC Teams are mutually exclusive. Please specify only one." -}}
   {{- end -}}
 {{- end -}}
@@ -1014,11 +1014,11 @@ Begin Kubecost 2.0 templates
     {{- end }}
     {{- end }}
     {{- end }}
-    {{- if or .Values.oidc.rbac.teamsEnabled .Values.saml.rbac.teamsEnabled }}
+    {{- if eq (include "rbacTeamsEnabled" .) "true" }}
     - name: kubecost-rbac-secret
       mountPath: /var/configs/kubecost-rbac-secret
     {{- end }}
-    {{- if eq (include "rbacTeamsConfig" .) "true" }}
+    {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
     - name: kubecost-rbac-teams-config
       mountPath: /var/configs/rbac-teams-configs
     {{- end }}
@@ -1177,12 +1177,18 @@ Begin Kubecost 2.0 templates
       value: "true"
     - name: OIDC_SKIP_ONLINE_VALIDATION
       value: {{ (quote .Values.oidc.skipOnlineTokenValidation) | default (quote false) }}
-    {{- if .Values.oidc.rbac.teamsEnabled }}
+    {{- end}}
+    {{- if eq (include "rbacTeamsEnabled" .) "true" }}
+    {{- if .Values.oidc.enabled }}
     - name: OIDC_RBAC_TEAMS_ENABLED
       value: "true"
     {{- end }}
-    {{- end}}
-    {{- if eq (include "rbacTeamsConfig" .) "true" }}
+    {{- if .Values.saml.enabled }}
+    - name: SAML_RBAC_TEAMS_ENABLED
+      value: "true"
+    {{- end }}
+    {{- end }}
+    {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
     - name: RBAC_TEAMS_HELM_CONFIG_PATH
       value: "/var/configs/rbac-teams-configs/rbac-teams-configs.json"
     {{- end }}
@@ -1228,10 +1234,6 @@ Begin Kubecost 2.0 templates
     {{- end}}
     {{- if .Values.saml.rbac.enabled }}
     - name: SAML_RBAC_ENABLED
-      value: "true"
-    {{- end }}
-    {{- if .Values.saml.rbac.teamsEnabled }}
-    - name: SAML_RBAC_TEAMS_ENABLED
       value: "true"
     {{- end }}
     {{- if and .Values.saml.encryptionCertSecret .Values.saml.decryptionKeySecret }}
@@ -1389,7 +1391,7 @@ SSO enabled flag for nginx configmap
 To use the Kubecost built-in Teams UI RBAC< you must enable SSO and RBAC and not specify any groups.
 Groups is only used when using external RBAC.
 */}}
-{{- define "rbacTeamsEnabled" -}}
+{{- define "rbacTeamsLegacyEnabled" -}}
   {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
     {{- if or ((.Values.saml).rbac).enabled ((.Values.oidc).rbac).enabled -}}
       {{- if not (or (.Values.saml).groups (.Values.oidc).groups) -}}
@@ -1405,12 +1407,36 @@ Groups is only used when using external RBAC.
   {{- end -}}
 {{- end -}}
 
-{{- define "rbacTeamsConfig" -}}
-  {{- if (.Values.rbac).teamsConfig -}}
-    {{- printf "true" -}}
-  {{- else -}}
-    {{- printf "false" -}}
-  {{- end }}
+{{/*
+RBAC teams enabled requires that it be explicitly enabled in addition to SAML or OIDC being enabled
+and legacy RBAC being disabled.
+*/}}
+{{- define "rbacTeamsEnabled" -}}
+    {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
+        {{- if and (not ((.Values.saml).rbac).enabled) (not ((.Values.oidc).rbac).enabled) -}}
+            {{- if (.Values.rbacTeams).enabled -}}
+                {{- printf "true" -}}
+            {{- else -}}
+                {{- printf "false" -}}
+            {{- end -}}
+        {{- else -}}
+            {{- printf "false" -}}
+        {{- end -}}
+    {{- else -}}
+        {{- printf "false" -}}
+    {{- end -}}
+{{- end }}
+
+{{- define "rbacTeamsConfigEnabled" -}}
+    {{- if  eq (include "rbacTeamsEnabled" .) "true" -}}
+        {{- if (.Values.rbacTeams).teamsConfig -}}
+            {{- printf "true" -}}
+        {{- else -}}
+            {{- printf "false" -}}
+        {{- end }}
+    {{- else -}}
+        {{- printf "false" -}}
+    {{- end }}
 {{- end }}
 
 {{/*

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -145,11 +145,6 @@ spec:
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-saml
         {{- end }}
-        {{- if .Values.saml.rbac.teamsEnabled }}
-        - name: kubecost-rbac-secret
-          secret:
-            secretName: kubecost-rbac-secret
-        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.oidc }}
@@ -167,14 +162,14 @@ spec:
           secret:
             secretName: {{ .Values.oidc.existingCustomSecret.name }}
         {{- end }}
-        {{- if .Values.oidc.rbac.teamsEnabled }}
+        {{- end }}
+        {{- end }}
+        {{- if eq (include "rbacTeamsEnabled" .) "true" }}
         - name: kubecost-rbac-secret
           secret:
             secretName: kubecost-rbac-secret
         {{- end }}
-        {{- end }}
-        {{- end }}
-        {{- if eq (include "rbacTeamsConfig" .) "true" }}
+        {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config
           configMap:
             name: kubecost-rbac-teams-config

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -145,6 +145,11 @@ spec:
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-saml
         {{- end }}
+        {{- if .Values.saml.rbac.teamsEnabled }}
+        - name: kubecost-rbac-secret
+          secret:
+            secretName: kubecost-rbac-secret
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.oidc }}
@@ -161,6 +166,11 @@ spec:
         - name: oidc-client-secret
           secret:
             secretName: {{ .Values.oidc.existingCustomSecret.name }}
+        {{- end }}
+        {{- if .Values.oidc.rbac.teamsEnabled }}
+        - name: kubecost-rbac-secret
+          secret:
+            secretName: kubecost-rbac-secret
         {{- end }}
         {{- end }}
         {{- end }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -172,7 +172,11 @@ spec:
         {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config
           configMap:
+        {{- if .Values.teams.teamsConfigMapName }}
+            name: {{ .Values.teams.teamsConfigMapName }}
+        {{- else }}
             name: kubecost-rbac-teams-config
+        {{- end }}
         {{- end }}
         {{- if .Values.global.integrations.postgres.enabled }}
         - name: postgres-creds

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -174,6 +174,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if eq (include "rbacTeamsConfig" .) "true" }}
+        - name: kubecost-rbac-teams-config
+          configMap:
+            name: kubecost-rbac-teams-config
+        {{- end }}
         {{- if .Values.global.integrations.postgres.enabled }}
         - name: postgres-creds
           secret:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -288,7 +288,11 @@ spec:
         {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config
           configMap:
+        {{- if .Values.teams.teamsConfigMapName }}
+            name: {{ .Values.teams.teamsConfigMapName }}
+        {{- else }}
             name: kubecost-rbac-teams-config
+        {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
@@ -1053,8 +1057,10 @@ spec:
               value: {{ .Values.saml.redirectURL }}
             {{- end}}
             {{- if .Values.saml.rbac.enabled }}
+            {{- if eq (include "rbacTeamsEnabled" .) "false" }}
             - name: SAML_RBAC_ENABLED
               value: "true"
+            {{- end }}
             {{- end }}
             {{- if and .Values.saml.encryptionCertSecret .Values.saml.decryptionKeySecret }}
             - name: SAML_RESPONSE_ENCRYPTED

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -290,6 +290,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if eq (include "rbacTeamsConfig" .) "true" }}
+        - name: kubecost-rbac-teams-config
+          configMap:
+            name: kubecost-rbac-teams-config
+        {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -261,6 +261,11 @@ spec:
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-saml
         {{- end }}
+        {{- if .Values.saml.rbac.teamsEnabled }}
+        - name: kubecost-rbac-secret
+          secret:
+            secretName: kubecost-rbac-secret
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.oidc }}
@@ -277,6 +282,11 @@ spec:
         - name: oidc-client-secret
           secret:
             secretName: {{ .Values.oidc.existingCustomSecret.name }}
+        {{- end }}
+        {{- if .Values.oidc.rbac.teamsEnabled }}
+        - name: kubecost-rbac-secret
+          secret:
+            secretName: kubecost-rbac-secret
         {{- end }}
         {{- end }}
         {{- end }}
@@ -737,6 +747,10 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- if or .Values.oidc.rbac.teamsEnabled .Values.saml.rbac.teamsEnabled }}
+            - name: kubecost-rbac-secret
+              mountPath: /var/configs/kubecost-rbac-secret
+            {{- end }}
           env:
             - name: CONTAINER_IMAGE_TAG
               value: {{ include "cost-model.imagetag" . }}
@@ -1000,7 +1014,7 @@ spec:
             {{- else}}
             - name: ADVANCED_NETWORK_STATS
               value: "false"
-            {{- end}}
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}
@@ -1009,7 +1023,11 @@ spec:
               value: "true"
             - name: OIDC_SKIP_ONLINE_VALIDATION
               value: {{ (quote .Values.oidc.skipOnlineTokenValidation) | default (quote false) }}
-            {{- end}}
+            {{- if .Values.oidc.rbac.teamsEnabled }}
+            - name: OIDC_RBAC_TEAMS_ENABLED
+              value: "true"
+            {{- end }}
+            {{- end }}
             {{- if .Values.saml }}
             {{- if .Values.saml.enabled }}
             - name: SAML_ENABLED
@@ -1046,6 +1064,10 @@ spec:
             - name: SAML_RESPONSE_ENCRYPTED
               value: "true"
             {{- end}}
+            {{- if .Values.saml.rbac.teamsEnabled }}
+            - name: SAML_RBAC_TEAMS_ENABLED
+              value: "true"
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.clusterIDConfigmap) }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -261,11 +261,6 @@ spec:
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-saml
         {{- end }}
-        {{- if .Values.saml.rbac.teamsEnabled }}
-        - name: kubecost-rbac-secret
-          secret:
-            secretName: kubecost-rbac-secret
-        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.oidc }}
@@ -283,14 +278,14 @@ spec:
           secret:
             secretName: {{ .Values.oidc.existingCustomSecret.name }}
         {{- end }}
-        {{- if .Values.oidc.rbac.teamsEnabled }}
+        {{- end }}
+        {{- end }}
+        {{- if eq (include "rbacTeamsEnabled" .) "true" }}
         - name: kubecost-rbac-secret
           secret:
             secretName: kubecost-rbac-secret
         {{- end }}
-        {{- end }}
-        {{- end }}
-        {{- if eq (include "rbacTeamsConfig" .) "true" }}
+        {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config
           configMap:
             name: kubecost-rbac-teams-config
@@ -752,7 +747,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            {{- if or .Values.oidc.rbac.teamsEnabled .Values.saml.rbac.teamsEnabled }}
+            {{- if eq (include "rbacTeamsEnabled" .) "true" }}
             - name: kubecost-rbac-secret
               mountPath: /var/configs/kubecost-rbac-secret
             {{- end }}
@@ -799,8 +794,8 @@ spec:
               value: {{ .Values.assetReportConfigmapName }}
             {{- end }}
             {{- if .Values.cloudCostReportConfigmapName }}
-              - name: CLOUD_COST_REPORT_CONFIGMAP_NAME
-                value: {{ .Values.cloudCostReportConfigmapName }}
+            - name: CLOUD_COST_REPORT_CONFIGMAP_NAME
+              value: {{ .Values.cloudCostReportConfigmapName }}
             {{- end }}
             {{- if .Values.savedReportConfigmapName }}
             - name: SAVED_REPORT_CONFIGMAP_NAME
@@ -1028,10 +1023,6 @@ spec:
               value: "true"
             - name: OIDC_SKIP_ONLINE_VALIDATION
               value: {{ (quote .Values.oidc.skipOnlineTokenValidation) | default (quote false) }}
-            {{- if .Values.oidc.rbac.teamsEnabled }}
-            - name: OIDC_RBAC_TEAMS_ENABLED
-              value: "true"
-            {{- end }}
             {{- end }}
             {{- if .Values.saml }}
             {{- if .Values.saml.enabled }}
@@ -1069,10 +1060,16 @@ spec:
             - name: SAML_RESPONSE_ENCRYPTED
               value: "true"
             {{- end}}
-            {{- if .Values.saml.rbac.teamsEnabled }}
-            - name: SAML_RBAC_TEAMS_ENABLED
+            {{- end }}
+            {{- end }}
+            {{- if eq (include "rbacTeamsEnabled" .) "true" }}
+            {{- if .Values.oidc.enabled }}
+            - name: OIDC_RBAC_TEAMS_ENABLED
               value: "true"
             {{- end }}
+            {{- if .Values.saml.enabled }}
+            - name: SAML_RBAC_TEAMS_ENABLED
+              value: "true"
             {{- end }}
             {{- end }}
             {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.clusterIDConfigmap) }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -966,6 +966,54 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/rbac/teams {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/rbac/teams;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/team {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/rbac/team;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/roles {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/rbac/roles;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/role {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/rbac/role;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/currentTeams {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/rbac/currentTeams;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/currentPermissions {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/rbac/currentPermissions;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/debug/orchestrator {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/debug/orchestrator;

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1511,7 +1511,7 @@ data:
             return 200 '\n
                 {
                 "ssoConfigured": "{{ template "ssoEnabled" . }}",
-                "rbacTeamsEnabled": "{{ template "rbacTeamsEnabled" . }}",
+                "rbacTeamsEnabled": "{{ template "rbacTeamsLegacyEnabled" . }}",
                 "dataBackupConfigured": "{{ template "dataBackupConfigured" . }}",
                 "costEventsAuditEnabled": "{{ template "costEventsAuditEnabled" . }}",
                 "frontendDeployMethod": "{{ template "frontend.deployMethod" . }}",

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1511,7 +1511,7 @@ data:
             return 200 '\n
                 {
                 "ssoConfigured": "{{ template "ssoEnabled" . }}",
-                "rbacTeamsEnabled": "{{ template "rbacTeamsLegacyEnabled" . }}",
+                "rbacTeamsEnabled": "{{ template "rbacTeamsEnabled" . }}",
                 "dataBackupConfigured": "{{ template "dataBackupConfigured" . }}",
                 "costEventsAuditEnabled": "{{ template "costEventsAuditEnabled" . }}",
                 "frontendDeployMethod": "{{ template "frontend.deployMethod" . }}",

--- a/cost-analyzer/templates/kubecost-rbac-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-rbac-secret-template.yaml
@@ -1,0 +1,22 @@
+{{- if or .Values.oidc.enabled .Values.saml.enabled }}
+{{- if and (not .Values.oidc.rbac.enabled) (not .Values.saml.rbac.enabled) }}
+{{- if or .Values.oidc.rbac.teamsEnabled .Values.saml.rbac.teamsEnabled }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: kubecost-rbac-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+stringData:
+  key:
+    {{- if .Values.oidc.enabled }}
+    {{ .Values.oidc.authSecret | default (randAlphaNum 32 | quote) }}
+    {{- end }}
+    {{- if .Values.saml.enabled }}
+    {{ .Values.saml.authSecret | default (randAlphaNum 32 | quote) }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/kubecost-rbac-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-rbac-secret-template.yaml
@@ -1,6 +1,4 @@
-{{- if or .Values.oidc.enabled .Values.saml.enabled }}
-{{- if and (not .Values.oidc.rbac.enabled) (not .Values.saml.rbac.enabled) }}
-{{- if or .Values.oidc.rbac.teamsEnabled .Values.saml.rbac.teamsEnabled }}
+{{- if eq (include "rbacTeamsEnabled" .) "true" }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -17,6 +15,4 @@ stringData:
     {{- if .Values.saml.enabled }}
     {{ .Values.saml.authSecret | default (randAlphaNum 32 | quote) }}
     {{- end }}
-{{- end }}
-{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
+++ b/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
+{{- if not .Values.teams.teamsConfigMapName }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,4 +9,5 @@ metadata:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   rbac-teams-configs.json: '{{ toJson .Values.rbacTeams.teamsConfig }}'
+{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
+++ b/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "rbacTeamsConfig" .) "true" }}
+{{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +7,5 @@ metadata:
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
-  rbac-teams-configs.json: '{{ toJson .Values.rbac.teamsConfig }}'
+  rbac-teams-configs.json: '{{ toJson .Values.rbacTeams.teamsConfig }}'
 {{- end }}

--- a/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
+++ b/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
@@ -1,0 +1,11 @@
+{{- if eq (include "rbacTeamsConfig" .) "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "kubecost-rbac-teams-config"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  rbac-teams-configs.json: '{{ toJson .Values.rbac.teamsConfig }}'
+{{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -456,7 +456,7 @@ rbacTeams:
   #         operator: ":"
   #         value: cluster-one
   #       assetFilters: []
-  #       cloudCostFilters: [] 
+  #       cloudCostFilters: []
   #     claims:
   #       NameID: email@domain.com
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -424,41 +424,41 @@ oidc:
     #       - "editor"
 
 rbacTeams:
-    enabled: false
-    # teamsConfig:
-    #   - id: ''
-    #     name: helm-team
-    #     roles:
-    #     - id: ''
-    #       name: helm-role
-    #       description: helm configrured role
-    #       pages:
-    #         showOverview: true
-    #         showAllocation: true
-    #         showAsset: true
-    #         showCloudCost: true
-    #         showClusters: true
-    #         showExternalCosts: true
-    #         showNetwork: true
-    #         showCollections: true
-    #         showReports: true
-    #         showInsights: true
-    #         showActions: true
-    #         showAlerts: true
-    #         showBudgets: true
-    #         showAnomalies: true
-    #         showEfficiency: true
-    #         showSettings: true
-    #       permissions: admin
-    #       routes: []
-    #       allocationFilters:
-    #       - key: cluster
-    #         operator: ":"
-    #         value: cluster-one
-    #       assetFilters: []
-    #       cloudCostFilters: [] 
-    #     claims:
-    #       NameID: email@domain.com
+  enabled: false
+  # teamsConfig:
+  #   - id: ''
+  #     name: helm-team
+  #     roles:
+  #     - id: ''
+  #       name: helm-role
+  #       description: helm configrured role
+  #       pages:
+  #         showOverview: true
+  #         showAllocation: true
+  #         showAsset: true
+  #         showCloudCost: true
+  #         showClusters: true
+  #         showExternalCosts: true
+  #         showNetwork: true
+  #         showCollections: true
+  #         showReports: true
+  #         showInsights: true
+  #         showActions: true
+  #         showAlerts: true
+  #         showBudgets: true
+  #         showAnomalies: true
+  #         showEfficiency: true
+  #         showSettings: true
+  #       permissions: admin
+  #       routes: []
+  #       allocationFilters:
+  #       - key: cluster
+  #         operator: ":"
+  #         value: cluster-one
+  #       assetFilters: []
+  #       cloudCostFilters: [] 
+  #     claims:
+  #       NameID: email@domain.com
 
 
 ## Adds the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables to all

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -423,8 +423,8 @@ oidc:
     #     claimValues:
     #       - "editor"
 
-rbacTeams:
-  enabled: false
+teams:
+  # teamsConfigMapName: kubecost-rbac-teams-config
   # teamsConfig:
   #   - id: ''
   #     name: helm-team

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -369,6 +369,7 @@ saml:
   # authSecretName: ""  # Name of K8s secret where the authSecret will be stored. Defaults to "kubecost-saml-secret" if not provided.
   rbac:
     enabled: false
+    teamsEnabled: false
     # groups:
     #   - name: admin
     #     enabled: false  # If admin is disabled, all SAML users will be able to make configuration changes to the Kubecost frontend
@@ -405,6 +406,7 @@ oidc:
   hostedDomain: ""  # Optional, blocks access to the auth domain specified in the hd claim of the provider ID token
   rbac:
     enabled: false
+    teamsEnabled: false
     # groups:
     #   - name: admin  # Admins have permissions to edit Kubecost settings and save reports
     #     enabled: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -369,7 +369,6 @@ saml:
   # authSecretName: ""  # Name of K8s secret where the authSecret will be stored. Defaults to "kubecost-saml-secret" if not provided.
   rbac:
     enabled: false
-    teamsEnabled: false
     # groups:
     #   - name: admin
     #     enabled: false  # If admin is disabled, all SAML users will be able to make configuration changes to the Kubecost frontend
@@ -406,7 +405,6 @@ oidc:
   hostedDomain: ""  # Optional, blocks access to the auth domain specified in the hd claim of the provider ID token
   rbac:
     enabled: false
-    teamsEnabled: false
     # groups:
     #   - name: admin  # Admins have permissions to edit Kubecost settings and save reports
     #     enabled: false
@@ -424,6 +422,44 @@ oidc:
     #     claimName: "roles"
     #     claimValues:
     #       - "editor"
+
+rbacTeams:
+    enabled: false
+    # teamsConfig:
+    #   - id: ''
+    #     name: helm-team
+    #     roles:
+    #     - id: ''
+    #       name: helm-role
+    #       description: helm configrured role
+    #       pages:
+    #         showOverview: true
+    #         showAllocation: true
+    #         showAsset: true
+    #         showCloudCost: true
+    #         showClusters: true
+    #         showExternalCosts: true
+    #         showNetwork: true
+    #         showCollections: true
+    #         showReports: true
+    #         showInsights: true
+    #         showActions: true
+    #         showAlerts: true
+    #         showBudgets: true
+    #         showAnomalies: true
+    #         showEfficiency: true
+    #         showSettings: true
+    #       permissions: admin
+    #       routes: []
+    #       allocationFilters:
+    #       - key: cluster
+    #         operator: ":"
+    #         value: cluster-one
+    #       assetFilters: []
+    #       cloudCostFilters: [] 
+    #     claims:
+    #       NameID: email@domain.com
+
 
 ## Adds the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables to all
 ## containers. Typically used in environments that have firewall rules which

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -423,9 +423,9 @@ oidc:
     #     claimValues:
     #       - "editor"
 
-teams:
-  # teamsConfigMapName: kubecost-rbac-teams-config
-  # teamsConfig:
+# teams:
+  # teamsConfigMapName: kubecost-rbac-teams-config # Name of the ConfigMap containing the teams configuration, if manually created, which overrides any other configured teams
+  # teamsConfig: # Values-defined teams configuration, if teamsConfigMapName is not set, which will override UI-configured teams
   #   - id: ''
   #     name: helm-team
   #     roles:


### PR DESCRIPTION
## What does this PR change?
Implements supporting helm changes for new RBAC teams. This includes token signing secret and teams helm config configmap mountings, env var configuration, and a config block in Values.yaml.

## Does this PR rely on any other PRs?
See linked KCM PR.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
See linked KCM PR.

## Links to Issues or tickets this PR addresses or fixes
Adds ability to configure new Teams functionality in 2.6.0, including enable/disable, blocking invalid configurations of rbac, and configuring teams via helm values and/or mounting a secret.

## What risks are associated with merging this PR? What is required to fully test this PR?
The risks are likely minimal, though testing should be performed for downgrade/upgrade scenarios.

## How was this PR tested?
See linked KCM PR for general auth testing.
Tested no-rbac auth config, simple rbac auth config, self-created configmap config, and config with helm-created configmap.

## Have you made an update to documentation? If so, please provide the corresponding PR.
In progress.
