### PR TITLE
[KCM-3366] Restrict CORS headers

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -153,6 +153,8 @@ data:
         root /var/www;
         index index.html;
 
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Methods;
         {{- range .Values.kubecostFrontend.nginxHeaders.server }}
         add_header {{ . }}
         {{- end }}


### PR DESCRIPTION
## What does this PR change?
Introduce proxy_hide_header directives at the root of the NGINX configuration to remove CORS headers from upstream services.

Some Opencost endpoints set fully open CORS headers in the application code (e.g. Access-Control-Allow-Origin: *). This is not maximally secure, and undesirable for the Kubecost application. Modifying the upstream project, Opencost, would cause a breaking behavioral change, potentailly inconveniencing others who leverage Opencost.

The approach taken here is to remove all Access-Control-Allow-Origin and Access-Control-Allow-Method headers from all upstream services at the NGINX level, and then optionally re-insert more secure headers, depending on how the Helm values are configured.

By default, Kubecost will apply fully-open CORS to all proxied endpoints. The values file can be used to set more restrictive CORS, or eliminate CORS altogether, resulting in same-domain data access only. This approach:

* Requires no changes to Opencost
* Keeps the default behavior of Kubecost the same
* Allows Kubecost users to fully control the application's CORS policy via Helm values


## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Allows users to fully control the permissiveness of Kubecost's CORS configuration.

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->

- Closes https://apptio.atlassian.net/browse/KCM-3366


## What risks are associated with merging this PR? What is required to fully test this PR?
The biggest risk is that the application relies on fully open CORS configurations for a service in some way that I'm not aware of. Because CORS applies only to browsers, and not inter-application network traffic, I doubt this is the case.

## How was this PR tested?

Clicked around the application with CORS disabled and saw that it functioned normally.

### API request on my test instance (No CORS Headers)
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/286d65a9-3f32-4d95-aeff-bac676cc0cbd" />

### API request on aggregator.nightly (see permissive CORS headers)
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/c8859192-b0fd-4625-9500-a67ad80a19fb" />


## Have you made an update to documentation? If so, please provide the corresponding PR.
I have not. I don't think one is needed.

