### PR TITLE
Bump cluster-controller to v0.16.14

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1867,7 +1867,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.13
+    tag: v0.16.14
   imagePullPolicy: IfNotPresent
   extraEnv: []
   # - name: EXTRA_ENV_VAR


### PR DESCRIPTION
## What does this PR change?

Bumps cluster-controller to v0.16.14

Most importantly the newest images of cluster-controller, kubecost-modeling, and network-costs are now built on top of the ubi9-minimal base image. Bumps to kubecost-modeling and network-costs were performed in https://github.com/kubecost/cost-analyzer-helm-chart/pull/3912

```sh
$ trivy image registry.access.redhat.com/ubi9-minimal:latest
2025-03-03T10:19:58-08:00	INFO	[vuln] Vulnerability scanning is enabled
2025-03-03T10:19:58-08:00	INFO	[secret] Secret scanning is enabled
2025-03-03T10:19:58-08:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-03-03T10:19:58-08:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.59/docs/scanner/secret#recommendation for faster secret detection
2025-03-03T10:20:00-08:00	INFO	Detected OS	family="redhat" version="9.5"
2025-03-03T10:20:00-08:00	INFO	[redhat] Detecting RHEL/CentOS vulnerabilities...	os_version="9" pkg_num=105
2025-03-03T10:20:00-08:00	INFO	Number of language-specific files	num=1
2025-03-03T10:20:00-08:00	INFO	[gobinary] Detecting vulnerabilities...
2025-03-03T10:20:00-08:00	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.59/docs/scanner/vulnerability#severity-selection for details.

gcr.io/kubecost1/cluster-controller:v0.16.14 (redhat 9.5)

Total: 44 (UNKNOWN: 0, LOW: 31, MEDIUM: 11, HIGH: 2, CRITICAL: 0
```

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

N/A

## How was this PR tested?

The new cluster-controller image was independently tested on a cluster. Test results here: https://github.com/kubecost/cluster-controller/pull/171. It will undergo further testing in nightly environments.

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A
