### PR TITLE
Fix logic for the `/model/multi-cluster-diagnostics-enabled` endpoint.

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1452,10 +1452,10 @@ costEventsAuditEnabled flag for nginx configmap
 {{- end -}}
 
 {{/*
-Mutli-Cluster Diagnostics is only functional when all its components are
-enabled, and when the federated storage config is present.
+Multi-Cluster Diagnostics is only fully functional when its agent and primary
+are both running, and when the federated storage config is present.
 */}}
-{{- define "multi-cluster-diagnostics-enabled" -}}
+{{- define "multiClusterDiagnosticsPrimaryEnabled" -}}
 {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled -}}
   {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig -}}
     {{- printf "true" -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1451,6 +1451,20 @@ costEventsAuditEnabled flag for nginx configmap
   {{- end -}}
 {{- end -}}
 
+{{/*
+Mutli-Cluster Diagnostics is only functional when all its components are
+enabled, and when the federated storage config is present.
+*/}}
+{{- define "multi-cluster-diagnostics-enabled" -}}
+{{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled -}}
+  {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig -}}
+    {{- printf "true" -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "gcpCloudIntegrationJSON" }}
 Kubecost 2.x requires a change to the method that cloud-provider billing integrations are configured.
 Please use this output to create a cloud-integration.json config. See:
@@ -1477,7 +1491,6 @@ for more information
 {{- fail (include "gcpCloudIntegrationJSON" .) }}
 {{- end }}
 {{- end }}
-
 
 {{- define "azureCloudIntegrationJSON" }}
 

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -132,7 +132,7 @@ data:
     }
   {{- end }}
 
-    {{- if and (template "multiClusterDiagnosticsPrimaryEnabled" .) .Values.diagnostics.deployment.enabled }}
+    {{- if and (include "multiClusterDiagnosticsPrimaryEnabled" .) .Values.diagnostics.deployment.enabled }}
     upstream multi-cluster-diagnostics {
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9007;
@@ -1563,7 +1563,7 @@ data:
             return 200 '{"multiClusterDiagnosticsEnabled": {{ template "multiClusterDiagnosticsPrimaryEnabled" . }}}';
         }
 
-        {{- if and (template "multiClusterDiagnosticsPrimaryEnabled" .) .Values.diagnostics.deployment.enabled }}
+        {{- if and (include "multiClusterDiagnosticsPrimaryEnabled" .) .Values.diagnostics.deployment.enabled }}
         # When the Multi-cluster Diagnostics Service is run within the
         # cost-model container, its endpoint is available at the path
         # `/model/diagnostics/multicluster`. No additional Nginx path forwarding

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -132,8 +132,7 @@ data:
     }
   {{- end }}
 
