### PR TITLE
add category/chargeback nginx routes

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -912,6 +912,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/category/chargeback {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/category/chargeback;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/kubernetes/containers/resources {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/kubernetes/containers/resources;


### PR DESCRIPTION
## What does this PR change?
New nginx routes for category sorting for collections 3.0 work

## Does this PR rely on any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/3114
* https://github.com/kubecost/kubecost-core/pull/107

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Category sorting capabilities for collections 3.0

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->
https://apptio.atlassian.net/browse/KCM-3288


## What risks are associated with merging this PR? What is required to fully test this PR?
None, these endpoints are new

## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

