### PR TITLE
add labels, securityContext and image pull secret in cluster controller

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -256,12 +256,6 @@ spec:
         {{- else if .Values.global.containerSecurityContext }}
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 -}}
         {{- end }}
-        {{- if .Values.imagePullSecrets }}
-        imagePullSecrets:
-          {{- range $.Values.imagePullSecrets }}
-          - name: {{ .name }}
-          {{- end }}
-        {{- end }}
         volumeMounts:
         - name: cluster-controller-keys
           mountPath: /var/keys
@@ -302,6 +296,12 @@ spec:
           hostPort: 9731
         resources:
           {{- toYaml .Values.clusterController.resources | nindent 12 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.Values.imagePullSecrets }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       serviceAccount: {{ template "kubecost.clusterControllerName" . }}
       serviceAccountName: {{ template "kubecost.clusterControllerName" . }}
       {{- with .Values.clusterController.tolerations }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -190,6 +190,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- if .Values.global.additionalLabels }}
+    {{- toYaml .Values.global.additionalLabels | nindent 4 }}
+    {{- end }}
+    {{- if .Values.clusterController.labels }}
+    {{- toYaml .Values.clusterController.labels | nindent 4 }}
+    {{- end }}
   annotations:
   {{- with .Values.global.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -210,11 +216,29 @@ spec:
     metadata:
       labels:
         app: {{ template "kubecost.clusterControllerName" . }}
+        {{- if .Values.global.additionalLabels }}
+        {{- toYaml .Values.global.additionalLabels | nindent 8 }}
+        {{- end }}
+        {{- if .Values.clusterController.labels }}
+        {{- toYaml .Values.clusterController.labels | nindent 8 }}
+        {{- end }}
       {{- with .Values.global.podAnnotations}}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.global.platforms.openshift.enabled }}
+      securityContext:
+      {{- toYaml .Values.global.platforms.openshift.securityContext | nindent 8 }}
+      {{- else if .Values.global.securityContext }}
+      securityContext:
+      {{- toYaml .Values.global.securityContext | nindent 8 }}
+      {{- else }}
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      {{- end }}
       {{- if .Values.clusterController.priorityClassName }}
       priorityClassName: "{{ .Values.clusterController.priorityClassName }}"
       {{- end }}
@@ -226,6 +250,18 @@ spec:
         image: {{ .Values.clusterController.image.repository }}:{{ .Values.clusterController.image.tag }}
         {{- end}}
         imagePullPolicy: {{ .Values.clusterController.imagePullPolicy }}
+        securityContext:
+        {{- if .Values.clusterController.securityContext }}
+          {{- toYaml .Values.clusterController.securityContext | nindent 10 -}}
+        {{- else if .Values.global.containerSecurityContext }}
+          {{- toYaml .Values.global.containerSecurityContext | nindent 10 -}}
+        {{- end }}
+        {{- if .Values.imagePullSecrets }}
+        imagePullSecrets:
+          {{- range $.Values.imagePullSecrets }}
+          - name: {{ .name }}
+          {{- end }}
+        {{- end }}
         volumeMounts:
         - name: cluster-controller-keys
           mountPath: /var/keys

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1867,6 +1867,8 @@ clusterController:
 
   ## Annotations to be added for cluster controller template
   annotations: {}
+  labels: {}
+  securityContext: {}
   resources: {}
   affinity: {}
   nodeSelector: {}


### PR DESCRIPTION
## What does this PR change?
Adds Labels, SecurityContext and image pull secrets to cluster controller configurations.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will now be able to add:
* custom labels to the deployment and pod.
* Security context at the pod and container level
* image pull secret to cluster controller pod

## Links to Issues or tickets this PR addresses or fixes
No
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
No

## How was this PR tested?
When setting `imagePullSecret`, `labels` and `securityContext`. We get the following deployment template using `helm template`
```yaml
# Source: cost-analyzer/templates/kubecost-cluster-controller-template.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cost-analyzer-cluster-controller
  namespace: default
  labels:
    app.kubernetes.io/name: cost-analyzer
    helm.sh/chart: cost-analyzer-2.3.3
    app.kubernetes.io/instance: cost-analyzer
    app.kubernetes.io/managed-by: Helm
    app: cost-analyzer
    hey: there
  annotations:
spec:
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
    type: RollingUpdate
  selector:
    matchLabels:
      app: cost-analyzer-cluster-controller
  template:
    metadata:
      labels:
        app: cost-analyzer-cluster-controller
        hey: there
    spec:
      securityContext:
        fsGroup: 1001
        fsGroupChangePolicy: OnRootMismatch
        runAsGroup: 1001
        runAsNonRoot: true
        runAsUser: 1001
        seccompProfile:
          type: RuntimeDefault
      containers:
      - name: cost-analyzer-cluster-controller
        image: gcr.io/kubecost1/cluster-controller:v0.16.11
        imagePullPolicy: IfNotPresent
        securityContext:
          hey: there
        volumeMounts:
        - name: cluster-controller-keys
          mountPath: /var/keys
        env:
          ...
        ports:
        - name: http-server
          containerPort: 9731
          hostPort: 9731
        resources:
            {}
      imagePullSecrets:
        - name: image-pull-secret
      serviceAccount: cost-analyzer-cluster-controller
      serviceAccountName: cost-analyzer-cluster-controller
      volumes:
        ...
```
deployed kubecost using these configurations
## Have you made an update to documentation? If so, please provide the corresponding PR.
No
