### PR TITLE
[KCM-3988] Make CSP more permissive by default

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -555,7 +555,7 @@ kubecostFrontend:
     server:
       - "'Access-Control-Allow-Origin' '*' always;"
       - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
-      - Content-Security-Policy "default-src 'self' 'unsafe-inline' api.userway.org cdn.userway.org api-js.mixpanel.com keyper.kubecost.com; frame-ancestors 'none'; font-src 'self' data:;";
+      - "Content-Security-Policy \"default-src 'self' 'unsafe-inline' http: https: ws: data:; frame-ancestors 'none';\";"
       - Cache-Control "must-revalidate";
 
 # Kubecost Metrics deploys a separate pod which will emit kubernetes specific metrics required


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
Make the default Content-Security-Policy for Kubecost more permissive so as not to break compatibility with old default behaviors. Note that this default errs on the side of flexibility over security. Users running in production are encouraged to harden this setting.

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
A while back, I introduced the notion of a Content Security Policy to Kubecost's nginx config. This is set via the Helm chart.
I tried to make the default behavior as restrictive/secure as possible without breaking any longstanding default behavior. This mostly succeeded, however we have found that the "Switch Context" feature, which allows a UI to point at an arbitrary Kubecost Primary API breaks, because the `connect-src` directive is not set, and the `default-src` directive does not allow fetch requests to target arbitrary hosts. Another issue is that some images which are embedded as `data://` URLs fail to render, because only fonts were allowed to use `data://` schemes.

This change updates the CSP to allow requests on the `https:`, `http:`, `ws:`, and `data:` schemes by default for all request types. We still set `frame-ancestors` to `'none'` to prevent clickjacking attacks.

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Closes https://apptio.atlassian.net/browse/KCM-3988

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
The primary impact is to restore the function of the "Switch Context" feature. This also slightly weakens security of the default CSP, because it is now more permissive. In a future release, in which breaking backwards compatibility is acceptable, I would like to make the CSP secure by default.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
I installed with the changes and performed cross-origin operations.

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
I do not believe any are required.
