### PR TITLE
Fix teams enablement condition

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1396,7 +1396,7 @@ Groups is only used when using simple RBAC.
 {{- define "rbacTeamsEnabled" -}}
   {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
     {{- if or ((.Values.saml).rbac).enabled ((.Values.oidc).rbac).enabled -}}
-      {{- if not (or (.Values.saml).groups (.Values.oidc).groups) -}}
+      {{- if not (or ((.Values.saml).rbac).groups ((.Values.oidc).rbac).groups) -}}
         {{- printf "true" -}}
         {{- else -}}
         {{- printf "false" -}}


### PR DESCRIPTION
## What does this PR change?
Fixes an issue with enabling rbac teams. This was present in previous versions.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixes an issue with enabling rbac teams.

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?
No.

## How was this PR tested?

Tested using local branch of the repo and `helm template . --values=values.yaml --set upgrade.toV2=true` (`values.yaml` being a modified file with dummy oidc config):

```yaml
oidc:
  enabled: true
  clientID: ""
  clientSecret: ""  
  secretName: "kubecost-oidc-secret" 
  existingCustomSecret:
    enabled: false
    name: ""  
  authURL: ""  
  loginRedirectURL: "" 
  discoveryURL: "" 
  skipOnlineTokenValidation: false  
  useClientSecretPost: false  
  hostedDomain: ""  
  rbac:
    enabled: true
    groups:
      - name: admin
        enabled: true 
        claimName: "groups" 
        claimValues:
          - "foo"
      - name: readonly
        enabled: true 
        claimName:  "groups"
        claimValues:
          - "bar"
```

Before change, viewed teams being enabled even though the intended behavior was disabling when groups had values. After change, viewed teams being disabled. Removing groups allows teams as intended.

## Have you made an update to documentation? If so, please provide the corresponding PR.
No.
