### PR TITLE
Refactor forecasting template

### DIFF
--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -55,6 +55,8 @@ spec:
         - name: forecasting
           {{- if .Values.forecasting.fullImageName }}
           image: {{ .Values.forecasting.fullImageName }}
+          {{- else if .Values.forecasting.image }}
+          image: {{ .Values.forecasting.image.repository }}:{{ .Values.forecasting.image.tag }}
           {{- else }}
           image: gcr.io/kubecost1/kubecost-modeling:prod-{{ $.Chart.AppVersion }}
           {{ end }}

--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -53,9 +53,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: forecasting
-          {{- if .Values.forecasting.fullImageName }}
-          image: {{ .Values.forecasting.fullImageName }}
-          {{- else if .Values.forecasting.image }}
+          {{- if .Values.forecasting.image }}
           image: {{ .Values.forecasting.image.repository }}:{{ .Values.forecasting.image.tag }}
           {{- else }}
           image: gcr.io/kubecost1/kubecost-modeling:prod-{{ $.Chart.AppVersion }}

--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -53,7 +53,9 @@ spec:
       restartPolicy: Always
       containers:
         - name: forecasting
-          {{- if .Values.forecasting.image }}
+          {{- if .Values.forecasting.fullImageName }}
+          image: {{ .Values.forecasting.fullImageName }}
+          {{- else if .Values.forecasting.image }}
           image: {{ .Values.forecasting.image.repository }}:{{ .Values.forecasting.image.tag }}
           {{- else }}
           image: gcr.io/kubecost1/kubecost-modeling:prod-{{ $.Chart.AppVersion }}

--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -18,7 +18,9 @@ kubecostModel:
   image: public.ecr.aws/kubecost/cost-model
 
 forecasting:
-  fullImageName: public.ecr.aws/kubecost/kubecost-modeling:v0.1.19
+  image:
+    repository: public.ecr.aws/kubecost/kubecost-modeling
+    tag: v0.1.19
 
 networkCosts:
   image:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1542,11 +1542,9 @@ kubecostDeployment:
 ## patterns observed by Kubecost.
 forecasting:
   enabled: true
-
-  # fullImageName overrides the default image construction logic. The exact
-  # image provided (registry, image, tag) will be used for the forecasting
-  # container.
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.19
+  image:
+    repository: public.ecr.aws/kubecost/kubecost-modeling
+    tag: v0.1.19
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1552,6 +1552,7 @@ kubecostDeployment:
 ## patterns observed by Kubecost.
 forecasting:
   enabled: true
+  fullImageName: ""
   image:
     repository: public.ecr.aws/kubecost/kubecost-modeling
     tag: v0.1.19


### PR DESCRIPTION
## What does this PR change?
Addressing the user's feedback below:

"This be refactored so that the tag is not part of the image?
https://github.com/kubecost/cost-analyzer-helm-chart/blob/c0cc2bb/cost-analyzer/values-eks-cost-monitoring.yaml#L21

this would allow operators to override <http://gcr.io/kubecost1/kubecost-modeling|gcr.io/kubecost1/kubecost-modeling> with public.ecr.aws/kubecost/kubecost-modeling without having to track the version downstream"

## Does this PR rely on any other PRs?
N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Added helm option for cluster controller image repository to be independent from tag.

## Links to Issues or tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/SUP-6756



## What risks are associated with merging this PR? What is required to fully test this PR?
None

## How was this PR tested?
Manually

[cost-analyzer-2.3.3-1.tgz](https://github.com/user-attachments/files/18773565/cost-analyzer-2.3.3-1.tgz)

```
TEST 1
➜ helm upgrade -i kubecost -n kubecost chartmuseum/cost-analyzer --version v2.3.3-1 --set forecasting.fullImageName=gcr.io/kubecost1/kubecost-modeling:v0.1.19
➜ helm ls                             
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
kubecost        kubecost        2               2025-02-12 15:03:09.929021 -0500 EST    deployed        cost-analyzer-2.3.3-1   development

➜  helm get values kubecost -n kubecost 
USER-SUPPLIED VALUES:
forecasting:
  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.19

➜ k describe deploy kubecost-forecasting  | grep -i image                    
    Image:      gcr.io/kubecost1/kubecost-modeling:v0.1.19

➜ k get pods | grep -i forecasting                       
kubecost-forecasting-58478df84-58gck          1/1     Running   0          70s

TEST 2
➜ helm upgrade -i kubecost -n kubecost chartmuseum/cost-analyzer --version v2.3.3-1 --set forecasting.image.repository=gcr.io/kubecost1/kubecost-modeling --set forecasting.image.tag=v0.1.19

➜ helm get values kubecost -n kubecost
USER-SUPPLIED VALUES:
forecasting:
  image:
    repository: gcr.io/kubecost1/kubecost-modeling
    tag: v0.1.19
    
➜ k get pods | grep -i forecasting    
kubecost-forecasting-58478df84-58gck          1/1     Running   0          5m40s

➜   k describe deploy kubecost-forecasting  | grep -i image
    Image:      gcr.io/kubecost1/kubecost-modeling:v0.1.19

TEST 3
➜ helm upgrade -i kubecost -n kubecost chartmuseum/cost-analyzer --version v2.3.3-1 --set forecasting.image.repository=gcr.io/kubecost1/kubecost-modeling --set forecasting.image.tag=v0.1.19 --set forecasting.fullImageName=gcr.io/kubecost1/kubecost-modeling:v0.1.18

➜ helm get values kubecost -n kubecost                   
USER-SUPPLIED VALUES:
forecasting:
  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.18
  image:
    repository: gcr.io/kubecost1/kubecost-modeling
    tag: v0.1.19

➜ k describe deploy kubecost-forecasting  | grep -i image
    Image:      gcr.io/kubecost1/kubecost-modeling:v0.1.18

➜ k get pods | grep -i forecasting                       
kubecost-forecasting-765b644669-rfcxz         1/1     Running   0          2m2s
```

## Have you made an update to documentation? If so, please provide the corresponding PR.
N/A
