### PR TITLE
cancel-in-progress action on chart test

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -10,6 +10,9 @@ on:
   #   branches:
   #     - develop
 
+# Prevents multiple runs of the same workflow on the same branch from executing 
+# simultaneously. Saves resources.
+# Ref: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -10,6 +10,10 @@ on:
   #   branches:
   #     - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-chart:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will kill the running test when branch changes are made.
That test wastes time and resources given there is no value to testing something that has already been updated.

Running test now in actions.