### PR TITLE
bump modeling for cve fix

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1550,7 +1550,7 @@ forecasting:
   fullImageName: ""
   image:
     repository: gcr.io/kubecost1/kubecost-modeling
-    tag: v0.1.25
+    tag: v0.1.26
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -23567,7 +23567,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: forecasting
-          image: gcr.io/kubecost1/kubecost-modeling:v0.1.24
+          image: gcr.io/kubecost1/kubecost-modeling:v0.1.26
           volumeMounts:
             - name: tmp
               mountPath: /tmp


### PR DESCRIPTION
Signed-off-by Cliff Colvin<clifford.colvin@ibm.com>

## Release Notes Headline

## Image Comparison Report
### Comparing images: gcr.io/kubecost1/kubecost-modeling:v0.1.25 and gcr.io/kubecost1/kubecost-modeling:v0.1.26

### CVE by Severity

| Severity | Count | Prev Count | Difference |
|---------|---------|---------|---------|
| critical | 0 | 1 | -1 |
| high | 0 | 0 | +0 |
| medium | 15 | 15 | +0 |
| low | 37 | 37 | +0 |

### Unchanged CVEs

#### Medium
| CVE ID | Severity | Affected Images |
|--------|----------|------------------|
| medium | medium | CVE-2025-32414, CVE-2023-30571, CVE-2024-12243, CVE-2024-12133, CVE-2025-24528, CVE-2021-3997, CVE-2025-0938, CVE-2025-25724, CVE-2025-0395, CVE-2022-4899, CVE-2024-52533, CVE-2025-3576 |

#### Low
| CVE ID | Severity | Affected Images |
|--------|----------|------------------|
| low | low | CVE-2025-1632, CVE-2024-9681, CVE-2024-56433, CVE-2025-0725, CVE-2023-4156, CVE-2025-1795, CVE-2023-2953, CVE-2025-32415, CVE-2023-36191, CVE-2023-45918, CVE-2023-45322, CVE-2025-30258, CVE-2024-7264, CVE-2025-3360, CVE-2022-3219, CVE-2022-41409, CVE-2024-11053, CVE-2024-41996, CVE-2022-29458, CVE-2023-50495, CVE-2024-0397, CVE-2025-27113, CVE-2022-27943, CVE-2024-34459, CVE-2023-32636, CVE-2024-0232 |
### Added CVEs

No new vulnerabilities found.

### Removed CVEs

#### Critical
| CVE ID | Severity | Affected Images |
|--------|----------|------------------|
| critical | critical | CVE-2025-43859 |

## Commentary for Reviewers

Contains no functional changes just dependency bump for critical cve

## Links to Issues or Tickets

N/A

## User Impact and Risks

N/A

## Testing

Locally

## Documentation Updates

N/A