### PR TITLE
Add configmap mounting for RBAC teams ENG-3182

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1018,6 +1018,10 @@ Begin Kubecost 2.0 templates
     - name: kubecost-rbac-secret
       mountPath: /var/configs/kubecost-rbac-secret
     {{- end }}
+    {{- if eq (include "rbacTeamsConfig" .) "true" }}
+    - name: kubecost-rbac-teams-config
+      mountPath: /var/configs/rbac-teams-configs
+    {{- end }}
     {{- if .Values.global.integrations.postgres.enabled }}
     - name: postgres-creds
       mountPath: /var/configs/integrations/postgres-creds
@@ -1171,6 +1175,10 @@ Begin Kubecost 2.0 templates
       value: "true"
     {{- end }}
     {{- end}}
+    {{- if eq (include "rbacTeamsConfig" .) "true" }}
+    - name: RBAC_TEAMS_HELM_CONFIG_PATH
+      value: "/var/configs/rbac-teams-configs/rbac-teams-configs.json"
+    {{- end }}
     {{- if .Values.kubecostAggregator }}
     {{- if .Values.kubecostAggregator.collections }}
     {{- if (((.Values.kubecostAggregator).collections).cache) }}
@@ -1382,6 +1390,14 @@ Groups is only used when using external RBAC.
     {{- printf "false" -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "rbacTeamsConfig" -}}
+  {{- if (.Values.rbac).teamsConfig -}}
+    {{- printf "true" -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end }}
+{{- end }}
 
 {{/*
 Backups configured flag for nginx configmap

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -161,7 +161,7 @@ will result in failure. Users are asked to select one of the two presently-avail
 RBAC exclusivity check: make sure either RBAC or RBAC Teams is enabled, not both
 */}}
 {{- define "rbacCheck" -}}
-  {{- if or (and ((.Values.saml).rbac).teamsEnabled ((.Values.saml).rbac).enabled) (and ((.Values.oidc).rbac).teamsEnabled ((.Values.oidc).rbac).enabled) -}}
+  {{- if and (or ((.Values.saml).rbac).enabled ((.Values.oidc).rbac).enabled) (.Values.rbacTeams).enabled  -}}
     {{- fail "\nSimple RBAC and RBAC Teams are mutually exclusive. Please specify only one." -}}
   {{- end -}}
 {{- end -}}
@@ -1014,11 +1014,11 @@ Begin Kubecost 2.0 templates
     {{- end }}
     {{- end }}
     {{- end }}
-    {{- if or .Values.oidc.rbac.teamsEnabled .Values.saml.rbac.teamsEnabled }}
+    {{- if eq (include "rbacTeamsEnabled" .) "true" }}
     - name: kubecost-rbac-secret
       mountPath: /var/configs/kubecost-rbac-secret
     {{- end }}
-    {{- if eq (include "rbacTeamsConfig" .) "true" }}
+    {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
     - name: kubecost-rbac-teams-config
       mountPath: /var/configs/rbac-teams-configs
     {{- end }}
@@ -1170,12 +1170,18 @@ Begin Kubecost 2.0 templates
       value: "true"
     - name: OIDC_SKIP_ONLINE_VALIDATION
       value: {{ (quote .Values.oidc.skipOnlineTokenValidation) | default (quote false) }}
-    {{- if .Values.oidc.rbac.teamsEnabled }}
+    {{- end}}
+    {{- if eq (include "rbacTeamsEnabled" .) "true" }}
+    {{- if .Values.oidc.enabled }}
     - name: OIDC_RBAC_TEAMS_ENABLED
       value: "true"
     {{- end }}
-    {{- end}}
-    {{- if eq (include "rbacTeamsConfig" .) "true" }}
+    {{- if .Values.saml.enabled }}
+    - name: SAML_RBAC_TEAMS_ENABLED
+      value: "true"
+    {{- end }}
+    {{- end }}
+    {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
     - name: RBAC_TEAMS_HELM_CONFIG_PATH
       value: "/var/configs/rbac-teams-configs/rbac-teams-configs.json"
     {{- end }}
@@ -1221,10 +1227,6 @@ Begin Kubecost 2.0 templates
     {{- end}}
     {{- if .Values.saml.rbac.enabled }}
     - name: SAML_RBAC_ENABLED
-      value: "true"
-    {{- end }}
-    {{- if .Values.saml.rbac.teamsEnabled }}
-    - name: SAML_RBAC_TEAMS_ENABLED
       value: "true"
     {{- end }}
     {{- if and .Values.saml.encryptionCertSecret .Values.saml.decryptionKeySecret }}
@@ -1375,7 +1377,7 @@ SSO enabled flag for nginx configmap
 To use the Kubecost built-in Teams UI RBAC< you must enable SSO and RBAC and not specify any groups.
 Groups is only used when using external RBAC.
 */}}
