### PR TITLE
Add master API key for auth integrations

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1434,7 +1434,11 @@ Groups is only used when using simple RBAC.
     {{- if or (.Values.saml).apiMasterKey (.Values.oidc).apiMasterKey -}}
         {{- printf "true" -}}
       {{- else -}}
-        {{- printf "false" -}}
+        {{- if or (.Values.saml).apiMasterKeySecret (.Values.oidc).apiMasterKeySecret -}}
+          {{- printf "true" -}}
+        {{- else -}}
+          {{- printf "false" -}}
+        {{- end -}}
     {{- end -}}
   {{- else -}}
     {{- printf "false" -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1432,13 +1432,13 @@ Groups is only used when using simple RBAC.
 {{- define "authMasterKeyEnabled" -}}
   {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
     {{- if or (.Values.saml).apiMasterKey (.Values.oidc).apiMasterKey -}}
+      {{- printf "true" -}}
+    {{- else -}}
+      {{- if or (.Values.saml).apiMasterKeySecret (.Values.oidc).apiMasterKeySecret -}}
         {{- printf "true" -}}
       {{- else -}}
-        {{- if or (.Values.saml).apiMasterKeySecret (.Values.oidc).apiMasterKeySecret -}}
-          {{- printf "true" -}}
-        {{- else -}}
-          {{- printf "false" -}}
-        {{- end -}}
+        {{- printf "false" -}}
+      {{- end -}}
     {{- end -}}
   {{- else -}}
     {{- printf "false" -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1018,6 +1018,10 @@ Begin Kubecost 2.0 templates
     - name: kubecost-rbac-secret
       mountPath: /var/configs/kubecost-rbac-secret
     {{- end }}
+    {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+    - name: kubecost-master-api-key
+      mountPath: /var/configs/auth
+    {{- end }}
     {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
     - name: kubecost-rbac-teams-config
       mountPath: /var/configs/rbac-teams-configs
@@ -1187,6 +1191,10 @@ Begin Kubecost 2.0 templates
     - name: SAML_RBAC_TEAMS_ENABLED
       value: "true"
     {{- end }}
+    {{- end }}
+    {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+    - name: AUTH_MASTER_API_KEY_ENABLED
+      value: "true"
     {{- end }}
     {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
     - name: RBAC_TEAMS_HELM_CONFIG_PATH
@@ -1420,6 +1428,18 @@ Groups is only used when using simple RBAC.
         {{- printf "false" -}}
     {{- end }}
 {{- end }}
+
+{{- define "authMasterKeyEnabled" -}}
+  {{- if or (.Values.saml).enabled (.Values.oidc).enabled -}}
+    {{- if or (.Values.saml).apiMasterKey (.Values.oidc).apiMasterKey -}}
+        {{- printf "true" -}}
+      {{- else -}}
+        {{- printf "false" -}}
+    {{- end -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end -}}
+{{- end -}}
 
 {{/*
 Backups configured flag for nginx configmap

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -169,6 +169,11 @@ spec:
           secret:
             secretName: kubecost-rbac-secret
         {{- end }}
+        {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+        - name: kubecost-master-api-key
+          secret:
+            secretName: kubecost-master-api-key
+        {{- end }}
         {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config
           configMap:

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -145,6 +145,11 @@ spec:
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-saml
         {{- end }}
+        {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+        - name: kubecost-master-api-key
+          secret:
+            secretName: {{ .Values.saml.apiMasterKeySecret | default "kubecost-master-api-key" }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.oidc }}
@@ -162,17 +167,17 @@ spec:
           secret:
             secretName: {{ .Values.oidc.existingCustomSecret.name }}
         {{- end }}
+        {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+        - name: kubecost-master-api-key
+          secret:
+            secretName: {{ .Values.oidc.apiMasterKeySecret | default "kubecost-master-api-key" }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if eq (include "rbacTeamsEnabled" .) "true" }}
         - name: kubecost-rbac-secret
           secret:
             secretName: kubecost-rbac-secret
-        {{- end }}
-        {{- if eq (include "authMasterKeyEnabled" .) "true" }}
-        - name: kubecost-master-api-key
-          secret:
-            secretName: kubecost-master-api-key
         {{- end }}
         {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -263,6 +263,11 @@ spec:
           configMap:
             name: {{ template "cost-analyzer.fullname" . }}-saml
         {{- end }}
+        {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+        - name: kubecost-master-api-key
+          secret:
+            secretName: {{ .Values.saml.apiMasterKeySecret | default "kubecost-master-api-key" }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.oidc }}
@@ -280,17 +285,17 @@ spec:
           secret:
             secretName: {{ .Values.oidc.existingCustomSecret.name }}
         {{- end }}
+        {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+        - name: kubecost-master-api-key
+          secret:
+            secretName: {{ .Values.oidc.apiMasterKeySecret | default "kubecost-master-api-key" }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if eq (include "rbacTeamsEnabled" .) "true" }}
         - name: kubecost-rbac-secret
           secret:
             secretName: kubecost-rbac-secret
-        {{- end }}
-        {{- if eq (include "authMasterKeyEnabled" .) "true" }}
-        - name: kubecost-master-api-key
-          secret:
-            secretName: kubecost-master-api-key
         {{- end }}
         {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -287,6 +287,11 @@ spec:
           secret:
             secretName: kubecost-rbac-secret
         {{- end }}
+        {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+        - name: kubecost-master-api-key
+          secret:
+            secretName: kubecost-master-api-key
+        {{- end }}
         {{- if eq (include "rbacTeamsConfigEnabled" .) "true" }}
         - name: kubecost-rbac-teams-config
           configMap:
@@ -757,6 +762,10 @@ spec:
             - name: kubecost-rbac-secret
               mountPath: /var/configs/kubecost-rbac-secret
             {{- end }}
+            {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+            - name: kubecost-master-api-key
+              mountPath: /var/configs/auth
+            {{- end }}
           env:
             - name: CONTAINER_IMAGE_TAG
               value: {{ include "cost-model.imagetag" . }}
@@ -1021,6 +1030,10 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- end }}
+            {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+            - name: AUTH_MASTER_API_KEY_ENABLED
+              value: "true"
             {{- end }}
             {{- if .Values.oidc.enabled }}
             - name: OIDC_ENABLED

--- a/cost-analyzer/templates/kubecost-auth-master-api-key-template.yaml
+++ b/cost-analyzer/templates/kubecost-auth-master-api-key-template.yaml
@@ -1,0 +1,18 @@
+ {{- if eq (include "authMasterKeyEnabled" .) "true" }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: kubecost-master-api-key
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+stringData:
+  master-api-key:
+    {{- if .Values.oidc.enabled }}
+    {{ .Values.oidc.apiMasterKey }}
+    {{- end }}
+    {{- if .Values.saml.enabled }}
+    {{ .Values.saml.apiMasterKey }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
## What does this PR change?
Adds template values that allow mounting/creation of a master API key secret.

## Does this PR rely on any other PRs?


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds ability to configure an API master key secret for use in Kubecost auth integrations.

## Links to Issues or tickets this PR addresses or fixes


## What risks are associated with merging this PR? What is required to fully test this PR?
No risk.

## How was this PR tested?
Tested by deploying to a SAML-enabled kubecost instance and hitting endpoints with the configured secret.

## Have you made an update to documentation? If so, please provide the corresponding PR.

