### PR TITLE
Fix teams configmap from values

### DIFF
--- a/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
+++ b/cost-analyzer/templates/kubecost-rbac-teams-configmap-template.yaml
@@ -8,6 +8,6 @@ metadata:
   labels:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
-  rbac-teams-configs.json: '{{ toJson .Values.rbacTeams.teamsConfig }}'
+  rbac-teams-configs.json: '{{ toJson .Values.teams.teamsConfig }}'
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What does this PR change?
Fixes issue where if `teams.teamsConfig` was set, the configmap would not be properly created.

## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fix an issue with `teamsConfig` not properly creating a configmap.

## Links to Issues or tickets this PR addresses or fixes



## What risks are associated with merging this PR? What is required to fully test this PR?
None.

## How was this PR tested?
Tested by deploying helm chart with change and without `teams.teamsConfig` and seeing the configmap be properly created.

## Have you made an update to documentation? If so, please provide the corresponding PR.
No, not needed.