-{{- define "rbacTeamsEnabled" -}}
+{{- define "rbacTeamsLegacyEnabled" -}}
   {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
     {{- if or ((.Values.saml).rbac).enabled ((.Values.oidc).rbac).enabled -}}
       {{- if not (or (.Values.saml).groups (.Values.oidc).groups) -}}
@@ -1391,12 +1393,36 @@ Groups is only used when using external RBAC.
   {{- end -}}
 {{- end -}}
 
-{{- define "rbacTeamsConfig" -}}
-  {{- if (.Values.rbac).teamsConfig -}}
-    {{- printf "true" -}}
-  {{- else -}}
-    {{- printf "false" -}}
-  {{- end }}
+{{/*
+RBAC teams enabled requires that it be explicitly enabled in addition to SAML or OIDC being enabled
+and legacy RBAC being disabled.
+*/}}
+{{- define "rbacTeamsEnabled" -}}
+    {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
+        {{- if and (not ((.Values.saml).rbac).enabled) (not ((.Values.oidc).rbac).enabled) -}}
+            {{- if (.Values.rbacTeams).enabled -}}
+                {{- printf "true" -}}
+            {{- else -}}
+                {{- printf "false" -}}
+            {{- end -}}
+        {{- else -}}
+            {{- printf "false" -}}
+        {{- end -}}
+    {{- else -}}
+        {{- printf "false" -}}
+    {{- end -}}
+{{- end }}
+
+{{- define "rbacTeamsConfigEnabled" -}}
+    {{- if  eq (include "rbacTeamsEnabled" .) "true" -}}
+        {{- if (.Values.rbacTeams).teamsConfig -}}
+            {{- printf "true" -}}
+        {{- else -}}
+            {{- printf "false" -}}
+        {{- end }}
+    {{- else -}}
+        {{- printf "false" -}}
+    {{- end }}
 {{- end }}
 
 {{/*

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -145,11 +145,6 @@ spec:
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-saml
         {{- end }}
-        {{- if .Values.saml.rbac.teamsEnabled }}
-        - name: kubecost-rbac-secret
-          secret:
-            secretName: kubecost-rbac-secret
-        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.oidc }}
@@ -167,14 +162,14 @@ spec:
           secret:
             secretName: {{ .Values.oidc.existingCustomSecret.name }}
         {{- end }}
-        {{- if .Values.oidc.rbac.teamsEnabled }}
+        {{- end }}
+        {{- end }}
+        {{- if eq (include "rbacTeamsEnabled" .) "true" }}
         - name: kubecost-rbac-secret
           secret:
             secretName: kubecost-rbac-secret
         {{- end }}
-        {{- end }}
-        {{- end }}
-        {{- if eq (include "rbacTeamsConfig" .) "true" }}
+        {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config
           configMap:
             name: kubecost-rbac-teams-config

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -174,6 +174,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if eq (include "rbacTeamsConfig" .) "true" }}
+        - name: kubecost-rbac-teams-config
+          configMap:
+            name: kubecost-rbac-teams-config
+        {{- end }}
         {{- if .Values.global.integrations.postgres.enabled }}
         - name: postgres-creds
           secret:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -248,11 +248,6 @@ spec:
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-saml
         {{- end }}
-        {{- if .Values.saml.rbac.teamsEnabled }}
-        - name: kubecost-rbac-secret
-          secret:
-            secretName: kubecost-rbac-secret
-        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.oidc }}
@@ -270,14 +265,14 @@ spec:
           secret:
             secretName: {{ .Values.oidc.existingCustomSecret.name }}
         {{- end }}
-        {{- if .Values.oidc.rbac.teamsEnabled }}
+        {{- end }}
+        {{- end }}
+        {{- if eq (include "rbacTeamsEnabled" .) "true" }}
         - name: kubecost-rbac-secret
           secret:
             secretName: kubecost-rbac-secret
         {{- end }}
-        {{- end }}
-        {{- end }}
-        {{- if eq (include "rbacTeamsConfig" .) "true" }}
+        {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config
           configMap:
             name: kubecost-rbac-teams-config
@@ -704,7 +699,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            {{- if or .Values.oidc.rbac.teamsEnabled .Values.saml.rbac.teamsEnabled }}
+            {{- if eq (include "rbacTeamsEnabled" .) "true" }}
             - name: kubecost-rbac-secret
               mountPath: /var/configs/kubecost-rbac-secret
             {{- end }}
@@ -751,8 +746,8 @@ spec:
               value: {{ .Values.assetReportConfigmapName }}
             {{- end }}
             {{- if .Values.cloudCostReportConfigmapName }}
-              - name: CLOUD_COST_REPORT_CONFIGMAP_NAME
-                value: {{ .Values.cloudCostReportConfigmapName }}
+            - name: CLOUD_COST_REPORT_CONFIGMAP_NAME
+              value: {{ .Values.cloudCostReportConfigmapName }}
             {{- end }}
             {{- if .Values.savedReportConfigmapName }}
             - name: SAVED_REPORT_CONFIGMAP_NAME
@@ -982,10 +977,6 @@ spec:
               value: "true"
             - name: OIDC_SKIP_ONLINE_VALIDATION
               value: {{ (quote .Values.oidc.skipOnlineTokenValidation) | default (quote false) }}
-            {{- if .Values.oidc.rbac.teamsEnabled }}
-            - name: OIDC_RBAC_TEAMS_ENABLED
-              value: "true"
-            {{- end }}
             {{- end }}
             {{- if .Values.saml }}
             {{- if .Values.saml.enabled }}
@@ -1023,10 +1014,16 @@ spec:
             - name: SAML_RESPONSE_ENCRYPTED
               value: "true"
             {{- end}}
-            {{- if .Values.saml.rbac.teamsEnabled }}
-            - name: SAML_RBAC_TEAMS_ENABLED
+            {{- end }}
+            {{- end }}
+            {{- if eq (include "rbacTeamsEnabled" .) "true" }}
+            {{- if .Values.oidc.enabled }}
+            - name: OIDC_RBAC_TEAMS_ENABLED
               value: "true"
             {{- end }}
+            {{- if .Values.saml.enabled }}
+            - name: SAML_RBAC_TEAMS_ENABLED
+              value: "true"
             {{- end }}
             {{- end }}
             {{- if and (.Values.prometheus.server.global.external_labels.cluster_id) (not .Values.prometheus.server.clusterIDConfigmap) }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -277,6 +277,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if eq (include "rbacTeamsConfig" .) "true" }}
+        - name: kubecost-rbac-teams-config
+          configMap:
+            name: kubecost-rbac-teams-config
+        {{- end }}
         {{- if .Values.extraVolumes }}
         # Extra volume(s)
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1531,7 +1531,7 @@ data:
             return 200 '\n
                 {
                 "ssoConfigured": "{{ template "ssoEnabled" . }}",
-                "rbacTeamsEnabled": "{{ template "rbacTeamsEnabled" . }}",
+                "rbacTeamsEnabled": "{{ template "rbacTeamsLegacyEnabled" . }}",
                 "dataBackupConfigured": "{{ template "dataBackupConfigured" . }}",
                 "costEventsAuditEnabled": "{{ template "costEventsAuditEnabled" . }}",
                 "frontendDeployMethod": "{{ template "frontend.deployMethod" . }}",

--- a/cost-analyzer/templates/kubecost-rbac-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-rbac-secret-template.yaml
@@ -1,6 +1,4 @@
-{{- if or .Values.oidc.enabled .Values.saml.enabled }}
-{{- if and (not .Values.oidc.rbac.enabled) (not .Values.saml.rbac.enabled) }}
-{{- if or .Values.oidc.rbac.teamsEnabled .Values.saml.rbac.teamsEnabled }}
+{{- if eq (include "rbacTeamsEnabled" .) "true" }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -17,6 +15,4 @@ stringData:
     {{- if .Values.saml.enabled }}
     {{ .Values.saml.authSecret | default (randAlphaNum 32 | quote) }}
     {{- end }}
-{{- end }}
-{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
+++ b/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "rbacTeamsConfig" .) "true" }}
+{{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +7,5 @@ metadata:
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
-  rbac-teams-configs.json: '{{ toJson .Values.rbac.teamsConfig }}'
+  rbac-teams-configs.json: '{{ toJson .Values.rbacTeams.teamsConfig }}'
 {{- end }}

--- a/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
+++ b/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
@@ -1,0 +1,11 @@
+{{- if eq (include "rbacTeamsConfig" .) "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "kubecost-rbac-teams-config"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  rbac-teams-configs.json: '{{ toJson .Values.rbac.teamsConfig }}'
+{{- end }}


### PR DESCRIPTION
## What does this PR change?
This PR adds the ability to mount a configmap via helm values to be used as a configuration for RBAC teams

## Does this PR rely on any other PRs?
https://github.com/kubecost/cost-analyzer-helm-chart/pull/3799
https://github.com/kubecost/kubecost-cost-model/pull/2875/files#diff-c2c67151419742af1f2e7c1e6e71238cda0f5bbb0a0a54147efa2fdd8ed8744a

## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
This PR was tested using helm template with the following values
```
rbac:
    teamsConfig:
      - id: test-id
        name: test-name
        roles:
          - id: test
        claims:
          key: value
          key2: value2
```
Key results in the template
```
env:
 ...
            - name: RBAC_TEAMS_HELM_CONFIG_PATH
              value: "/var/configs/rbac-teams-configs/rbac-teams-configs.json"

```
```
# Source: cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "kubecost-rbac-teams-config"
  namespace: default
  labels:
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-2.3.3
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
data:
  rbac-teams-configs.json: '[{"claims":{"key":"value","key2":"value2"},"id":"test-id","name":"test-name","roles":[{"id":"test"}]}]'
---
```
```
volumes:
  ...
        - name: kubecost-rbac-teams-config
          configMap:
            name: kubecost-rbac-teams-config
```
```
 volumeMounts:
            ...
            - name: kubecost-rbac-teams-config
              mountPath: /var/configs/rbac-teams-configs

```



## Have you made an update to documentation? If so, please provide the corresponding PR.

