### PR TITLE
[KCM-170] Prevent always deploying a kubecost replica when kubecostDeployment.replicas is explicitly set to 0

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -21,7 +21,7 @@ metadata:
   {{- end }}
 spec:
 {{- if .Values.kubecostDeployment }}
-  replicas: {{ toString .Values.kubecostDeployment.replicas | default 1 | int }}
+  replicas: {{ .Values.kubecostDeployment.replicas }}
 {{- end }}
   selector:
     matchLabels:

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -21,7 +21,7 @@ metadata:
   {{- end }}
 spec:
 {{- if .Values.kubecostDeployment }}
-  replicas: {{ .Values.kubecostDeployment.replicas | default 1 }}
+  replicas: {{ toString .Values.kubecostDeployment.replicas | default 1 | int }}
 {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
## Release Notes Headline
Prevent always deploying a Kubecost replica when `kubecostDeployment.replicas` is explicitly set to 0

## Commentary for Reviewers

Due to Helm treating `0` as "falsey", the idiom `{{ .Values.myValue | default 1 }}` does _not_ behave as the docs claim, where the `default` is used in the case of an _omitted_ value. Explicitly setting `.Values.myValue` to `0` also triggers the default. As a result, it was impossible to actually set the number of deployment replicas to `0`.

Why someone would want to deploy 0 of something is beyond me, but we do have an old customer ticket for it.

This change gets around the odd Helm behavior by casting the input to a string, then piping through the `default` function, and then casting the result back to an `int`.

## Links to Issues or Tickets
- Closes https://apptio.atlassian.net/browse/KCM-170

## User Impact and Risks
I someone is relying on setting 0 replicas to get a single replica, this will break them by causing them to actually deploy 0 replicas.

## Testing
I tested by deploying Kubecost, both with no custom values (resulted in 1 replica) and with a custom value for 0 replicas. The result of the 0-replica deployment is shown here:
<img width="785" alt="image" src="https://github.com/user-attachments/assets/1e3898f1-acf3-44c6-98b6-1af2551a9015" />


## Documentation Updates

I don't believe this should require a docs update.
