### PR TITLE
remove unused timezone offset values

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -985,8 +985,6 @@ spec:
               value: {{ (quote .Values.persistentVolume.enabled) | default (quote true) }}
             - name: MAX_QUERY_CONCURRENCY
               value: {{ (quote .Values.kubecostModel.maxQueryConcurrency) | default (quote 5) }}
-            - name: UTC_OFFSET
-              value: {{ (quote .Values.kubecostModel.utcOffset) | default (quote ) }}
             {{- if .Values.networkCosts }}
             {{- if .Values.networkCosts.enabled }}
             - name: NETWORK_COSTS_PORT

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -685,7 +685,6 @@ kubecostModel:
   #   - name: ASSET_INCLUDE_LOCAL_DISK_COST
   #     value: "true"
 
-  utcOffset: "+00:00"
   extraPorts: []
 
 ## etlUtils is a utility typically used by Enterprise customers transitioning


### PR DESCRIPTION
## What does this PR change?
Removes old utcOffset value that is unused in Kubecost 2.x

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Remove unused utcOffset value from values.yaml

## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
Local helm upgrade on existing environment.

## Have you made an update to documentation? If so, please provide the corresponding PR.
It is not mentioned in docs.

