### PR TITLE
hide bell by default

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1617,7 +1617,7 @@ data:
                 "hideSpotCommander": "{{ default false ((.Values.kubecostProductConfigs).hideSpotCommander) }}",
                 "hideUnclaimedVolumes": "{{ default false ((.Values.kubecostProductConfigs).hideUnclaimedVolumes) }}",
                 "hideCloudIntegrationsUI": "{{ default false ((.Values.kubecostProductConfigs).hideCloudIntegrationsUI) }}",
-                "hideBellIcon": "{{ default false ((.Values.kubecostProductConfigs).hideBellIcon) }}",
+                "hideBellIcon": "{{ default true ((.Values.kubecostProductConfigs).hideBellIcon) }}",
                 "hideTeams": "{{ default false ((.Values.kubecostProductConfigs).hideTeams) }}"
                 }
             ';

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2386,7 +2386,7 @@ costEventsAudit:
 #   hideSpotCommander: false
 #   hideUnclaimedVolumes: false
 #   hideCloudIntegrationsUI: false
-#   hideBellIcon: false
+#   hideBellIcon: true # deprecated in v2.7. default is true, which hides the bell icon in the top right corner of the UI. The new diagnostics is top level in left nav. Change to false to restore the bell icon.
 #   hideTeams: false
 #   savingsProfiles: # Define custom profiles used in the Right-Size Container Request savings card. Supported parameters are explained in https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=apis-container-request-right-sizing-recommendation-api.
 #     requestSizing:


### PR DESCRIPTION
Signed-off-by: jesse goodier <31039225+jessegoodier@users.noreply.github.com>

Disable bell icon by default - the new diagnostics has easier to undertand information and is in the top level in left nav. 

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers

tested on qa-esk3/kc27

## Links to Issues or Tickets

https://apptio.atlassian.net/browse/KCM-3689

## User Impact and Risks

Disable bell icon by default - the new diagnostics has easier to undertand information and is in the top level in left nav. 

## Testing

tested in qa

## Documentation Updates

added comment to values file