### PR TITLE
KCM-3462: allow user to provide custom labels to append each provider's default nodegroup label using helm to identify nodegroups in their setup 

### DIFF
--- a/cost-analyzer/templates/savings-recommendations-nodegroup-config-map-template.yaml
+++ b/cost-analyzer/templates/savings-recommendations-nodegroup-config-map-template.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.kubecostProductConfigs }}
+{{- if .Values.kubecostProductConfigs.savingsRecommendationsNodegroupCustomLabels }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "savings-recommendations-nodegroup-custom-labels"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  nodegroup-custom-labels.json: '{{ toJson .Values.kubecostProductConfigs.savingsRecommendationsNodegroupCustomLabels }}'
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2379,6 +2379,10 @@ costEventsAudit:
 #     AWS: []
 #     GCP: []
 #     Azure: []
+#   savingsRecommendationsNodegroupCustomLabels: # Define select list of label that are used to identify nodegroups.
+#     AWS: []
+#     GCP: []
+#     Azure: []
 
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain
   ## a key with name `cloud-integration.json` and the contents must be in a specific format. It is expected

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2379,7 +2379,7 @@ costEventsAudit:
 #     AWS: []
 #     GCP: []
 #     Azure: []
-#   savingsRecommendationsNodegroupCustomLabels: # Define select list of label that are used to identify nodegroups.
+#   savingsRecommendationsNodegroupCustomLabels: # Define select list of labels to be used to identify node groups
 #     AWS: []
 #     GCP: []
 #     Azure: []


### PR DESCRIPTION
## What does this PR change?
savings-recommendations-nodegroup-custom-labels configmap to provide list of labels to identify in env not following the default install. This is an availability for customer to allow labels that identify nodegroup in their setup for AWS,Azure and GCP providers

## Does this PR rely on any other PRs?
KCM PR: https://github.com/kubecost/kubecost-cost-model/pull/3134

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
They have ability to identify nodegroup for nodegroup recommendation in setup that does not follow conventional CSP managed clusters.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
NONE

## How was this PR tested?
Refer KCM PR

## Have you made an update to documentation? If so, please provide the corresponding PR.
No
