### PR TITLE
Update kubecost.yaml and cost-analyzer/values.yaml to target v0.1.22 of the kubecost-modeling image

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1555,7 +1555,7 @@ forecasting:
   fullImageName: ""
   image:
     repository: gcr.io/kubecost1/kubecost-modeling
-    tag: v0.1.19
+    tag: v0.1.22
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -23569,7 +23569,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: forecasting
-          image: gcr.io/kubecost1/kubecost-modeling:v0.1.19
+          image: gcr.io/kubecost1/kubecost-modeling:v0.1.21
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -23569,7 +23569,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: forecasting
-          image: gcr.io/kubecost1/kubecost-modeling:v0.1.21
+          image: gcr.io/kubecost1/kubecost-modeling:v0.1.22
           volumeMounts:
             - name: tmp
               mountPath: /tmp


### PR DESCRIPTION
## What does this PR change?
Updates kubecost.yaml to target v0.1.22 of the kubecost-modeling image

## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Causes the Kubecost product to use the latest kubecost-modeling image, which fixes an issue where anomaly detection did not work with the new RBAC Teams released in 2.6.0.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
Build job for the new image is here: https://github.com/kubecost/kubecost-modeling/actions/runs/13334586552
When it completes, I will attempt to install a local copy of the helm chart to an image from this branch, and ensure that the kc-modeling image is deployed correctly.


## How was this PR tested?
Deployed to the test environment & confirmed that the new image is in use:
<img width="732" alt="image" src="https://github.com/user-attachments/assets/61a6cb62-b2ae-4cb1-8d0f-545d3cd876e0" />

Anomaly detection functions as normal:
<img width="1723" alt="image" src="https://github.com/user-attachments/assets/64261d11-b223-438e-a1cd-ef0e4b8739ab" />



## Have you made an update to documentation? If so, please provide the corresponding PR.
No.

