### PR TITLE
bump cluster-controller to v0.16.18

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1868,7 +1868,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.17
+    tag: v0.16.18
   imagePullPolicy: IfNotPresent
   extraEnv: []
   # - name: EXTRA_ENV_VAR


### PR DESCRIPTION
Signed-off-by: jesse goodier <31039225+jessegoodier@users.noreply.github.com>

cluster controller: fix-cve-2025-22871-cve-2025-22872 by @cliffcolvin in #207
cluster controler: [KCM-3986] fixes log message for 500 and add info log with API key redacted by @avrodrigues5 in #211

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

low impact and risk

## Testing

running on controleler NS in qa-eks3

log:

```
INF Recommendation service CheckAvailable() GET finished apiKey=mMH1pTXXXX status=200 url=https://saml-...
```

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->


[KCM-3986]: https://apptio.atlassian.net/browse/KCM-3986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