### PR TITLE
CP 2.6 Bump grafana/grafana from 11.5.1 to 11.5.2 in /cost-analyzer

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2076,7 +2076,7 @@ grafana:
     failureThreshold: 10
   image:
     repository: grafana/grafana
-    tag: 11.4.0
+    tag: 11.5.2
     pullPolicy: IfNotPresent
     # pullSecrets:
   securityContext: {}


### PR DESCRIPTION
Bumps grafana/grafana from 11.5.1 to 11.5.2.

---
updated-dependencies:
- dependency-name: grafana/grafana
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

## What does this PR change?


## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)


## Links to Issues or tickets this PR addresses or fixes

<!--
Please use GithHub's closing keywords to link to any issue(s) this PR addresses. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue how to use closing keywords.
-->



## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?


## Have you made an update to documentation? If so, please provide the corresponding PR.

