### PR TITLE
Set runAsUser=0 for network-costs daemonset

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -116,7 +116,8 @@ spec:
           name: network-costs-config
         {{- end }}
         securityContext:
-          privileged: true
+          privileged: true  # Required
+          runAsUser: 0  # Required
         {{- if .Values.networkCosts.additionalSecurityContext }}
         {{- toYaml .Values.networkCosts.additionalSecurityContext | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
## What does this PR change?

By default, sets `runAsUser: 0` for the network-costs daemonset.

Historically, the network-costs image has always set `USER 0` at build time. However with the update to `gcr.io/kubecost1/kubecost-network-costs:v0.17.8` (https://github.com/kubecost/cost-analyzer-helm-chart/pull/3912, [release v0.17.8](https://github.com/kubecost/network-costs-rs/releases/tag/v0.17.8)) the image now sets `USER 1001` at build time to comply with image registry requirements. Therefore, we have to override back to 0 in the k8s spec.

I'm open to feedback as to whether we should make this value configurable via `values.yaml`. Seeing as to how the `privileged: true` was never configurable, I believe it should be ok to follow precedent and apply this as a non-configurable default. Open to changing this in the future.

Without the `runAsUser: 0` override:

```txt
INFO network_costs_rs: Starting Kubernetes Network Map...
INFO network_costs_rs::network::monitor: Initializing Watcher with 5s interval
INFO network_costs_rs::network::watcher: Network Watcher Starting...
INFO network_costs_rs: Starting HTTP Server...
ERROR network_costs_rs::conntrack::tracer: Failed to parse conntrack flows: netlink error: Nlmsgerr(Nlmsgerr { error: -1, nlmsg: NlmsghdrErr { nl_len: 20, nl_type: Conntrack, nl_flags: NlmFFlags(FlagBuffer(769, PhantomData<neli::consts::nl::NlmF>)), nl_seq: 0, nl_pid: 0, nl_payload: Genlmsghdr { cmd: 0, version: 0, reserved: 0, header: NoUserHeader, attrs: GenlBuffer(]) } } })
INFO network_costs_rs::network::watcher: Processed 0 Connection Entries
ERROR network_costs_rs::conntrack::tracer: Failed to parse conntrack flows: netlink error: Nlmsgerr(Nlmsgerr { error: -1, nlmsg: NlmsghdrErr { nl_len: 20, nl_type: Conntrack, nl_flags: NlmFFlags(FlagBuffer(769, PhantomData<neli::consts::nl::NlmF>)), nl_seq: 0, nl_pid: 0, nl_payload: Genlmsghdr { cmd: 0, version: 0, reserved: 0, header: NoUserHeader, attrs: GenlBuffer(]) } } })
```

With the `runAsUser: 0` override:

```txt
INFO network_costs_rs: Starting Kubernetes Network Map...
INFO network_costs_rs::network::monitor: Initializing Watcher with 5s interval
INFO network_costs_rs::network::watcher: Network Watcher Starting...
INFO network_costs_rs: Starting HTTP Server...
INFO network_costs_rs::network::watcher: Processed 3272 Connection Entries
INFO network_costs_rs::network::watcher: Processed 3306 Connection Entries
INFO network_costs_rs::network::watcher: Processed 3326 Connection Entries
INFO network_costs_rs::network::watcher: Processed 3268 Connection Entries
INFO network_costs_rs::network::watcher: Processed 3068 Connection Entries
INFO network_costs_rs::network::watcher: Processed 2882 Connection Entries
INFO network_costs_rs::network::watcher: Processed 2878 Connection Entries
```

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

If running the network-costs daemonset, default to `runAsUser: 0`.

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

N/A

## How was this PR tested?

Manually set `runAsUser: 0` in a nightly environment's k8s spec. Saw successful logs as shown above.

## Have you made an update to documentation? If so, please provide the corresponding PR.

This doc already outlines the permissions required by network-costs https://docs.kubecost.com/install-and-configure/advanced-configuration/network-costs-configuration#permissions