### PR TITLE
[KCM-3289] Collections 3.0: Add /query/chargeback/total and /timeseries

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -896,6 +896,22 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/collections/query/chargeback/total {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/collections/query/chargeback/total;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/collections/query/chargeback/timeseries {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/collections/query/chargeback/timeseries;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/collection/cache/status {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/collection/cache/status;


### PR DESCRIPTION
## What does this PR change?
Add new nginx routes:
- `/model/collections/query/chargeback/total`
- `/model/collections/query/chargeback/timeseries`

## Does this PR rely on any other PRs?
- KCM: https://github.com/kubecost/kubecost-cost-model/pull/3122
- kc-core: https://github.com/kubecost/kubecost-core/pull/109


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Collections 3.0: Support for chargeback APIs

## Links to Issues or tickets this PR addresses or fixes
https://apptio.atlassian.net/browse/KCM-3289

## What risks are associated with merging this PR? What is required to fully test this PR?
N/A

## How was this PR tested?
N/A

## Have you made an update to documentation? If so, please provide the corresponding PR.
TBD
