### PR TITLE
[KCM-3986] restart cluster controller deployment when there is a change in API key

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1624,6 +1624,7 @@ for more information
   "kubecost-saml-secret-template.yaml"
   "mimir-proxy-configmap-template.yaml"
   "savings-recommendations-allowlists-config-map-template.yaml"
+  "kubecost-cluster-controller-template.yaml"
 -}}
 {{- $checksum := "" -}}
 {{- range $files -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1624,7 +1624,7 @@ for more information
   "kubecost-saml-secret-template.yaml"
   "mimir-proxy-configmap-template.yaml"
   "savings-recommendations-allowlists-config-map-template.yaml"
-  "kubecost-cluster-controller-template.yaml"
+  "kubecost-cluster-controller-secret-template.yaml"
 -}}
 {{- $checksum := "" -}}
 {{- range $files -}}

--- a/cost-analyzer/templates/kubecost-cluster-controller-secret-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-secret-template.yaml
@@ -1,0 +1,14 @@
+{{- if (.Values.clusterController).enabled }}
+{{- if and .Values.clusterController.createClusterControllerSecret .Values.clusterController.kubecostAPIKey }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.clusterController.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  kubecostAPIKey: {{ .Values.clusterController.kubecostAPIKey | b64enc }}
+{{- end }}
+{{- end }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -202,6 +202,7 @@ metadata:
   {{- with .Values.clusterController.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+    checksum/configs: {{ include "configsChecksum" . }}
 spec:
   strategy:
     rollingUpdate:

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -359,17 +359,4 @@ spec:
     targetPort: 9731
   selector:
     app: {{ template "kubecost.clusterControllerName" . }}
----
-{{- if and .Values.clusterController.createClusterControllerSecret .Values.clusterController.kubecostAPIKey }}
-apiVersion: v1
-kind: Secret
-type: Opaque
-metadata:
-  name: {{ .Values.clusterController.secretName }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
-data:
-  kubecostAPIKey: {{ .Values.clusterController.kubecostAPIKey | b64enc }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
## Release Notes Headline
add annotation to restart cluster controller deployment when there is a change in API key
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
Restarts the cluster controller pod when a change in API key.
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-3986
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
minimal 
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Verified using 

`h template cost-analyzer -f /Users/alanrodrigues/clusters/clusters/aws/qa-eks3/controller/helmValues-controller.yaml|grep checksum`
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
