### PR TITLE
add extraEnv and logLevel in helm values for clusterController

### DIFF
--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -300,6 +300,9 @@ spec:
               name: {{ .Values.clusterController.secretName }}
               key: kubecostAPIKey
         {{- end }}
+        {{- if .Values.clusterController.extraEnv -}}
+        {{ toYaml .Values.clusterController.extraEnv | nindent 8 }}
+        {{- end }}
         {{- if .Values.clusterController.kubescaler }}
         - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
           value: {{ .Values.clusterController.kubescaler.defaultResizeAll | default "false" | quote }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -300,12 +300,12 @@ spec:
               name: {{ .Values.clusterController.secretName }}
               key: kubecostAPIKey
         {{- end }}
-        {{- if .Values.clusterController.extraEnv -}}
-        {{ toYaml .Values.clusterController.extraEnv | nindent 8 }}
-        {{- end }}
         {{- if .Values.clusterController.kubescaler }}
         - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
           value: {{ .Values.clusterController.kubescaler.defaultResizeAll | default "false" | quote }}
+        {{- end }}
+        {{- if .Values.clusterController.extraEnv -}}
+        {{ toYaml .Values.clusterController.extraEnv | nindent 8 }}
         {{- end }}
         ports:
         - name: http-server

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1871,6 +1871,12 @@ clusterController:
     repository: gcr.io/kubecost1/cluster-controller
     tag: v0.16.13
   imagePullPolicy: IfNotPresent
+
+  # extraEnv:
+  # - name: EXTRA_ENV_VAR
+  #   value: "extra_env_var_value"
+
+  logLevel: info
   priorityClassName: ""
   tolerations: []
   annotations: {}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1871,11 +1871,9 @@ clusterController:
     repository: gcr.io/kubecost1/cluster-controller
     tag: v0.16.13
   imagePullPolicy: IfNotPresent
-
   extraEnv: []
   # - name: EXTRA_ENV_VAR
   #   value: "extra_env_var_value"
-
   logLevel: info
   priorityClassName: ""
   tolerations: []

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1872,7 +1872,7 @@ clusterController:
     tag: v0.16.13
   imagePullPolicy: IfNotPresent
 
-  # extraEnv:
+  extraEnv: []
   # - name: EXTRA_ENV_VAR
   #   value: "extra_env_var_value"
 


### PR DESCRIPTION
## What does this PR change?
add extraEnv config for clusterController and add already present logLevel in helm Values

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will be able to add extra Env and log level for cluster Controller deployment

## Links to Issues or tickets this PR addresses or fixes
NA
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
Helm template:
1. Setting log level without `extraEnv`
```yaml
# Source: cost-analyzer/templates/kubecost-cluster-controller-template.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cost-analyzer-cluster-controller
  namespace: default
  labels:
    ...
  annotations:
spec:
   ...
    spec:
      securityContext:
        ...
      containers:
      - name: cost-analyzer-cluster-controller
        image: gcr.io/kubecost1/cluster-controller:v0.16.13
        imagePullPolicy: IfNotPresent
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          privileged: false
          readOnlyRootFilesystem: true
        volumeMounts:
        - name: cluster-controller-keys
          mountPath: /var/keys
        env:
        ...
        - name: CC_LOG_LEVEL
          value: debug
        ...
        ports:
        - name: http-server
          containerPort: 9731
          hostPort: 9731
        resources:
            {}
      serviceAccount: cost-analyzer-cluster-controller
      serviceAccountName: cost-analyzer-cluster-controller
      volumes:
      ...
```
2. Setting logLevel and setting extraEnv
```yaml
# Source: cost-analyzer/templates/kubecost-cluster-controller-template.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cost-analyzer-cluster-controller
  namespace: default
  labels:
    ...
  annotations:
spec:
  ...
      containers:
      - name: cost-analyzer-cluster-controller
        image: gcr.io/kubecost1/cluster-controller:v0.16.13
        imagePullPolicy: IfNotPresent
        securityContext:
         ...
        volumeMounts:
        ...
        env:
        ...
        - name: CC_LOG_LEVEL
          value: debug
        - name: CC_KUBESCALER_COST_MODEL_PATH
          value: http://cost-analyzer.default:9090/model
        - name: CC_CCL_COST_MODEL_PATH
          value: http://cost-analyzer.default:9090/model
        - name: EXTRA_ENV_VAR
          value: extra_env_var_value
        - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
          value: "false"
        ports:
        - name: http-server
          containerPort: 9731
          hostPort: 9731
        resources:
            {}
      serviceAccount: cost-analyzer-cluster-controller
      serviceAccountName: cost-analyzer-cluster-controller
      volumes:
      ...
```
## Have you made an update to documentation? If so, please provide the corresponding PR.

