### PR TITLE
remove pvc from test

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -1,4 +1,4 @@
-name: Chart build
+name: Chart build and test
 
 on:
   workflow_dispatch: {}
@@ -238,8 +238,8 @@ jobs:
         working-directory: ./cost-analyzer
         run: |
           helm install --wait --wait-for-jobs kubecost . -n kubecost -f values-eks-cost-monitoring.yaml \
-          --set persistentVolume.storageClass=gp2 \
-          --set prometheus.server.persistentVolume.storageClass=gp2
+          --set persistentVolume.enabled=false \
+          --set prometheus.server.persistentVolume.enabled=false
         # run: ct install --namespace kubecost --chart-dirs=cost-analyzer/ --charts cost-analyzer/
       - name: Wait for ready 
         run: kubectl wait -n kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=120s


### PR DESCRIPTION
edit chart test to remove pvc requirement for eks due to current failures.
NA on release notes.
test: https://github.com/kubecost/cost-analyzer-helm-chart/actions/runs/14846038124

issue: 
<img width="926" alt="image" src="https://github.com/user-attachments/assets/d67595e1-b4cb-4120-a267-3388939214b4" />

I deployed a replicated cluster and found that there are no SC. which we really don't need for this test anyway.

Signed-off-by: jesse goodier <31039225+jessegoodier@users.noreply.github.com>