### PR TITLE
bump cluster controller to v0.16.13

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1860,7 +1860,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.12
+    tag: v0.16.13
   imagePullPolicy: IfNotPresent
   priorityClassName: ""
   tolerations: []


### PR DESCRIPTION
## What does this PR change?
Fixes a formatting issue on pod specs where memory was displayed as bytes rather than Mi

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
One click request sizing will now edit pod specs to use Mi and not bytes

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
https://apptio.atlassian.net/browse/KCM-3312


## What risks are associated with merging this PR? What is required to fully test this PR?
Only one click request sizing is affected

## How was this PR tested?
Unit tests

## Have you made an update to documentation? If so, please provide the corresponding PR.
N/A
