### PR TITLE
Do not put the Kubecost logo behind auth

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -186,6 +186,7 @@ data:
             return 200 "healthy\n";
         }
         location = /teamsError.html { }
+        location = /images/kubecost-logo.svg { }
 
 {{- else }}
         add_header Cache-Control "max-age=300";


### PR DESCRIPTION
## What does this PR change?
Prevents access to a logo used by the "auth failed" error page from becoming inaccessible due to...auth failing.

This is a wildly-overly-specific nginx location directive, but when I tried to use `/images/` or `/images`, the image was still blocked by invalid auth. Maybe `^/images/*$`, or something, works. I'd need to read more about nginx. I think we'll want to revise the way our route handling is set up anyway.

## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Prevent access to a logo used by the "auth failed" error page from becoming inaccessible due to...auth failing.



## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
No real risk - I tested by seeing that the logo failed to load before the change, and afterward it loads fine.


## How was this PR tested?
I tested by seeing that the logo failed to load before the change, and afterward it loads fine.


## Have you made an update to documentation? If so, please provide the corresponding PR.
No.

