### PR TITLE
Update values.yaml to define teams configuration, as opposed to commented out

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -423,43 +423,44 @@ oidc:
     #     claimValues:
     #       - "editor"
 
-# teams:
-  # teamsConfigMapName: kubecost-rbac-teams-config # Name of the ConfigMap containing the teams configuration, if manually created, which overrides any other configured teams
-  # teamsConfig: # Values-defined teams configuration, if teamsConfigMapName is not set, which will override UI-configured teams
-  #   - id: ''
-  #     name: helm-team
-  #     roles:
-  #     - id: ''
-  #       name: helm-role
-  #       description: helm configrured role
-  #       pages:
-  #         showOverview: true
-  #         showAllocation: true
-  #         showAsset: true
-  #         showCloudCost: true
-  #         showClusters: true
-  #         showExternalCosts: true
-  #         showNetwork: true
-  #         showCollections: true
-  #         showReports: true
-  #         showInsights: true
-  #         showActions: true
-  #         showAlerts: true
-  #         showBudgets: true
-  #         showAnomalies: true
-  #         showEfficiency: true
-  #         showSettings: true
-  #       permissions: admin
-  #       routes: []
-  #       allocationFilters:
-  #       - key: cluster
-  #         operator: ":"
-  #         value: cluster-one
-  #       assetFilters: []
-  #       cloudCostFilters: []
-  #     claims:
-  #       NameID: email@domain.com
-
+## Kubecost Teams (enterprise key required)
+## Ref: https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/teams
+teams:
+  teamsConfigMapName: ""  # Name of the ConfigMap containing the teams configuration, if manually created, which overrides any other configured teams
+  teamsConfig: []  # List of teams configurations, if teamsConfigMapName is not set, which will override UI-configured teams
+    # - id: ''
+    #   name: helm-team
+    #   roles:
+    #   - id: ''
+    #     name: helm-role
+    #     description: helm configrured role
+    #     pages:
+    #       showOverview: true
+    #       showAllocation: true
+    #       showAsset: true
+    #       showCloudCost: true
+    #       showClusters: true
+    #       showExternalCosts: true
+    #       showNetwork: true
+    #       showCollections: true
+    #       showReports: true
+    #       showInsights: true
+    #       showActions: true
+    #       showAlerts: true
+    #       showBudgets: true
+    #       showAnomalies: true
+    #       showEfficiency: true
+    #       showSettings: true
+    #     permissions: admin
+    #     routes: []
+    #     allocationFilters:
+    #     - key: cluster
+    #       operator: ":"
+    #       value: cluster-one
+    #     assetFilters: []
+    #     cloudCostFilters: []
+    #   claims:
+    #     NameID: email@domain.com
 
 ## Adds the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables to all
 ## containers. Typically used in environments that have firewall rules which


### PR DESCRIPTION
## What does this PR change?

I believe that the better Helm UX, is to define all the possible configurations the user could possibly make, as opposed to leaving them commented out. I believe we should only be commenting out _examples_ of configurations.

I've updated the Teams configuration to instantiate `.Values.teams.teamsConfigMapName` and `.Values.teams.teamsConfig` as empty values. This should have the same exact effect of when it was previously commented out. Tests shown below.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

N/A

## How was this PR tested?

```sh
helm template ./cost-analyzer > kubecost1.yaml

git checkout develop
helm template ./cost-analyzer > kubecost2.yaml

diff kubecost1.yaml kubecost2.yaml
```

The diff shows there is no difference between the two files, with the exception of [this line](https://github.com/kubecost/cost-analyzer-helm-chart/blob/0feac4119142c25ced1d68be76fad9656087c08a/kubecost.yaml#L23306-L23307) which is a base64 encoded string of all the helm values.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A