### PR TITLE
Prevent installing Grafana dashboards when Grafana is disabled

### DIFF
--- a/cost-analyzer/templates/grafana/grafana-dashboard-attached-disks.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-attached-disks.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   attached-disks.json: |-
 {{- .Files.Get "grafana-dashboards/attached-disks.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-cluster-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-cluster-metrics-template.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   cluster-metrics.json: |-
 {{- .Files.Get "grafana-dashboards/cluster-metrics.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-cluster-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-cluster-utilization-template.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   cluster-utilization.json: |-
 {{- .Files.Get "grafana-dashboards/cluster-utilization.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-deployment-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-deployment-utilization-template.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   deployment-utilization.json: |-
 {{- .Files.Get "grafana-dashboards/deployment-utilization.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   kubernetes-resource-efficiency.json: |-
 {{- .Files.Get "grafana-dashboards/kubernetes-resource-efficiency.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-label-cost-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-label-cost-utilization-template.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   label-cost-utilization.json: |-
 {{- .Files.Get "grafana-dashboards/label-cost-utilization.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-namespace-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-namespace-utilization-template.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   namespace-utilization.json: |-
 {{- .Files.Get "grafana-dashboards/namespace-utilization.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-network-cloud-sevices.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-network-cloud-sevices.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   grafana-network-cloud-services.json: |-
 {{- .Files.Get "grafana-dashboards/network-cloud-services.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-network-costs.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-network-costs.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   networkCosts-metrics.json: |-
 {{- .Files.Get "grafana-dashboards/networkCosts-metrics.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-node-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-node-utilization-template.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   node-utilization.json: |-
 {{- .Files.Get "grafana-dashboards/node-utilization.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-pod-utilization-multi-cluster.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-pod-utilization-multi-cluster.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   pod-utilization-multi-cluster.json: |-
 {{- .Files.Get "grafana-dashboards/pod-utilization-multi-cluster.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-pod-utilization-template.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-pod-utilization-template.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   pod-utilization.json: |-
 {{- .Files.Get "grafana-dashboards/pod-utilization.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-prometheus-metrics-template.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-prometheus-metrics-template.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   prom-benchmark.json: |-
 {{- .Files.Get "grafana-dashboards/prom-benchmark.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-workload-aggregator.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-workload-aggregator.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   workload-metrics-aggregator.json: |-
 {{- .Files.Get "grafana-dashboards/workload-metrics-aggregator.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/grafana/grafana-dashboard-workload-metrics.yaml
+++ b/cost-analyzer/templates/grafana/grafana-dashboard-workload-metrics.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (include "cost-analyzer.grafanaEnabled" .) "true") }}
 {{- if (((.Values.grafana).sidecar).dashboards).enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,4 +19,5 @@ metadata:
 data:
   grafana-workload-metrics.json: |-
 {{- .Files.Get "grafana-dashboards/workload-metrics.json" | nindent 4 }}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?

Prevents installation of Grafana dashboards when Grafana has been disabled.

## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Makes a Kubecost installation more efficient, particularly when Kubecost is installed on secondary clusters (agent only) in a federated architecture.

## Links to Issues or tickets this PR addresses or fixes

Closes KCM-3478


## What risks are associated with merging this PR? What is required to fully test this PR?

The risk is some users may somehow prefer or depend on Grafana dashboards being installed even when Grafana itself is not.

## How was this PR tested?

Installed Kubecost and set the value `global.grafana.enabled` to `false` and checked that no Grafana-related ConfigMaps were installed.


## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A

