### PR TITLE
Add options to set additional nginx headers

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -153,7 +153,6 @@ data:
         root /var/www;
         index index.html;
 
-        add_header Cache-Control "must-revalidate";
         {{- range .Values.kubecostFrontend.nginxHeaders.server }}
         add_header {{ . }}
         {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -154,6 +154,9 @@ data:
         index index.html;
 
         add_header Cache-Control "must-revalidate";
+        {{- range .Values.kubecostFrontend.nginxHeaders.server }}
+        add_header {{ . }}
+        {{- end }}
 
         {{- if .Values.kubecostFrontend.extraServerConfig }}
         {{- .Values.kubecostFrontend.extraServerConfig | toString | nindent 8 -}}
@@ -170,6 +173,9 @@ data:
 
         add_header Cache-Control "max-age=0";
         location / {
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.root }}
+            add_header {{ . }}
+            {{- end }}
             auth_request /auth;
             proxy_redirect off;
             proxy_http_version 1.1;
@@ -183,6 +189,9 @@ data:
         # need to be served outside of the auth middleware
         location /healthz {
             add_header 'Content-Type' 'text/plain';
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.healthz }}
+            add_header {{ . }}
+            {{- end }}
             return 200 "healthy\n";
         }
         location = /teamsError.html { }
@@ -224,6 +233,9 @@ data:
 {{- end }}
         
         location /model/ {
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.model }}
+            add_header {{ . }}
+            {{- end }}
             proxy_connect_timeout       {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_send_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
@@ -240,8 +252,9 @@ data:
 
         location ~ ^/(turndown|cluster)/ {
 
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.clusterTurndown }}
+            add_header {{ . }}
+            {{- end }}
 {{- if .Values.clusterController }}
 {{- if .Values.clusterController.enabled }}
             {{- if or .Values.saml .Values.oidc }}
@@ -1473,8 +1486,9 @@ data:
 {{- end }}
         location = /model/hideOrphanedResources {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.hideOrphanedResources }}
+            add_header {{ . }}
+            {{- end }}
             {{- if .Values.kubecostFrontend.hideOrphanedResources }}
             return 200 '{"hideOrphanedResources": "true"}';
             {{- else }}
@@ -1483,8 +1497,9 @@ data:
         }
         location = /model/hideDiagnostics {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.hideDiagnostics }}
+            add_header {{ . }}
+            {{- end }}
             {{- if .Values.kubecostFrontend.hideDiagnostics }}
             return 200 '{"hideDiagnostics": "true"}';
             {{- else }}
@@ -1500,8 +1515,9 @@ data:
 
         location /model/multi-cluster-diagnostics-enabled {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.multiClusterDiagnosticsEnabled }}
+            add_header {{ . }}
+            {{- end }}
             {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled }}
             {{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig }}
             return 200 '{"multiClusterDiagnosticsEnabled": true}';
@@ -1521,8 +1537,9 @@ data:
         # Deployment, we should forward that path to the K8s Service.
         location /model/diagnostics/multicluster {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.multiClusterDiagnostics }}
+            add_header {{ . }}
+            {{- end }}
             proxy_read_timeout          300;
             proxy_pass http://multi-cluster-diagnostics/status;
             proxy_redirect off;
@@ -1533,8 +1550,9 @@ data:
         # simple alias for support
         location /mcd {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.multiClusterDiagnostics }}
+            add_header {{ . }}
+            {{- end }}
             proxy_read_timeout          300;
             proxy_pass http://multi-cluster-diagnostics/status?window=7d;
             proxy_redirect off;
@@ -1554,8 +1572,9 @@ data:
         {{- if .Values.forecasting.enabled }}
         location /forecasting {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.forecastingEnabled }}
+            add_header {{ . }}
+            {{- end }}
             proxy_read_timeout          300;
             proxy_pass http://forecasting/;
             proxy_redirect off;
@@ -1572,8 +1591,9 @@ data:
 
         location /model/productConfigs {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+            {{- range .Values.kubecostFrontend.nginxHeaders.location.productConfigs }}
+            add_header {{ . }}
+            {{- end }}
             return 200 '\n
                 {
                 "ssoConfigured": "{{ template "ssoEnabled" . }}",

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -172,9 +172,6 @@ data:
 
         add_header Cache-Control "max-age=0";
         location / {
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.root }}
-            add_header {{ . }}
-            {{- end }}
             auth_request /auth;
             proxy_redirect off;
             proxy_http_version 1.1;
@@ -188,9 +185,6 @@ data:
         # need to be served outside of the auth middleware
         location /healthz {
             add_header 'Content-Type' 'text/plain';
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.healthz }}
-            add_header {{ . }}
-            {{- end }}
             return 200 "healthy\n";
         }
         location = /teamsError.html { }
