### PR TITLE
[KCM-3870] Add route for /collections/sharing

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -968,6 +968,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/collections/sharing {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/collections/sharing;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/kubernetes/containers/resources {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/kubernetes/containers/resources;


### PR DESCRIPTION
## Release Notes Headline

Collections: New routes for '/collections' APIs.

## Commentary for Reviewers

Add new route for the following Collections API:

- `/collections/sharing`

## Links to Issues or Tickets

Closes https://apptio.atlassian.net/browse/KCM-3870

Related PRs:
- https://github.com/kubecost/kubecost-core/pull/153
- https://github.com/kubecost/kubecost-cost-model/pull/3326

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A
