### PR TITLE
Fix repo for kubecost-modeling

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1554,7 +1554,7 @@ forecasting:
   enabled: true
   fullImageName: ""
   image:
-    repository: public.ecr.aws/kubecost/kubecost-modeling
+    repository: gcr.io/kubecost1/kubecost-modeling
     tag: v0.1.19
   imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What does this PR change?

N/A

## Does this PR rely on any other PRs?

Fixes mistake in https://github.com/kubecost/cost-analyzer-helm-chart/pull/3863. The default repo should be `gcr.io`. Only in `values-eks.yaml` should it be `public.ecr.aws/kubecost/kubecost-modeling`.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

N/A

## How was this PR tested?

Validate that this repo/image exist:

```sh
docker pull gcr.io/kubecost1/kubecost-modeling:v0.1.19
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A