@@ -232,9 +226,6 @@ data:
 {{- end }}
         
         location /model/ {
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.model }}
-            add_header {{ . }}
-            {{- end }}
             proxy_connect_timeout       {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_send_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
@@ -251,9 +242,6 @@ data:
 
         location ~ ^/(turndown|cluster)/ {
 
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.clusterTurndown }}
-            add_header {{ . }}
-            {{- end }}
 {{- if .Values.clusterController }}
 {{- if .Values.clusterController.enabled }}
             {{- if or .Values.saml .Values.oidc }}
@@ -1485,9 +1473,6 @@ data:
 {{- end }}
         location = /model/hideOrphanedResources {
             default_type 'application/json';
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.hideOrphanedResources }}
-            add_header {{ . }}
-            {{- end }}
             {{- if .Values.kubecostFrontend.hideOrphanedResources }}
             return 200 '{"hideOrphanedResources": "true"}';
             {{- else }}
@@ -1496,9 +1481,6 @@ data:
         }
         location = /model/hideDiagnostics {
             default_type 'application/json';
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.hideDiagnostics }}
-            add_header {{ . }}
-            {{- end }}
             {{- if .Values.kubecostFrontend.hideDiagnostics }}
             return 200 '{"hideDiagnostics": "true"}';
             {{- else }}
@@ -1514,9 +1496,6 @@ data:
 
         location /model/multi-cluster-diagnostics-enabled {
             default_type 'application/json';
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.multiClusterDiagnosticsEnabled }}
-            add_header {{ . }}
-            {{- end }}
             {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled }}
             {{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig }}
             return 200 '{"multiClusterDiagnosticsEnabled": true}';
@@ -1536,9 +1515,6 @@ data:
         # Deployment, we should forward that path to the K8s Service.
         location /model/diagnostics/multicluster {
             default_type 'application/json';
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.multiClusterDiagnostics }}
-            add_header {{ . }}
-            {{- end }}
             proxy_read_timeout          300;
             proxy_pass http://multi-cluster-diagnostics/status;
             proxy_redirect off;
@@ -1549,9 +1525,6 @@ data:
         # simple alias for support
         location /mcd {
             default_type 'application/json';
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.multiClusterDiagnostics }}
-            add_header {{ . }}
-            {{- end }}
             proxy_read_timeout          300;
             proxy_pass http://multi-cluster-diagnostics/status?window=7d;
             proxy_redirect off;
@@ -1571,9 +1544,6 @@ data:
         {{- if .Values.forecasting.enabled }}
         location /forecasting {
             default_type 'application/json';
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.forecastingEnabled }}
-            add_header {{ . }}
-            {{- end }}
             proxy_read_timeout          300;
             proxy_pass http://forecasting/;
             proxy_redirect off;
