### PR TITLE
add helm flag to allow opt-in to new DB

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1075,6 +1075,10 @@ Begin Kubecost 2.0 templates
     - name: NUM_DB_COPY_CHUNKS
       value: {{ .Values.kubecostAggregator.numDBCopyPartitions | quote }}
     {{- end }}
+    {{- if .Values.kubecostAggregator.useUpgradedDB }}
+    - name: CLICKHOUSE_ENABLED
+      value: "true"
+    {{- end }}
     {{- if .Values.kubecostAggregator.jaeger.enabled }}
     - name: TRACING_URL
       value: "http://localhost:14268/api/traces"

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1075,7 +1075,7 @@ Begin Kubecost 2.0 templates
     - name: NUM_DB_COPY_CHUNKS
       value: {{ .Values.kubecostAggregator.numDBCopyPartitions | quote }}
     {{- end }}
-    {{- if .Values.kubecostAggregator.useUpgradedDB }}
+    {{- if .Values.kubecostAggregator.useDBv3 }}
     - name: CLICKHOUSE_ENABLED
       value: "true"
     {{- end }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1672,7 +1672,7 @@ kubecostAggregator:
 
   # Enable the use of the v3 database (ClickHouse) as the database for the aggregator.
   # the existing database will be migrated if it exists
-  # This is required to be 'true' to use the CSV pricing feature pre kubecost 3.0.0
+  # This is required to be 'true' to use the enterpriseCustomPricing feature prior to kubecost 3.0.0
   # this will not be optional starting in kubecost 3.0.0 and will be removed
   # default: false
   useDBv3: false

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1670,12 +1670,12 @@ kubecostAggregator:
   dbMemoryLimit: 0GB
   dbWriteMemoryLimit: 0GB
 
-  # Enable the use of the upgraded database (ClickHouse) as the database for the aggregator.
+  # Enable the use of the v3 database (ClickHouse) as the database for the aggregator.
   # the existing database will be migrated if it exists
   # This is required to be 'true' to use the CSV pricing feature pre kubecost 3.0.0
   # this will not be optional starting in kubecost 3.0.0 and will be removed
   # default: false
-  useUpgradedDB: false
+  useDBv3: false
 
   # How much data to ingest from the federated store bucket, and how much data
   # to keep in the DB before rolling the data off.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1670,6 +1670,13 @@ kubecostAggregator:
   dbMemoryLimit: 0GB
   dbWriteMemoryLimit: 0GB
 
+  # Enable the use of the upgraded database (ClickHouse) as the database for the aggregator.
+  # the existing database will be migrated if it exists
+  # This is required to be 'true' to use the CSV pricing feature pre kubecost 3.0.0
+  # this will not be optional starting in kubecost 3.0.0 and will be removed
+  # default: false
+  useUpgradedDB: false
+
   # How much data to ingest from the federated store bucket, and how much data
   # to keep in the DB before rolling the data off.
   #


### PR DESCRIPTION
## What does this PR change?
Adds a helm flag to enable opting in to using clickhouse. this will be needed pre-3.0 to run clickhouse so users can use clickhouse features like CSV pricing.

@chipzoller , would love your input as to the ergonomics of this one esp since you are interested in playing around with CSV pricing. This switch will need to be flipped to get CSV pricing working

## Does this PR rely on any other PRs?
no

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
adds a flag that users can optionally leverage in their helm config



## What risks are associated with merging this PR? What is required to fully test this PR?
no risks, is opt-in

## How was this PR tested?
tested via helm template, manually verified rendering was correct

## Have you made an update to documentation? If so, please provide the corresponding PR.
There are comments in values.yaml. I think we deliberately don't want to document this, since it will only be enabled for customers working with Kubecost directly. 

cc @nikovacevic @nik-kc 