-    {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
-    {{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig }}
+    {{- if and (template "multi-cluster-diagnostics-enabled" .) .Values.diagnostics.deployment.enabled }}
     upstream multi-cluster-diagnostics {
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9007;
@@ -145,7 +144,6 @@ data:
         {{- end }}
         {{- end }}
     }
-    {{- end }}
     {{- end }}
 
     server {
@@ -1562,18 +1560,10 @@ data:
 
         location /model/multi-cluster-diagnostics-enabled {
             default_type 'application/json';
-            {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled }}
-            {{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig }}
-            return 200 '{"multiClusterDiagnosticsEnabled": true}';
-            {{- end }}
-            {{- else }}
-            return 200 '{"multiClusterDiagnosticsEnabled": false}';
-            {{- end }}
+            return 200 '{"multiClusterDiagnosticsEnabled": {{ template "multi-cluster-diagnostics-enabled" . }}}';
         }
 
-        {{- if and .Values.diagnostics.enabled .Values.diagnostics.primary.enabled .Values.diagnostics.deployment.enabled }}
-        {{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig }}
-
+        {{- if and (template "multi-cluster-diagnostics-enabled" .) .Values.diagnostics.deployment.enabled }}
         # When the Multi-cluster Diagnostics Service is run within the
         # cost-model container, its endpoint is available at the path
         # `/model/diagnostics/multicluster`. No additional Nginx path forwarding
@@ -1588,18 +1578,6 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-        # simple alias for support
-        location /mcd {
-            default_type 'application/json';
-            proxy_read_timeout          300;
-            proxy_pass http://multi-cluster-diagnostics/status?window=7d;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        {{- end }}
         {{- end }}
 
         location /model/aggregatorEnabled {

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -132,7 +132,7 @@ data:
     }
   {{- end }}
 
-    {{- if and (template "multi-cluster-diagnostics-enabled" .) .Values.diagnostics.deployment.enabled }}
+    {{- if and (template "multiClusterDiagnosticsPrimaryEnabled" .) .Values.diagnostics.deployment.enabled }}
     upstream multi-cluster-diagnostics {
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "diagnostics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9007;
@@ -1560,10 +1560,10 @@ data:
 
         location /model/multi-cluster-diagnostics-enabled {
             default_type 'application/json';
-            return 200 '{"multiClusterDiagnosticsEnabled": {{ template "multi-cluster-diagnostics-enabled" . }}}';
+            return 200 '{"multiClusterDiagnosticsEnabled": {{ template "multiClusterDiagnosticsPrimaryEnabled" . }}}';
         }
 
-        {{- if and (template "multi-cluster-diagnostics-enabled" .) .Values.diagnostics.deployment.enabled }}
+        {{- if and (template "multiClusterDiagnosticsPrimaryEnabled" .) .Values.diagnostics.deployment.enabled }}
         # When the Multi-cluster Diagnostics Service is run within the
         # cost-model container, its endpoint is available at the path
         # `/model/diagnostics/multicluster`. No additional Nginx path forwarding

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -1,4 +1,5 @@
-{{- if and (template "multi-cluster-diagnostics-enabled" .) .Values.diagnostics.deployment.enabled }}
+{{- if and .Values.diagnostics.enabled .Values.diagnostics.deployment.enabled }}
+{{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig -}}
 
 {{- if eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one" }}
 {{- fail "Error: The 'cluster_id' is set to default 'cluster-one'. Please update so that the diagnostics service can uniquely identify data coming from this cluster." }}
@@ -182,4 +183,5 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.diagnostics.enabled .Values.diagnostics.deployment.enabled }}
-{{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig -}}
+{{- if and (template "multi-cluster-diagnostics-enabled" .) .Values.diagnostics.deployment.enabled }}
 
 {{- if eq .Values.prometheus.server.global.external_labels.cluster_id "cluster-one" }}
 {{- fail "Error: The 'cluster_id' is set to default 'cluster-one'. Please update so that the diagnostics service can uniquely identify data coming from this cluster." }}
@@ -183,5 +182,4 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/diagnostics-service.yaml
+++ b/cost-analyzer/templates/diagnostics-service.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.diagnostics.enabled .Values.diagnostics.deployment.enabled .Values.diagnostics.primary.enabled }}
-{{- if or (not (empty .Values.kubecostModel.federatedStorageConfigSecret )) .Values.kubecostModel.federatedStorageConfig -}}
+{{- if and (template "multi-cluster-diagnostics-enabled" .) .Values.diagnostics.deployment.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,5 +15,4 @@ spec:
   selector:
     {{- include "diagnostics.selectorLabels" . | nindent 4 }}
   type: ClusterIP
-{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/diagnostics-service.yaml
+++ b/cost-analyzer/templates/diagnostics-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (template "multiClusterDiagnosticsPrimaryEnabled" .) .Values.diagnostics.deployment.enabled }}
+{{- if and (include "multiClusterDiagnosticsPrimaryEnabled" .) (eq .Values.diagnostics.deployment.enabled true) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/cost-analyzer/templates/diagnostics-service.yaml
+++ b/cost-analyzer/templates/diagnostics-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (template "multi-cluster-diagnostics-enabled" .) .Values.diagnostics.deployment.enabled }}
+{{- if and (template "multiClusterDiagnosticsPrimaryEnabled" .) .Values.diagnostics.deployment.enabled }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## What does this PR change?

Most importantly, this provides a fix for the `/model/multi-cluster-diagnostics-enabled` endpoint. In environments where a federated-storage-config was not set up, it would result in the following:

```txt
$ helm template nightly nightly/cost-analyzer | grep multi-cluster-diagnostics -A4
        location /model/multi-cluster-diagnostics-enabled {
            default_type 'application/json';
        }
```

Additionally abstracts away re-used logic to a helper function.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

As titled

## Links to Issues or tickets this PR addresses or fixes

N/A

## What risks are associated with merging this PR? What is required to fully test this PR?

Low risk. For a default install, this PR has a tested fix. Continue to run this in nightly environments and monitor.

## How was this PR tested?

### Test 1 (default configs)

```
$ helm template ./cost-analyzer -f mcd.yaml --debug > out.yaml
...
        location /model/multi-cluster-diagnostics-enabled {
            default_type 'application/json';
            return 200 '{"multiClusterDiagnosticsEnabled": false}';
        }
...
            - name: DIAGNOSTICS_RUN_IN_COST_MODEL
              value: "false"
```

### Test 2 (primary configs)

```yaml
kubecostModel:
  federatedStorageConfig: "STORAGE_CONFIG_HERE"
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "MCD_CLUSTER_1"
```

```txt
$ helm template ./cost-analyzer -f mcd.yaml --debug > out.yaml
...
        location /model/multi-cluster-diagnostics-enabled {
            default_type 'application/json';
            return 200 '{"multiClusterDiagnosticsEnabled": true}';
        }
...
            - name: DIAGNOSTICS_RUN_IN_COST_MODEL
              value: "true"
```

### Test 3 (agent configs)

```yaml
kubecostModel:
  federatedStorageConfig: "STORAGE_CONFIG_HERE"
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "MCD_CLUSTER_1"
federatedETL:
  agentOnly: true
```

```txt
$ helm template ./cost-analyzer -f mcd.yaml --debug > out.yaml
...
            - name: DIAGNOSTICS_RUN_IN_COST_MODEL
              value: "true"
```

### Test 4 (agent deployment configs)

```yaml
kubecostModel:
  federatedStorageConfig: "STORAGE_CONFIG_HERE"
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "MCD_CLUSTER_1"
diagnostics:
  deployment:
    enabled: true
```

```txt
$ helm template ./cost-analyzer -f mcd.yaml --debug > out.yaml
...
    upstream multi-cluster-diagnostics {
        server release-name-diagnostics.default:9007;
    }
...
        location /model/multi-cluster-diagnostics-enabled {
            default_type 'application/json';
            return 200 '{"multiClusterDiagnosticsEnabled": true}';
        }
...
        location /model/diagnostics/multicluster {
...
# Source: cost-analyzer/templates/diagnostics-service.yaml
...
# Source: cost-analyzer/templates/diagnostics-deployment.yaml
```

## Have you made an update to documentation? If so, please provide the corresponding PR.

N/A