### PR TITLE
25-image-bumps

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -116,7 +116,8 @@ spec:
           name: network-costs-config
         {{- end }}
         securityContext:
-          privileged: true
+          privileged: true  # Required
+          runAsUser: 0  # Required
         {{- if .Values.networkCosts.additionalSecurityContext }}
         {{- toYaml .Values.networkCosts.additionalSecurityContext | nindent 10 }}
         {{- end }}

--- a/cost-analyzer/values-eks-cost-monitoring.yaml
+++ b/cost-analyzer/values-eks-cost-monitoring.yaml
@@ -18,12 +18,12 @@ kubecostModel:
   image: public.ecr.aws/kubecost/cost-model
 
 forecasting:
-  fullImageName: public.ecr.aws/kubecost/kubecost-modeling:v0.1.19
+  fullImageName: public.ecr.aws/kubecost/kubecost-modeling:v0.1.23
 
 networkCosts:
   image:
     repository: public.ecr.aws/kubecost/kubecost-network-costs
-    tag: v0.17.6
+    tag: v0.17.8
 
 clusterController:
   image:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1383,7 +1383,7 @@ networkCosts:
   enabled: false
   image:
     repository: gcr.io/kubecost1/kubecost-network-costs
-    tag: v0.17.6
+    tag: v0.17.8
   imagePullPolicy: IfNotPresent
   updateStrategy:
     type: RollingUpdate
@@ -1508,7 +1508,7 @@ forecasting:
   # fullImageName overrides the default image construction logic. The exact
   # image provided (registry, image, tag) will be used for the forecasting
   # container.
-  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.19
+  fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.23
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.
@@ -2077,7 +2077,7 @@ grafana:
   sidecar:
     image:
       repository: ghcr.io/kiwigrid/k8s-sidecar
-      tag: 1.28.1
+      tag: 1.29.1
       pullPolicy: IfNotPresent
     resources: {}
     dashboards:


### PR DESCRIPTION
## What does this PR change?
bumps images with CVEs

## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Image bumps for CVEs:
gcr.io/kubecost1/kubecost-modeling:v0.1.23
gcr.io/kubecost1/kubecost-network-costs:v0.17.8
ghcr.io/kiwigrid/k8s-sidecar:1.29.1

## Links to Issues or tickets this PR addresses or fixes
NA

## What risks are associated with merging this PR? What is required to fully test this PR?


## How was this PR tested?
qa-eks3/kc25 
Passing:
- network costs logs (root user changes)
- forecast on allocation works
- grafana sidecar logs normal

## Have you made an update to documentation? If so, please provide the corresponding PR.

