### PR TITLE
when cloud costs is not enabled, don't deploy it

### DIFF
--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -8,7 +8,6 @@
 {{- if not ( or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaBucketName)) }}
 {{- fail "\n\nA cloud-integration secret is required when using the aggregator statefulset and cloudCost is enabled." }}
 {{- end }}
-{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -211,4 +210,5 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
changes the scope of the if cloud costs enabled control statement to avoid rendering the cloud costs deployment (thereby installing it), when cloud costs is disabled

## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
should allow them to not deploy cloud costs if they don't want to


## What risks are associated with merging this PR? What is required to fully test this PR?
Low risk

## How was this PR tested?
tested via argo install on clickhouse demo env

## Have you made an update to documentation? If so, please provide the corresponding PR.

