### PR TITLE
fix: ksm metrics were getting duplicated in openshift env using in-cluster prometheus

### DIFF
--- a/cost-analyzer/values-openshift-cluster-prometheus.yaml
+++ b/cost-analyzer/values-openshift-cluster-prometheus.yaml
@@ -24,3 +24,6 @@ serviceMonitor:
 
 prometheusRule:
   enabled: true
+
+kubecostMetrics:
+  emitKsmV1Metrics: false


### PR DESCRIPTION
## What does this PR change?
Adds default option for disabling emitting ksm metrics when using in-cluster prometheus in an openshift environment.

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users installing kubecost in openshift environment using in-cluster prometheus will now not get degraded warning and will see correct number of CPU in openshift overview page.

## Links to Issues or tickets this PR addresses or fixes
https://github.com/opencost/opencost-helm-chart/issues/249
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
No

## How was this PR tested?
Installed kubecost in openshift environment with in-cluster prometheus. earlier was getting degraded warning after setting:
```yaml
kubecostMetrics:
  emitKsmV1Metrics: false
```
the warning was gone and nothing else was affected(We were getting correct etls and cost was showing up in UI).

## Have you made an update to documentation? If so, please provide the corresponding PR.

