### PR TITLE
Remove thread limit on read database

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1627,7 +1627,7 @@ kubecostAggregator:
   numDBCopyPartitions: 25
 
   # How many threads the read database is configured with (i.e. Kubecost API /
-  # UI queries). If no value is set, the number of threads is bound by the
+  # UI queries). If value is 0, the number of threads is bound by the
   # number of cores
   # default: 0 is no limit
   dbReadThreads: 0

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1627,7 +1627,7 @@ kubecostAggregator:
   numDBCopyPartitions: 25
 
   # How many threads the read database is configured with (i.e. Kubecost API /
-  # UI queries). If value is 0, the number of threads is bound by the
+  # UI queries). If value is 0, the number of threads is bounded by the
   # number of cores
   # default: 0 is no limit
   dbReadThreads: 0

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1627,10 +1627,10 @@ kubecostAggregator:
   numDBCopyPartitions: 25
 
   # How many threads the read database is configured with (i.e. Kubecost API /
-  # UI queries). If increasing this value, it is recommended to increase the
-  # aggregator's memory requests & limits.
-  # default: 1
-  dbReadThreads: 1
+  # UI queries). If no value is set, the number of threads is bound by the
+  # number of cores
+  # default: 0 is no limit
+  dbReadThreads: 0
 
   # How many threads the write database is configured with (i.e. ingestion of
   # new data from S3). If increasing this value, it is recommended to increase


### PR DESCRIPTION
## What does this PR change?
This PR removes the default thread limit (1) on the read database.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
The number of threads available on the read database can go up to the number of cores on the resource unless it is explicitly set.

## Links to Issues or tickets this PR addresses or fixes
The default limit of 1 caused https://kubecost.atlassian.net/browse/ENG-3277

## What risks are associated with merging this PR? What is required to fully test this PR?
N/A

## How was this PR tested?
We have manually validated that setting the value to zero effectively disables setting the number of threads on the read db.

## Have you made an update to documentation? If so, please provide the corresponding PR.
Public docs PR: https://github.com/kubecost/docs/pull/1176 modifying:
- https://docs.kubecost.com/install-and-configure/install/multi-cluster/federated-etl/aggregator
- https://docs.kubecost.com/install-and-configure/advanced-configuration/resource-consumption#aggregator

