### PR TITLE
Removes ALLOCATION_NODE_LABELS_INCLUDE_LIST and associated values.yaml option so all node labels get populated in the allocation workload

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -979,8 +979,6 @@ spec:
             {{- with .Values.kubecostModel.allocation.nodeLabels }}
             - name: ALLOCATION_NODE_LABELS_ENABLED
               value: {{ (quote .enabled) | default (quote true) }}
-            - name: ALLOCATION_NODE_LABELS_INCLUDE_LIST
-              value: {{ (quote .includeList) }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -673,11 +673,10 @@ kubecostModel:
 
   allocation:
     # Enables or disables adding node labels to allocation data (i.e. workloads).
-    # Defaults to "true" and starts with a sensible includeList for basics like
-    # topology (e.g. zone, region) and instance type labels.
+    # Defaults to "true". If nodeLabels is set to true, all workloads will inherit
+    # the node labels of the nodes they are running on.
     # nodeLabels:
     #   enabled: true
-    #   includeList: "node.kubernetes.io/instance-type,topology.kubernetes.io/region,topology.kubernetes.io/zone"
 
   # Enables or disables the ContainerStats pipeline, used for quantile-based
   # queries like for request sizing recommendations.


### PR DESCRIPTION
## What does this PR change?
Removes ALLOCATION_NODE_LABELS_INCLUDE_LIST helm value and associated values.yaml example

## Does this PR rely on any other PRs?
OC PR https://github.com/opencost/opencost/pull/3061

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Allocation bingen will have all the node labels on which the workload resides for all workload rather than a predetermined set of node labels that was configurable.

## Links to Issues or tickets this PR addresses or fixes
https://apptio.atlassian.net/browse/KCM-3403
<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
No risk.

## How was this PR tested?
Refer OC PR

## Have you made an update to documentation? If so, please provide the corresponding PR.
No
