### PR TITLE
[KCM-3869] Add route for /categories/query/trends

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -928,6 +928,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+          location = /model/categories/query/trends {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/categories/query/trends;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/collection/cache/status {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/collection/cache/status;


### PR DESCRIPTION
## Release Notes Headline

Collections: New routes for '/categories' APIs.

## Commentary for Reviewers

Add new route for the following Collections API:

- `/categories/query/trends`

## Links to Issues or Tickets

Closes https://apptio.atlassian.net/browse/KCM-3869

Related PRs:
- https://github.com/kubecost/kubecost-core/pull/152
- https://github.com/kubecost/kubecost-cost-model/pull/3317

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A
