### PR TITLE
bump kubecost-network-costs 0.17.8, bump kubecost-modeling 0.1.23

### DIFF
--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -20,12 +20,12 @@ kubecostModel:
 forecasting:
   image:
     repository: public.ecr.aws/kubecost/kubecost-modeling
-    tag: v0.1.19
+    tag: v0.1.23
 
 networkCosts:
   image:
     repository: public.ecr.aws/kubecost/kubecost-network-costs
-    tag: v0.17.6
+    tag: v0.17.8
 
 clusterController:
   image:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1429,7 +1429,7 @@ networkCosts:
   enabled: false
   image:
     repository: gcr.io/kubecost1/kubecost-network-costs
-    tag: v0.17.6
+    tag: v0.17.8
   imagePullPolicy: IfNotPresent
   updateStrategy:
     type: RollingUpdate
@@ -1553,7 +1553,7 @@ forecasting:
   fullImageName: ""
   image:
     repository: gcr.io/kubecost1/kubecost-modeling
-    tag: v0.1.22
+    tag: v0.1.23
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.


### PR DESCRIPTION
## What does this PR change?
kubecost-modeling:v0.1.22 to v0.1.23 fixes:
Base Image Vulnerabilities ():
  HIGH: 2 vulnerabilities
    - openssl 1:3.2.2-6.el9_5 (CVE-2024-12797)
    - openssl-libs 1:3.2.2-6.el9_5 (CVE-2024-12797) MEDIUM: 5 vulnerabilities
    - bzip2-libs 1.0.8-8.el9 (CVE-2019-12900)
    - libgcc 11.5.0-2.el9 (CVE-2020-11023)
    - libgomp 11.5.0-2.el9 (CVE-2020-11023)
    - libstdc++ 11.5.0-2.el9 (CVE-2020-11023)
    - libxml2 2.9.13-6.el9_4 (CVE-2022-49043)

kubecost-network-costs:v0.17.6 to v01.17.8 fixes:
Base Image Vulnerabilities ():
  HIGH: 2 vulnerabilities
    - libcrypto3 3.3.2-r0 (CVE-2024-12797)
    - libssl3 3.3.2-r0 (CVE-2024-12797) LOW: 2 vulnerabilities
    - libcrypto3 3.3.2-r0 (CVE-2024-9143)
    - libssl3 3.3.2-r0 (CVE-2024-9143) MEDIUM: 6 vulnerabilities
    - glibc 2.40-r1 (CVE-2025-0395)
    - glibc-locale-posix 2.40-r1 (CVE-2025-0395)
    - ld-linux 2.40-r1 (CVE-2025-0395)
    - libcrypt1 2.40-r1 (CVE-2025-0395)
    - libcrypto3 3.3.2-r0 (CVE-2024-13176)
    - libssl3 3.3.2-r0 (CVE-2024-13176)


## Does this PR rely on any other PRs?
NA

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
NA

## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?
NA

## How was this PR tested?
NA

## Have you made an update to documentation? If so, please provide the corresponding PR.
NA
