### PR TITLE
set up config persistence correctly

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -969,6 +969,16 @@ Begin Kubecost 2.0 templates
       # This hasn't been observed as a problem in cost-analyzer, likely because
       # of the init container that gives everything under /var/configs 777.
       mountPath: /var/configs/waterfowl
+      {{- if .Values.kubecostAggregator.useDBv3 }}
+      # mount the clickhouse directories on the same PV as the duckdb, 
+      # this way they can seamlessly share the same PV before, during, and after the upgrade
+    - name: aggregator-db-storage
+      mountPath: /var/lib/clickhouse
+      {{- end }}
+    {{- end }}
+    {{- if eq (include "aggregator.deployMethod" .) "singlepod" }}
+    - name: persistent-configs
+      mountPath: /var/lib/clickhouse
     {{- end }}
     {{- if and ((.Values.kubecostProductConfigs).productKey).enabled ((.Values.kubecostProductConfigs).productKey).secretname (eq (include "aggregator.deployMethod" .) "statefulset") }}
     - name: productkey-secret

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -976,7 +976,7 @@ Begin Kubecost 2.0 templates
       mountPath: /var/lib/clickhouse
       {{- end }}
     {{- end }}
-    {{- if eq (include "aggregator.deployMethod" .) "singlepod" }}
+    {{- if and .Values.kubecostAggregator.useDBv3 (eq (include "aggregator.deployMethod" .) "singlepod") }}
     - name: persistent-configs
       mountPath: /var/lib/clickhouse
     {{- end }}


### PR DESCRIPTION
## Release Notes Headline
N/A

## Commentary for Reviewers

configures persistence properly for DBV3. fixes "permission denied for /var/lib/clickhouse" error

## Links to Issues or Tickets

N/A

## User Impact and Risks

low, this change only takes effect if useDBv3 is enabled

## Testing

tested via manual install 

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
