### PR TITLE
Nginx route for new Container request right sizing report as well as reading configmap for new report similar to other reports

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-container-request-rightsizing-reports-configmap.yaml
+++ b/cost-analyzer/templates/cost-analyzer-container-request-rightsizing-reports-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.containerRequestRightSizingReports }}
+{{- if .Values.global.containerRequestRightSizingReports.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ default "crrs-configs" .Values.containerRequestRightSizingReportConfigmapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  crrs-reports.json: '{{ toJson .Values.global.containerRequestRightSizingReports.reports }}'
+{{- end -}}
+{{- end -}}
+

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -776,6 +776,10 @@ spec:
             - name: CLOUD_COST_REPORT_CONFIGMAP_NAME
               value: {{ .Values.cloudCostReportConfigmapName }}
             {{- end }}
+             {{- if .Values.containerRequestRightSizingReportConfigmapName }}
+            - name: CONTAINER_REQUEST_RIGHTSIZING_REPORT_CONFIGMAP_NAME
+              value: {{ .Values.containerRequestRightSizingReportConfigmapName }}
+            {{- end }}
             {{- if .Values.savedReportConfigmapName }}
             - name: SAVED_REPORT_CONFIGMAP_NAME
               value: {{ .Values.savedReportConfigmapName }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -765,6 +765,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/reports/containerRequestRightSizing {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/reports/containerRequestRightSizing;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/reports/group {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/reports/group;


### PR DESCRIPTION
## Release Notes Headline
Container Request Right-Sizing Report Endpoint Routes to Aggregator Pod and Container Request Right-Sizing Report creation via Helm
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers

- Similar to other reports end point routes needed and fixed in this PR
- Similar to other report helm value creation of Container request right sizing report is fixed in this PR.
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-3908
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
None but they will be able to create Container request right sizing report similar to other reports
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Please refer [KCM PR ](https://github.com/kubecost/kubecost-cost-model/pull/3331)
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