@@ -1590,9 +1560,6 @@ data:
 
         location /model/productConfigs {
             default_type 'application/json';
-            {{- range .Values.kubecostFrontend.nginxHeaders.location.productConfigs }}
-            add_header {{ . }}
-            {{- end }}
             return 200 '\n
                 {
                 "ssoConfigured": "{{ template "ssoEnabled" . }}",

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -539,11 +539,12 @@ kubecostFrontend:
 #    fqdn: cluster-controller.kubecost.svc.cluster.local:9731
 #
 
-  # Configurable, optional headers for nginx responses.
+  # Configurable headers for nginx responses.
   nginxHeaders:
     # applied to all route locations
     server:
       - Content-Security-Policy "default-src 'self' cdn.userway.org; frame-ancestors 'none';";
+      - Cache-Control "must-revalidate";
     # per-location headers
     location:
       root: []
@@ -2491,4 +2492,3 @@ extraObjects: []
 # -- Optional override for the image used for the basic health test container
 # basicHealth:
 #   fullImageName: alpine/k8s:1.26.9
-

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -543,34 +543,10 @@ kubecostFrontend:
   nginxHeaders:
     # applied to all route locations
     server:
+      - "'Access-Control-Allow-Origin' '*' always;"
+      - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
       - Content-Security-Policy "default-src 'self' 'unsafe-inline' api.userway.org cdn.userway.org api-js.mixpanel.com keyper.kubecost.com; frame-ancestors 'none'; font-src 'self' data:;";
       - Cache-Control "must-revalidate";
-    # per-location headers
-    location:
-      root: []
-      healthz: []
-      model: []
-      clusterTurndown:
-        - "'Access-Control-Allow-Origin' '*' always;"
-        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
-      hideOrphanedResources:
-        - "'Access-Control-Allow-Origin' '*' always;"
-        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
-      hideDiagnostics:
-        - "'Access-Control-Allow-Origin' '*' always;"
-        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
-      multiClusterDiagnosticsEnabled:
-        - "'Access-Control-Allow-Origin' '*' always;"
-        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
-      multiClusterDiagnostics:
-        - "'Access-Control-Allow-Origin' '*' always;"
-        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
-      forecastingEnabled:
-        - "'Access-Control-Allow-Origin' '*' always;"
-        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
-      productConfigs:
-        - "'Access-Control-Allow-Origin' '*' always;"
-        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
 
 # Kubecost Metrics deploys a separate pod which will emit kubernetes specific metrics required
 # by the cost-model. This pod is designed to remain active and decoupled from the cost-model itself.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -543,7 +543,7 @@ kubecostFrontend:
   nginxHeaders:
     # applied to all route locations
     server:
-      - Content-Security-Policy "default-src 'self' cdn.userway.org; frame-ancestors 'none';";
+      - Content-Security-Policy "default-src 'self' 'unsafe-inline' api.userway.org cdn.userway.org api-js.mixpanel.com keyper.kubecost.com; frame-ancestors 'none'; font-src 'self' data:;";
       - Cache-Control "must-revalidate";
     # per-location headers
     location:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -537,6 +537,39 @@ kubecostFrontend:
 #    fqdn: kubecost-multi-diag.kubecost.svc.cluster.local:9007
 #  clusterController:
 #    fqdn: cluster-controller.kubecost.svc.cluster.local:9731
+#
+
+  # Configurable, optional headers for nginx responses.
+  nginxHeaders:
+    # applied to all route locations
+    server:
+      - Content-Security-Policy "default-src 'self' cdn.userway.org; frame-ancestors 'none';";
+    # per-location headers
+    location:
+      root: []
+      healthz: []
+      model: []
+      clusterTurndown:
+        - "'Access-Control-Allow-Origin' '*' always;"
+        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
+      hideOrphanedResources:
+        - "'Access-Control-Allow-Origin' '*' always;"
+        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
+      hideDiagnostics:
+        - "'Access-Control-Allow-Origin' '*' always;"
+        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
+      multiClusterDiagnosticsEnabled:
+        - "'Access-Control-Allow-Origin' '*' always;"
+        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
+      multiClusterDiagnostics:
+        - "'Access-Control-Allow-Origin' '*' always;"
+        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
+      forecastingEnabled:
+        - "'Access-Control-Allow-Origin' '*' always;"
+        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
+      productConfigs:
+        - "'Access-Control-Allow-Origin' '*' always;"
+        - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
 
 # Kubecost Metrics deploys a separate pod which will emit kubernetes specific metrics required
 # by the cost-model. This pod is designed to remain active and decoupled from the cost-model itself.
@@ -2458,3 +2491,4 @@ extraObjects: []
 # -- Optional override for the image used for the basic health test container
 # basicHealth:
 #   fullImageName: alpine/k8s:1.26.9
+


### PR DESCRIPTION
## What does this PR change?
Adds options to values.yaml and the nginx template for injecting extra `add_header` directives at the server and location levels. I haven't gone and stubbed this out for every location directive yet - I'd like directional feedback on the concept.

The primary motivation here is that security tools (correctly) flag that `Access-Control-Allow-Origin '*'` is, in many cases, overly-permissive, and that the absence of a `Content-Security-Policy` header opens attack vectors for XSS and clickjacking.

The default values supplied in `values.yaml` with this commit keep the CORS behavior consistent, by defaulting to the permissive approach. Users will now be able to override this permissive configuration to harden their application. The default values for CSP disallow iframe embedding to prevent clickjacking, and forbid pulling in sources (scripts, images, etc) from domains other than self, and Userway (an accessibility application leveraged by some Kubecost users). Users who embed Kubecost in an iframe in their own context would need to update their Helm charts to allow this behavior again.

## Does this PR rely on any other PRs?
No.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users who currently embed Kubecost in an iframe will need to update their `values.yaml` files. Users who want to add extra headers on a per-location basis will now be able to do so via Helm.


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
One risk is that the CSP could inadvertently block externally-loaded content that I missed in testing.


## How was this PR tested?
It hasn't been (yet), hence draft mode. My test plan will be to deploy to an environment using this chart and explore the application with the network tab open, and look for any content requests blocked by the CSP or CORS errors.


## Have you made an update to documentation? If so, please provide the corresponding PR.
Not yet, but I believe this will require an update.
