### PR TITLE
Add teamsError.html to nginx routing

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -167,6 +167,7 @@ data:
         }
 
 {{- if or .Values.saml.enabled .Values.oidc.enabled }}
+
         add_header Cache-Control "max-age=0";
         location / {
             auth_request /auth;
@@ -178,10 +179,14 @@ data:
             error_page 401 = /login;
             try_files $uri $uri/ /index.html;
         }
+        
+        # need to be served outside of the auth middleware
         location /healthz {
             add_header 'Content-Type' 'text/plain';
             return 200 "healthy\n";
         }
+        location = /teamsError.html { }
+
 {{- else }}
         add_header Cache-Control "max-age=300";
         location / {


### PR DESCRIPTION
## What does this PR change?
Adds a route for the teamsError page introduced in https://github.com/kubecost/kubecost-frontend/pull/2377 outside of the auth handling so it can be served to unauthorized users.

## Does this PR rely on any other PRs?
https://github.com/kubecost/kubecost-frontend/pull/2377

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
No release notes impact.

## Links to Issues or tickets this PR addresses or fixes


## What risks are associated with merging this PR? What is required to fully test this PR?
Should be no risk.

## How was this PR tested?
Tested by manually editing live nginx config with changes.

## Have you made an update to documentation? If so, please provide the corresponding PR.

