### PR TITLE
Revert "fix: ksm metrics were getting duplicated in openshift env using in-cluster prometheus (cherry-pick #3864)"

### DIFF
--- a/cost-analyzer/values-openshift-cluster-prometheus.yaml
+++ b/cost-analyzer/values-openshift-cluster-prometheus.yaml
@@ -24,6 +24,3 @@ serviceMonitor:
 
 prometheusRule:
   enabled: true
-
-kubecostMetrics:
-  emitKsmV1Metrics: false


### PR DESCRIPTION
Reverts kubecost/cost-analyzer-helm-chart#3867