### PR TITLE
update develop branch

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: development
 description: Kubecost Helm chart - monitor your cloud costs!
 name: cost-analyzer
-version: 2.3.3
+version: 0.0.0
 icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
 annotations:
   "artifacthub.io/links": |

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -9,14 +9,13 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
 ---
-# Source: cost-analyzer/templates/grafana-serviceaccount.yaml
+# Source: cost-analyzer/templates/grafana/grafana-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -27,7 +26,7 @@ metadata:
   name: kubecost-grafana
   namespace: kubecost
 ---
-# Source: cost-analyzer/templates/prometheus-server-serviceaccount.yaml
+# Source: cost-analyzer/templates/prometheus/prometheus-server-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -39,7 +38,7 @@ metadata:
   name: kubecost-prometheus-server
   namespace: kubecost
 ---
-# Source: cost-analyzer/templates/grafana-secret.yaml
+# Source: cost-analyzer/templates/grafana/grafana-secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -53,7 +52,6 @@ type: Opaque
 data:
   admin-user: "YWRtaW4="
   admin-password: "c3Ryb25ncGFzc3dvcmQ="
-  ldap-toml: ""
 ---
 # Source: cost-analyzer/templates/cost-analyzer-config-map-template.yaml
 apiVersion: v1
@@ -62,9 +60,8 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -80,9 +77,8 @@ metadata:
   name: nginx-conf
   namespace: kubecost
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -124,10 +120,6 @@ data:
         text/x-component
         text/x-cross-domain-policy;
 
-    upstream api {
-        server kubecost-cost-analyzer.kubecost:9001;
-    }
-
     upstream model {
         server kubecost-cost-analyzer.kubecost:9003;
     }
@@ -149,6 +141,11 @@ data:
         root /var/www;
         index index.html;
 
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Methods;
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
+        add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' http: https: ws: data:; frame-ancestors 'none';";
         add_header Cache-Control "must-revalidate";
         large_client_header_buffers 4 32k;
 
@@ -160,17 +157,10 @@ data:
         location / {
             try_files $uri $uri/ /index.html;
         }
-        add_header ETag "2.3.3";
+        add_header ETag "2.7.2";
         listen 9090;
         listen [::]:9090;
-        location /api/ {
-            proxy_pass http://api/;
-            proxy_redirect off;
-            proxy_http_version 1.1;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
+        
         location /model/ {
             proxy_connect_timeout       300;
             proxy_send_timeout          300;
@@ -184,9 +174,6 @@ data:
         }
 
         location ~ ^/(turndown|cluster)/ {
-
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
             return 404;
         }
         location /grafana/ {
@@ -198,7 +185,7 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
         }
-
+    
     # TODO make aggregator route the default, start special-casing
     # cost-model APIs
 
@@ -220,7 +207,7 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-
+        
         location = /model/allocation/view {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/allocation/view;
@@ -329,6 +316,46 @@ data:
         location = /model/savings/clusterSizingETL {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/savings/clusterSizingETL;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/savings/nodeGroupSizingETL {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/nodeGroupSizingETL;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/savings/recommendations/allowLists {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/recommendations/allowLists;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location ~* /model/savings/gpuContainersDetails(.*) {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/gpuContainersDetails$1$is_args$args;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location ~* /model/savings/gpuWorkloadUtilization(.*) {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/gpuWorkloadUtilization$1$is_args$args;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location ~* /model/savings/gpuRecommendation(.*) {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/gpuRecommendation$1$is_args$args;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
@@ -457,14 +484,6 @@ data:
         location = /model/reports/asset {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/reports/asset;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/reports/advanced {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/reports/advanced;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
@@ -609,9 +628,89 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/collections/query/chargeback/total {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/collections/query/chargeback/total;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/collections/query/chargeback/timeseries {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/collections/query/chargeback/timeseries;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/collection/cache/status {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/collection/cache/status;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/collection/configs {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/collection/configs;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/category/chargeback {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/category/chargeback;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/category/sharing {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/category/sharing;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/collection/sharing {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/collection/sharing;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/kubernetes/containers/resources {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/kubernetes/containers/resources;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/kubernetes/containers/resources/timeseries {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/kubernetes/containers/resources/timeseries;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/kubernetes/containers/costs {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/kubernetes/containers/costs;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/kubernetes/containers/costs/timeseries {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/kubernetes/containers/costs/timeseries;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
@@ -705,6 +804,54 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/rbac/teams {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/rbac/teams;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/team {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/rbac/team;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/roles {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/rbac/roles;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/role {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/rbac/role;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/currentTeams {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/rbac/currentTeams;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/rbac/currentPermissions {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/rbac/currentPermissions;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/debug/orchestrator {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/debug/orchestrator;
@@ -724,6 +871,14 @@ data:
         location = /model/diagnostic/coreCount {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/diagnostic/coreCount;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/diagnostic/nodeCount {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/diagnostic/nodeCount;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
@@ -852,6 +1007,22 @@ data:
         location = /model/setApiConfig {
             proxy_read_timeout          300;
             proxy_pass http://aggregator/setApiConfig;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+         location = /model/getIngestionConfig {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/getIngestionConfig;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/setIngestionConfig {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/setIngestionConfig;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
@@ -1028,23 +1199,76 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+
+        # alert end points with v2 will be routed to aggregator server
+        location = /model/v2/alerts {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/alerts;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location ~* ^/model/v2/alerts/(.*) {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/alerts/$1;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        # alert end points without any version will be routed to model server
+        location = /model/alerts {
+            proxy_read_timeout          300;
+            proxy_pass http://model/alerts;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location ~* ^/model/alerts/(.*) {
+            proxy_read_timeout          300;
+            proxy_pass http://model/alerts/$1;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location ~* ^/model/reports/(.*)/schedule/test {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/reports/$1/schedule/test;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/savings/requestSizingV2/profiles {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/requestSizingV2/profiles;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/savings/requestSizingV2/profile {
+            proxy_read_timeout          300;
+            proxy_pass http://aggregator/savings/requestSizingV2/profile;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/hideOrphanedResources {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
             return 200 '{"hideOrphanedResources": "false"}';
         }
         location = /model/hideDiagnostics {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
             return 200 '{"hideDiagnostics": "false"}';
         }
 
         location /model/multi-cluster-diagnostics-enabled {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
             return 200 '{"multiClusterDiagnosticsEnabled": false}';
         }
 
@@ -1054,8 +1278,6 @@ data:
         }
         location /forecasting {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
             proxy_read_timeout          300;
             proxy_pass http://forecasting/;
             proxy_redirect off;
@@ -1066,8 +1288,6 @@ data:
 
         location /model/productConfigs {
             default_type 'application/json';
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;
             return 200 '\n
                 {
                 "ssoConfigured": "false",
@@ -1079,7 +1299,18 @@ data:
                 "carbonEstimatesEnabled": "false",
                 "clusterControllerEnabled": "false",
                 "forecastingEnabled": "true",
-                "chartVersion": "2.3.3"
+                "chartVersion": "2.7.2",
+                "hourlyDataRetention": "49",
+                "dailyDataRetention": "91",
+                "hideDiagnostics": "false",
+                "hideOrphanedResources": "false",
+                "hideKubecostActions": "false",
+                "hideReservedInstances": "false",
+                "hideSpotCommander": "false",
+                "hideUnclaimedVolumes": "false",
+                "hideCloudIntegrationsUI": "false",
+                "hideBellIcon": "true",
+                "hideTeams": "false"
                 }
             ';
         }
@@ -1093,12 +1324,12 @@ metadata:
   namespace: kubecost
   labels:
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
 ---
-# Source: cost-analyzer/templates/grafana-configmap-dashboard-provider.yaml
+# Source: cost-analyzer/templates/grafana/grafana-configmap-dashboard-provider.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -1120,7 +1351,7 @@ data:
       options:
         path: /tmp/dashboards
 ---
-# Source: cost-analyzer/templates/grafana-configmap.yaml
+# Source: cost-analyzer/templates/grafana/grafana-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -1164,15 +1395,14 @@ data:
         prometheusVersion: 2.35.0
         timeInterval: 1m
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-attached-disks.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-attached-disks.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-attached-disk-metrics
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -1214,7 +1444,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1295,7 +1525,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(container_fs_limit_bytes{instance=~'$disk', device!=\"tmpfs\", id=\"/\", cluster_id=~'$cluster'}) by (cluster_id, instance)",
@@ -1313,7 +1543,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1396,7 +1626,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(container_fs_usage_bytes{instance=~'$disk',id=\"/\", cluster_id=~'$cluster'}) by (cluster_id, instance) / sum(container_fs_limit_bytes{instance=~'$disk',device!=\"tmpfs\", id=\"/\", cluster_id=~'$cluster'}) by (cluster_id,instance)",
@@ -1414,7 +1644,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1497,7 +1727,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "1 - sum(container_fs_inodes_free{instance=~'$disk',id=\"/\", cluster_id=~'$cluster'}) by (cluster_id, instance) / sum(container_fs_inodes_total{instance=~'$disk',id=\"/\", cluster_id=~'$cluster'}) by (cluster_id, instance)",
@@ -1514,7 +1744,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1595,7 +1825,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(container_fs_usage_bytes{instance=~'$disk',id=\"/\", cluster_id=~'$cluster'}) by (cluster_id, instance)",
@@ -1624,7 +1854,7 @@ data:
             "current": {
               "selected": false,
               "text": "Prometheus",
-              "value": "PBFA97CFB590B2093"
+              "value": "Prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -1646,7 +1876,7 @@ data:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+              "uid": "${datasource}"
             },
             "definition": "label_values(cluster_id)",
             "hide": 0,
@@ -1672,7 +1902,7 @@ data:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+              "uid": "${datasource}"
             },
             "definition": "label_values(container_fs_limit_bytes{cluster_id=~\"$cluster\"}, instance)",
             "hide": 0,
@@ -1726,20 +1956,19 @@ data:
       },
       "timezone": "",
       "title": "Attached disk metrics",
-      "uid": "nBH7qBgMk",
+      "uid": "attached-disk-metrics",
       "version": 7,
       "weekStart": ""
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-cluster-metrics-template.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-cluster-metrics
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -3432,15 +3661,14 @@ data:
       "version": 20
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-cluster-utilization-template.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-cluster-utilization
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -3564,7 +3792,7 @@ data:
               {
                 "datasource": {
                   "type": "prometheus",
-                  "uid": "P0C970EB638C812D0"
+                  "uid": "${datasource}"
                 },
                 "exemplar": false,
                 "expr": "sum(\n (\n (\n sum(kube_node_status_capacity_cpu_cores) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) * $costpcpu\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) * ($costcpu - ($costcpu / 100 * $costDiscount))\n )\n) ",
@@ -3648,7 +3876,7 @@ data:
               {
                 "datasource": {
                   "type": "prometheus",
-                  "uid": "P0C970EB638C812D0"
+                  "uid": "${datasource}"
                 },
                 "exemplar": false,
                 "expr": "sum(\n (\n (\n sum(kube_node_status_capacity_memory_bytes) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) /1024/1024/1024 * $costpram\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) /1024/1024/1024 * ($costram - ($costram / 100 * $costDiscount))\n)\n) ",
@@ -3732,7 +3960,7 @@ data:
               {
                 "datasource": {
                   "type": "prometheus",
-                  "uid": "P0C970EB638C812D0"
+                  "uid": "${datasource}"
                 },
                 "exemplar": false,
                 "expr": "sum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageSSD\n\n+\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageStandard\n\n+ \n\nsum(container_fs_limit_bytes{id=\"/\"}) / 1024 / 1024 / 1024 * 1.03 * $costStorageStandard",
@@ -3817,7 +4045,7 @@ data:
               {
                 "datasource": {
                   "type": "prometheus",
-                  "uid": "P0C970EB638C812D0"
+                  "uid": "${datasource}"
                 },
                 "exemplar": false,
                 "expr": "SUM(rate(node_network_transmit_bytes_total{device=\"eth0\"}[60m]) / 1024 / 1024 / 1024 ) * (60 * 60 * 24 * 30) * $costEgress",
@@ -4394,7 +4622,7 @@ data:
               {
                 "datasource": {
                   "type": "prometheus",
-                  "uid": "P0C970EB638C812D0"
+                  "uid": "${datasource}"
                 },
                 "exemplar": false,
                 "expr": "# CPU\nsum(\n (\n (\n sum(kube_node_status_capacity_cpu_cores) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) * $costpcpu\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) * ($costcpu - ($costcpu / 100 * $costDiscount))\n )\n) \n\n+ \n\n# Storage\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageSSD\n\n+\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageStandard\n\n+ \n\nsum(container_fs_limit_bytes{id=\"/\"}) / 1024 / 1024 / 1024 * 1.03 * $costStorageStandard \n\n+\n\n# END STORAGE\n# RAM \nsum(\n (\n (\n sum(kube_node_status_capacity_memory_bytes) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) /1024/1024/1024 * $costpram\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) /1024/1024/1024 * ($costram - ($costram / 100 * $costDiscount))\n)\n)\n\n+\n\n#Network \nSUM(rate(node_network_transmit_bytes_total{device=\"eth0\"}[60m]) / 1024 / 1024 / 1024 ) * (60 * 60 * 24 * 30) * $costEgress",
@@ -6646,15 +6874,14 @@ data:
         "weekStart": ""
       }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-deployment-utilization-template.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-deployment-utilization
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -8050,15 +8277,14 @@ data:
       "version": 2
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-kubernetes-resource-efficiency-template.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-kubernetes-resource-efficiency
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -8073,8 +8299,8 @@ data:
           {
             "builtIn": 1,
             "datasource": {
-              "type": "grafana",
-              "uid": "-- Grafana --"
+              "type": "datasource",
+              "uid": "grafana"
             },
             "enable": true,
             "hide": true,
@@ -8476,15 +8702,14 @@ data:
       "weekStart": ""
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-label-cost-utilization-template.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-label-cost
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -8588,7 +8813,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "P0C970EB638C812D0"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "sum(\n  avg(container_cpu_allocation) by (pod,node)\n\n  * on (node) group_left()\n  avg(avg_over_time(node_cpu_hourly_cost[10m])) by (node)\n\n  * on (pod) group_left()\n  label_replace(\n    max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod),\n    \"pod_name\",\n    \"$1\", \n    \"pod\", \n    \"(.+)\"\n  )\n) * 730",
@@ -8672,7 +8897,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "P0C970EB638C812D0"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "sum(\n  avg(container_memory_allocation_bytes) by (pod,node) / 1024 / 1024 / 1024\n\n  * on (node) group_left()\n  avg(avg_over_time(node_ram_hourly_cost[10m])) by (node)\n\n  * on (pod) group_left()\n  label_replace(\n    max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod),\n    \"pod_name\",\n    \"$1\", \n    \"pod\", \n    \"(.+)\"\n  )\n) * 730",
@@ -8756,7 +8981,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "P0C970EB638C812D0"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "sum(\n sum(kube_persistentvolumeclaim_info{storageclass!=\".*ssd.*\"}) by (persistentvolumeclaim, storageclass)\n * on (persistentvolumeclaim) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim)\n * on (persistentvolumeclaim) group_left(label_app)\n max(kube_persistentvolumeclaim_labels{label_$label=~\"$label_value\"}) by (persistentvolumeclaim) or up * 0\n) / 1024 / 1024 /1024 * .04 \n\n+\n\nsum(\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, storageclass)\n * on (persistentvolumeclaim) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim)\n * on (persistentvolumeclaim) group_left(label_app)\n max(kube_persistentvolumeclaim_labels{label_$label=~\"$label_value\"}) by (persistentvolumeclaim) or up * 0\n) / 1024 / 1024 /1024 * .17 \n",
@@ -8840,7 +9065,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "P0C970EB638C812D0"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CPU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\nsum(\n  avg(container_cpu_allocation) by (pod,node)\n\n  * on (node) group_left()\n  avg(avg_over_time(node_cpu_hourly_cost[10m])) by (node)\n\n  * on (pod) group_left()\n  label_replace(\n    max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod),\n    \"pod_name\",\n    \"$1\", \n    \"pod\", \n    \"(.+)\"\n  )\n) * 730\n\n#END CPU\n+\n\n# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Memory ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\nsum(\n  avg(container_memory_allocation_bytes) by (pod,node) / 1024 / 1024 / 1024\n\n  * on (node) group_left()\n  avg(avg_over_time(node_ram_hourly_cost[10m])) by (node)\n\n  * on (pod) group_left()\n  label_replace(\n    max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod),\n    \"pod_name\",\n    \"$1\", \n    \"pod\", \n    \"(.+)\"\n  )\n) * 730\n\n# END MEMORY\n\n+\n\n# ~~~~~~~~~~~~~~~~~~~~~~~~~~~ STORAGE ~~~~~~~~~~~~~~~~~~~~~~~~~\n\nsum(\n sum(kube_persistentvolumeclaim_info{storageclass!=\".*ssd.*\"}) by (persistentvolumeclaim, storageclass)\n * on (persistentvolumeclaim) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim)\n * on (persistentvolumeclaim) group_left(label_app)\n max(kube_persistentvolumeclaim_labels{label_$label=~\"$label_value\"}) by (persistentvolumeclaim) or up * 0\n) / 1024 / 1024 /1024 * .04 \n\n+\n\nsum(\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, storageclass)\n * on (persistentvolumeclaim) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim)\n * on (persistentvolumeclaim) group_left(label_app)\n max(kube_persistentvolumeclaim_labels{label_$label=~\"$label_value\"}) by (persistentvolumeclaim) or up * 0\n) / 1024 / 1024 /1024 * .17 \n\n\n# END STORAGE\n",
@@ -9635,20 +9860,19 @@ data:
       },
       "timezone": "",
       "title": "Label costs & utilization",
-      "uid": "lWMhIA-ik",
+      "uid": "at-label-costs-and-utilization",
       "version": 1,
       "weekStart": ""
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-namespace-utilization-template.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-namespace-utilization
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -9678,7 +9902,7 @@ data:
     	"id":9,
     	"iteration":1553150922105,
     	"links":[
-
+    
     	],
     	"panels":[
     		{
@@ -9699,7 +9923,7 @@ data:
     			"hideTimeOverride":true,
     			"id":73,
     			"links":[
-
+    
     			],
     			"pageSize":8,
     			"repeat":null,
@@ -9744,7 +9968,7 @@ data:
     					"decimals":2,
     					"pattern":"Value #B",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"decbytes"
@@ -9762,7 +9986,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value #A",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"percent"
@@ -9780,7 +10004,7 @@ data:
     					"mappingType":1,
     					"pattern":"Time",
     					"thresholds":[
-
+    
     					],
     					"type":"hidden",
     					"unit":"short"
@@ -9798,7 +10022,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value #C",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"currencyUSD"
@@ -9816,7 +10040,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value #D",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"currencyUSD"
@@ -9906,7 +10130,7 @@ data:
     			"hideTimeOverride":true,
     			"id":90,
     			"links":[
-
+    
     			],
     			"pageSize":8,
     			"repeatDirection":"v",
@@ -9930,7 +10154,7 @@ data:
     					"mappingType":1,
     					"pattern":"namespace",
     					"thresholds":[
-
+    
     					],
     					"type":"hidden",
     					"unit":"short"
@@ -9948,7 +10172,7 @@ data:
     					"mappingType":1,
     					"pattern":"persistentvolumeclaim",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"short"
@@ -9966,7 +10190,7 @@ data:
     					"mappingType":1,
     					"pattern":"storageclass",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"short"
@@ -9984,7 +10208,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"gbytes"
@@ -10002,7 +10226,7 @@ data:
     					"mappingType":1,
     					"pattern":"Time",
     					"thresholds":[
-
+    
     					],
     					"type":"hidden",
     					"unit":"short"
@@ -10029,7 +10253,7 @@ data:
     		},
     		{
     			"aliasColors":{
-
+    
     			},
     			"bars":false,
     			"dashLength":10,
@@ -10056,7 +10280,7 @@ data:
     			"lines":true,
     			"linewidth":1,
     			"links":[
-
+    
     			],
     			"nullPointMode":"null",
     			"percentage":false,
@@ -10064,7 +10288,7 @@ data:
     			"points":false,
     			"renderer":"flot",
     			"seriesOverrides":[
-
+    
     			],
     			"spaceLength":10,
     			"stack":false,
@@ -10078,7 +10302,7 @@ data:
     				}
     			],
     			"thresholds":[
-
+    
     			],
     			"timeFrom":null,
     			"timeShift":null,
@@ -10095,7 +10319,7 @@ data:
     				"name":null,
     				"show":true,
     				"values":[
-
+    
     				]
     			},
     			"yaxes":[
@@ -10123,7 +10347,7 @@ data:
     		},
     		{
     			"aliasColors":{
-
+    
     			},
     			"bars":false,
     			"dashLength":10,
@@ -10135,7 +10359,7 @@ data:
     			"error":false,
     			"fill":0,
     			"grid":{
-
+    
     			},
     			"gridPos":{
     				"h":6,
@@ -10165,7 +10389,7 @@ data:
     			"lines":true,
     			"linewidth":2,
     			"links":[
-
+    
     			],
     			"nullPointMode":"connected",
     			"percentage":false,
@@ -10173,7 +10397,7 @@ data:
     			"points":false,
     			"renderer":"flot",
     			"seriesOverrides":[
-
+    
     			],
     			"spaceLength":10,
     			"stack":false,
@@ -10193,7 +10417,7 @@ data:
     				}
     			],
     			"thresholds":[
-
+    
     			],
     			"timeFrom":"",
     			"timeShift":null,
@@ -10211,7 +10435,7 @@ data:
     				"name":null,
     				"show":true,
     				"values":[
-
+    
     				]
     			},
     			"yaxes":[
@@ -10240,7 +10464,7 @@ data:
     		},
     		{
     			"aliasColors":{
-
+    
     			},
     			"bars":false,
     			"dashLength":10,
@@ -10252,7 +10476,7 @@ data:
     			"error":false,
     			"fill":0,
     			"grid":{
-
+    
     			},
     			"gridPos":{
     				"h":6,
@@ -10279,7 +10503,7 @@ data:
     			"lines":true,
     			"linewidth":2,
     			"links":[
-
+    
     			],
     			"nullPointMode":"connected",
     			"percentage":false,
@@ -10287,7 +10511,7 @@ data:
     			"points":false,
     			"renderer":"flot",
     			"seriesOverrides":[
-
+    
     			],
     			"spaceLength":10,
     			"stack":false,
@@ -10303,7 +10527,7 @@ data:
     				}
     			],
     			"thresholds":[
-
+    
     			],
     			"timeFrom":"",
     			"timeShift":null,
@@ -10321,7 +10545,7 @@ data:
     				"name":null,
     				"show":true,
     				"values":[
-
+    
     				]
     			},
     			"yaxes":[
@@ -10350,7 +10574,7 @@ data:
     		},
     		{
     			"aliasColors":{
-
+    
     			},
     			"bars":false,
     			"dashLength":10,
@@ -10362,7 +10586,7 @@ data:
     			"error":false,
     			"fill":1,
     			"grid":{
-
+    
     			},
     			"gridPos":{
     				"h":6,
@@ -10392,7 +10616,7 @@ data:
     			"lines":true,
     			"linewidth":2,
     			"links":[
-
+    
     			],
     			"nullPointMode":"connected",
     			"percentage":false,
@@ -10400,7 +10624,7 @@ data:
     			"points":false,
     			"renderer":"flot",
     			"seriesOverrides":[
-
+    
     			],
     			"spaceLength":10,
     			"stack":false,
@@ -10430,7 +10654,7 @@ data:
     				}
     			],
     			"thresholds":[
-
+    
     			],
     			"timeFrom":"",
     			"timeShift":null,
@@ -10448,7 +10672,7 @@ data:
     				"name":null,
     				"show":true,
     				"values":[
-
+    
     				]
     			},
     			"yaxes":[
@@ -10476,7 +10700,7 @@ data:
     		},
     		{
     			"aliasColors":{
-
+    
     			},
     			"bars":false,
     			"dashLength":10,
@@ -10488,7 +10712,7 @@ data:
     			"error":false,
     			"fill":1,
     			"grid":{
-
+    
     			},
     			"gridPos":{
     				"h":6,
@@ -10518,7 +10742,7 @@ data:
     			"lines":true,
     			"linewidth":2,
     			"links":[
-
+    
     			],
     			"nullPointMode":"connected",
     			"percentage":false,
@@ -10526,7 +10750,7 @@ data:
     			"points":false,
     			"renderer":"flot",
     			"seriesOverrides":[
-
+    
     			],
     			"spaceLength":10,
     			"stack":false,
@@ -10556,7 +10780,7 @@ data:
     				}
     			],
     			"thresholds":[
-
+    
     			],
     			"timeFrom":"",
     			"timeShift":null,
@@ -10574,7 +10798,7 @@ data:
     				"name":null,
     				"show":true,
     				"values":[
-
+    
     				]
     			},
     			"yaxes":[
@@ -10750,7 +10974,7 @@ data:
     				"multi":false,
     				"name":"namespace",
     				"options":[
-
+    
     				],
     				"query":"query_result(sum(kube_namespace_created{namespace!=\"\"}) by (namespace))",
     				"refresh":1,
@@ -10759,7 +10983,7 @@ data:
     				"sort":0,
     				"tagValuesQuery":"",
     				"tags":[
-
+    
     				],
     				"tagsQuery":"",
     				"type":"query",
@@ -10768,7 +10992,7 @@ data:
     			{
     				"datasource":"${datasource}",
     				"filters":[
-
+    
     				],
     				"hide":0,
     				"label":"",
@@ -10833,15 +11057,14 @@ data:
     	"version":1
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-network-cloud-sevices.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-network-cloud-sevices.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-network-cloud-services
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -10856,8 +11079,8 @@ data:
           {
             "builtIn": 1,
             "datasource": {
-              "type": "grafana",
-              "uid": "-- Grafana --"
+              "type": "datasource",
+              "uid": "grafana"
             },
             "enable": true,
             "hide": true,
@@ -11127,7 +11350,7 @@ data:
             "current": {
               "selected": false,
               "text": "Prometheus",
-              "value": "PBFA97CFB590B2093"
+              "value": "Prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -11203,7 +11426,7 @@ data:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+              "uid": "${datasource}"
             },
             "definition": "label_values(kube_pod_container_status_running{namespace=\"$namespace\"},container)",
             "hide": 0,
@@ -11259,15 +11482,14 @@ data:
       "weekStart": ""
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-network-costs.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-network-costs.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-network-costs-metrics
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -11282,8 +11504,8 @@ data:
           {
             "builtIn": 1,
             "datasource": {
-              "type": "grafana",
-              "uid": "-- Grafana --"
+              "type": "datasource",
+              "uid": "grafana"
             },
             "enable": true,
             "hide": true,
@@ -11299,7 +11521,7 @@ data:
           }
         ]
       },
-      "description": "https://docs.kubecost.com/install-and-configure/advanced-configuration/network-costs-configuration",
+      "description": "https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=configuration-network-cost",
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
@@ -11544,7 +11766,7 @@ data:
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Cross region and cross zone subnets must be defined via the configMap. \nSee: \n<https://docs.kubecost.com/install-and-configure/advanced-configuration/network-costs-configuration#overriding-traffic-classifications>",
+          "description": "Cross region and cross zone subnets must be defined via the configMap. \nSee: \n<https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=configuration-network-cost>",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -11655,7 +11877,7 @@ data:
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Cross region and cross zone subnets must be defined via the configMap. \nSee: \n<https://docs.kubecost.com/install-and-configure/advanced-configuration/network-costs-configuration#overriding-traffic-classifications>",
+          "description": "Cross region and cross zone subnets must be defined via the configMap. \nSee: \n<https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=configuration-network-cost>",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -11776,7 +11998,7 @@ data:
             "current": {
               "selected": false,
               "text": "Prometheus",
-              "value": "PBFA97CFB590B2093"
+              "value": "Prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -11949,15 +12171,14 @@ data:
       "weekStart": ""
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-node-utilization-template.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-node-utilization
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -11986,7 +12207,7 @@ data:
     	"id":6,
     	"iteration":1557245882378,
     	"links":[
-
+    
     	],
     	"panels":[
     		{
@@ -12016,7 +12237,7 @@ data:
     			"id":2,
     			"interval":null,
     			"links":[
-
+    
     			],
     			"mappingType":1,
     			"mappingTypes":[
@@ -12098,7 +12319,7 @@ data:
     			"id":3,
     			"interval":null,
     			"links":[
-
+    
     			],
     			"mappingType":1,
     			"mappingTypes":[
@@ -12180,7 +12401,7 @@ data:
     			"id":4,
     			"interval":null,
     			"links":[
-
+    
     			],
     			"mappingType":1,
     			"mappingTypes":[
@@ -12253,7 +12474,7 @@ data:
     			"hideTimeOverride":true,
     			"id":21,
     			"links":[
-
+    
     			],
     			"pageSize":8,
     			"repeat":null,
@@ -12299,7 +12520,7 @@ data:
     					"mappingType":1,
     					"pattern":"Time",
     					"thresholds":[
-
+    
     					],
     					"type":"hidden",
     					"unit":"short"
@@ -12317,7 +12538,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value #C",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"short"
@@ -12335,7 +12556,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value #A",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"short"
@@ -12353,7 +12574,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value #B",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"short"
@@ -12371,7 +12592,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value #D",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"bytes"
@@ -12389,7 +12610,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value #E",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"bytes"
@@ -12407,7 +12628,7 @@ data:
     					"mappingType":1,
     					"pattern":"Value #F",
     					"thresholds":[
-
+    
     					],
     					"type":"number",
     					"unit":"bytes"
@@ -12478,7 +12699,7 @@ data:
     			"id":8,
     			"interval":null,
     			"links":[
-
+    
     			],
     			"mappingType":1,
     			"mappingTypes":[
@@ -12561,7 +12782,7 @@ data:
     			"id":18,
     			"interval":null,
     			"links":[
-
+    
     			],
     			"mappingType":1,
     			"mappingTypes":[
@@ -12643,7 +12864,7 @@ data:
     			"id":9,
     			"interval":null,
     			"links":[
-
+    
     			],
     			"mappingType":1,
     			"mappingTypes":[
@@ -12725,7 +12946,7 @@ data:
     			"id":19,
     			"interval":null,
     			"links":[
-
+    
     			],
     			"mappingType":1,
     			"mappingTypes":[
@@ -12782,7 +13003,7 @@ data:
     		},
     		{
     			"aliasColors":{
-
+    
     			},
     			"bars":false,
     			"dashLength":10,
@@ -12794,7 +13015,7 @@ data:
     			"error":false,
     			"fill":0,
     			"grid":{
-
+    
     			},
     			"gridPos":{
     				"h":6,
@@ -12824,7 +13045,7 @@ data:
     			"lines":true,
     			"linewidth":2,
     			"links":[
-
+    
     			],
     			"nullPointMode":"connected",
     			"percentage":false,
@@ -12832,7 +13053,7 @@ data:
     			"points":false,
     			"renderer":"flot",
     			"seriesOverrides":[
-
+    
     			],
     			"spaceLength":10,
     			"stack":false,
@@ -12852,7 +13073,7 @@ data:
     				}
     			],
     			"thresholds":[
-
+    
     			],
     			"timeFrom":"",
     			"timeShift":null,
@@ -12870,7 +13091,7 @@ data:
     				"name":null,
     				"show":true,
     				"values":[
-
+    
     				]
     			},
     			"yaxes":[
@@ -12899,7 +13120,7 @@ data:
     		},
     		{
     			"aliasColors":{
-
+    
     			},
     			"bars":false,
     			"dashLength":10,
@@ -12911,7 +13132,7 @@ data:
     			"error":false,
     			"fill":0,
     			"grid":{
-
+    
     			},
     			"gridPos":{
     				"h":6,
@@ -12938,7 +13159,7 @@ data:
     			"lines":true,
     			"linewidth":2,
     			"links":[
-
+    
     			],
     			"nullPointMode":"connected",
     			"percentage":false,
@@ -12946,7 +13167,7 @@ data:
     			"points":false,
     			"renderer":"flot",
     			"seriesOverrides":[
-
+    
     			],
     			"spaceLength":10,
     			"stack":false,
@@ -12965,7 +13186,7 @@ data:
     				}
     			],
     			"thresholds":[
-
+    
     			],
     			"timeFrom":"",
     			"timeShift":null,
@@ -12983,7 +13204,7 @@ data:
     				"name":null,
     				"show":true,
     				"values":[
-
+    
     				]
     			},
     			"yaxes":[
@@ -13012,7 +13233,7 @@ data:
     		},
     		{
     			"aliasColors":{
-
+    
     			},
     			"bars":false,
     			"dashLength":10,
@@ -13024,7 +13245,7 @@ data:
     			"error":false,
     			"fill":1,
     			"grid":{
-
+    
     			},
     			"gridPos":{
     				"h":6,
@@ -13054,7 +13275,7 @@ data:
     			"lines":true,
     			"linewidth":2,
     			"links":[
-
+    
     			],
     			"nullPointMode":"connected",
     			"percentage":false,
@@ -13062,7 +13283,7 @@ data:
     			"points":false,
     			"renderer":"flot",
     			"seriesOverrides":[
-
+    
     			],
     			"spaceLength":10,
     			"stack":false,
@@ -13092,7 +13313,7 @@ data:
     				}
     			],
     			"thresholds":[
-
+    
     			],
     			"timeFrom":"",
     			"timeShift":null,
@@ -13110,7 +13331,7 @@ data:
     				"name":null,
     				"show":true,
     				"values":[
-
+    
     				]
     			},
     			"yaxes":[
@@ -13138,7 +13359,7 @@ data:
     		},
     		{
     			"aliasColors":{
-
+    
     			},
     			"bars":false,
     			"dashLength":10,
@@ -13150,7 +13371,7 @@ data:
     			"error":false,
     			"fill":1,
     			"grid":{
-
+    
     			},
     			"gridPos":{
     				"h":6,
@@ -13180,7 +13401,7 @@ data:
     			"lines":true,
     			"linewidth":2,
     			"links":[
-
+    
     			],
     			"nullPointMode":"connected",
     			"percentage":false,
@@ -13188,7 +13409,7 @@ data:
     			"points":false,
     			"renderer":"flot",
     			"seriesOverrides":[
-
+    
     			],
     			"spaceLength":10,
     			"stack":false,
@@ -13218,7 +13439,7 @@ data:
     				}
     			],
     			"thresholds":[
-
+    
     			],
     			"timeFrom":"",
     			"timeShift":null,
@@ -13236,7 +13457,7 @@ data:
     				"name":null,
     				"show":true,
     				"values":[
-
+    
     				]
     			},
     			"yaxes":[
@@ -13285,7 +13506,7 @@ data:
     				"multi":false,
     				"name":"node",
     				"options":[
-
+    
     				],
     				"query":"query_result(kube_node_labels)",
     				"refresh":1,
@@ -13294,7 +13515,7 @@ data:
     				"sort":0,
     				"tagValuesQuery":"",
     				"tags":[
-
+    
     				],
     				"tagsQuery":"",
     				"type":"query",
@@ -13356,15 +13577,14 @@ data:
     	"version":1
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-pod-utilization-multi-cluster.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-pod-utilization-multi-cluster.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-pod-utilization-multi-cluster
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -14157,20 +14377,19 @@ data:
       },
       "timezone": "browser",
       "title": "Pod utilization metrics (multi-cluster)",
-      "uid": "at-cost-analysis-pod-utilization-multi-cluster",
+      "uid": "at-cost-analysis-pod-multicluster",
       "version": 2,
       "weekStart": ""
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-pod-utilization-template.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-pod-utilization
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -14784,12 +15003,115 @@ data:
           "timeFrom": "",
           "title": "CPU throttle percent",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "default": false,
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "NVIDIA GPU usage for this container.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": 3600000,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "id": 100,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "9.4.7",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "DCGM_FI_PROF_GR_ENGINE_ACTIVE{namespace=~\"$namespace\",container=~\"$container\",pod=~\"$pod\"}",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "__auto",
+              "metric": "container_cpu",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "timeFrom": "",
+          "title": "GPU Usage",
+          "type": "timeseries"
         }
       ],
       "refresh": "",
       "revision": 1,
-      "schemaVersion": 38,
-      "style": "dark",
+      "schemaVersion": 39,
       "tags": [
         "kubecost",
         "utilization",
@@ -14937,15 +15259,14 @@ data:
       "weekStart": ""
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-prometheus-metrics-template.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-prom-benchmark
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -20646,15 +20967,14 @@ data:
       "version": 4
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-workload-aggregator.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-workload-aggregator.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-workload-aggregator
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -21530,7 +21850,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "kubecost_read_db_size",
@@ -21570,7 +21890,7 @@ data:
             "current": {
               "selected": false,
               "text": "Prometheus",
-              "value": "PBFA97CFB590B2093"
+              "value": "Prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -21652,15 +21972,14 @@ data:
       "weekStart": ""
     }
 ---
-# Source: cost-analyzer/templates/grafana-dashboard-workload-metrics.yaml
+# Source: cost-analyzer/templates/grafana/grafana-dashboard-workload-metrics.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-workload-metrics
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -22454,7 +22773,7 @@ data:
             "current": {
               "selected": false,
               "text": "Prometheus",
-              "value": "PBFA97CFB590B2093"
+              "value": "Prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -22530,7 +22849,7 @@ data:
             },
             "datasource": {
               "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+              "uid": "${datasource}"
             },
             "definition": "label_values({namespace=~\"$namespace\", pod=~\"$pod\"},container)",
             "hide": 0,
@@ -22563,7 +22882,7 @@ data:
       "weekStart": ""
     }
 ---
-# Source: cost-analyzer/templates/prometheus-server-configmap.yaml
+# Source: cost-analyzer/templates/prometheus/prometheus-server-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22577,8 +22896,6 @@ metadata:
 data:
   alerting_rules.yml: |
     {}
-  alerts: |
-    {}
   prometheus.yml: |
     global:
       evaluation_interval: 1m
@@ -22589,8 +22906,6 @@ data:
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml
-    - /etc/config/rules
-    - /etc/config/alerts
     scrape_configs:
     - job_name: prometheus
       static_configs:
@@ -22732,10 +23047,22 @@ data:
         - kubecost-aggregator
         type: 'A'
         port: 9004
-
+    ## Enables scraping of NVIDIA GPU metrics via dcgm-exporter. Scrapes all
+    ## endpoints which contain "dcgm-exporter" in labels "app",
+    ## "app.kubernetes.io/component", or "app.kubernetes.io/name" with a case
+    ## insensitive match. The label must be present on the K8s service endpoints and not just pods.
+    ## Refs:
+    ## https://github.com/NVIDIA/gpu-operator/blob/d4316a415bbd684ce8416a88042305fc1a093aa4/assets/state-dcgm-exporter/0600_service.yaml#L7
+    ## https://github.com/NVIDIA/dcgm-exporter/blob/54fd1ca137c66511a87a720390613680b9bdabdd/deployment/templates/service.yaml#L23
+    - job_name: kubecost-dcgm-exporter
+      kubernetes_sd_configs:
+        - role: endpoints
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_label_app_kubernetes_io_component, __meta_kubernetes_pod_label_app_kubernetes_io_name]
+          action: keep
+          regex: (?i)(.*dcgm-exporter.*|.*dcgm-exporter.*|.*dcgm-exporter.*)
+    
   recording_rules.yml: |
-    {}
-  rules: |
     groups:
     - name: CPU
       rules:
@@ -22781,9 +23108,8 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -22794,7 +23120,7 @@ spec:
     requests:
       storage: 32Gi
 ---
-# Source: cost-analyzer/templates/prometheus-server-pvc.yaml
+# Source: cost-analyzer/templates/prometheus/prometheus-server-pvc.yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -22818,9 +23144,8 @@ kind: ClusterRole
 metadata:
   name: kubecost-cost-analyzer
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -22880,9 +23205,9 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
+  - apiGroups: 
       - storage.k8s.io
-    resources:
+    resources: 
       - storageclasses
     verbs:
       - get
@@ -22897,7 +23222,7 @@ rules:
       - list
       - watch
 ---
-# Source: cost-analyzer/templates/grafana-clusterrole.yaml
+# Source: cost-analyzer/templates/grafana/grafana-clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -22911,7 +23236,7 @@ rules:
   resources: ["configmaps"]
   verbs: ["get", "watch", "list"]
 ---
-# Source: cost-analyzer/templates/prometheus-server-clusterrole.yaml
+# Source: cost-analyzer/templates/prometheus/prometheus-server-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22957,9 +23282,8 @@ kind: ClusterRoleBinding
 metadata:
   name: kubecost-cost-analyzer
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -22972,7 +23296,7 @@ subjects:
     name: kubecost-cost-analyzer
     namespace: kubecost
 ---
-# Source: cost-analyzer/templates/grafana-clusterrolebinding.yaml
+# Source: cost-analyzer/templates/grafana/grafana-clusterrolebinding.yaml
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -22990,7 +23314,7 @@ roleRef:
   name: kubecost-grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: cost-analyzer/templates/prometheus-server-clusterrolebinding.yaml
+# Source: cost-analyzer/templates/prometheus/prometheus-server-clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -23016,14 +23340,13 @@ metadata:
   namespace: kubecost
   name: kubecost-cost-analyzer
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
 rules:
-- apiGroups:
+- apiGroups: 
     - ''
   resources:
     - "pods/log"
@@ -23048,9 +23371,8 @@ metadata:
   name: kubecost-cost-analyzer
   namespace: kubecost
   labels:
-
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -23070,15 +23392,13 @@ metadata:
   name: kubecost-cloud-cost
   namespace: kubecost
   labels:
-
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cost-analyzer
     app.kubernetes.io/instance: kubecost
     app: cost-analyzer
 spec:
   selector:
-
     app.kubernetes.io/name: cost-analyzer
     app.kubernetes.io/instance: kubecost
     app: cost-analyzer
@@ -23095,13 +23415,11 @@ metadata:
   name: kubecost-aggregator
   namespace: kubecost
   labels:
-
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/managed-by: Helm
     app: aggregator
 spec:
   selector:
-
     app.kubernetes.io/name: cost-analyzer
     app.kubernetes.io/instance: kubecost
     app: cost-analyzer
@@ -23119,7 +23437,7 @@ metadata:
   namespace: kubecost
   labels:
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -23145,7 +23463,7 @@ metadata:
   name: kubecost-forecasting
   namespace: kubecost
   labels:
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: forecasting
     app.kubernetes.io/instance: kubecost
@@ -23161,7 +23479,7 @@ spec:
       port: 5000
       targetPort: 5000
 ---
-# Source: cost-analyzer/templates/grafana-service.yaml
+# Source: cost-analyzer/templates/grafana/grafana-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -23183,7 +23501,7 @@ spec:
     app: grafana
     release: kubecost
 ---
-# Source: cost-analyzer/templates/prometheus-server-service.yaml
+# Source: cost-analyzer/templates/prometheus/prometheus-server-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -23215,7 +23533,7 @@ metadata:
   namespace: kubecost
   labels:
     app.kubernetes.io/name: cost-analyzer
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/instance: kubecost
     app.kubernetes.io/managed-by: Helm
     app: cost-analyzer
@@ -23237,6 +23555,8 @@ spec:
         app.kubernetes.io/name: cost-analyzer
         app.kubernetes.io/instance: kubecost
         app: cost-analyzer
+      annotations:
+        checksum/configs: 94efe14b6d552763f575fc2e59e0ffe829dc64011940e47b4785990b90ea9534
     spec:
       securityContext:
         fsGroup: 1001
@@ -23251,6 +23571,8 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: log
+          emptyDir: {}
         - name: nginx-conf
           configMap:
             name: nginx-conf
@@ -23262,7 +23584,7 @@ spec:
             claimName: kubecost-cost-analyzer
       initContainers:
       containers:
-        - image: gcr.io/kubecost1/cost-model:prod-2.3.3
+        - image: "gcr.io/kubecost1/cost-model:prod-2.7.2"
           name: cost-model
           securityContext:
             allowPrivilegeEscalation: false
@@ -23301,10 +23623,12 @@ spec:
             - name: persistent-configs
               mountPath: /var/configs
           env:
+            - name: CONTAINER_IMAGE_TAG
+              value: prod-2.7.2
             - name: GRAFANA_ENABLED
               value: "true"
-            - name: HELM_VALUES
-              value: eyJhZmZpbml0eSI6e30sImF3c3N0b3JlIjp7ImFubm90YXRpb25zIjp7fSwiY3JlYXRlU2VydmljZUFjY291bnQiOmZhbHNlLCJpbWFnZU5hbWVBbmRWZXJzaW9uIjoiZ2NyLmlvL2t1YmVjb3N0MS9hd3NzdG9yZTpsYXRlc3QiLCJub2RlU2VsZWN0b3IiOnt9LCJwcmlvcml0eUNsYXNzTmFtZSI6IiIsInVzZUF3c1N0b3JlIjpmYWxzZX0sImRpYWdub3N0aWNzIjp7ImNvbGxlY3RIZWxtVmFsdWVzIjpmYWxzZSwiZW5hYmxlZCI6dHJ1ZSwia2VlcERpYWdub3N0aWNIaXN0b3J5IjpmYWxzZSwicG9sbGluZ0ludGVydmFsIjoiMzAwcyJ9LCJleHRyYU9iamVjdHMiOltdLCJleHRyYVZvbHVtZU1vdW50cyI6W10sImV4dHJhVm9sdW1lcyI6W10sImZlZGVyYXRlZEVUTCI6eyJhZ2VudE9ubHkiOmZhbHNlLCJmZWRlcmF0ZWRDbHVzdGVyIjpmYWxzZSwicmVhZE9ubHlQcmltYXJ5IjpmYWxzZSwicmVkaXJlY3RTM0JhY2t1cCI6ZmFsc2UsInVzZU11bHRpQ2x1c3RlckRCIjpmYWxzZX0sImZvcmVjYXN0aW5nIjp7ImFmZmluaXR5Ijp7fSwiZW5hYmxlZCI6dHJ1ZSwiZW52Ijp7IkdVTklDT1JOX0NNRF9BUkdTIjoiLS1sb2ctbGV2ZWwgaW5mbyAtdCAxMjAwIn0sImZ1bGxJbWFnZU5hbWUiOiJnY3IuaW8va3ViZWNvc3QxL2t1YmVjb3N0LW1vZGVsaW5nOnYwLjEuMTIiLCJpbWFnZVB1bGxQb2xpY3kiOiJJZk5vdFByZXNlbnQiLCJsaXZlbmVzc1Byb2JlIjp7ImVuYWJsZWQiOnRydWUsImZhaWx1cmVUaHJlc2hvbGQiOjIwMCwiaW5pdGlhbERlbGF5U2Vjb25kcyI6MTAsInBlcmlvZFNlY29uZHMiOjEwfSwibm9kZVNlbGVjdG9yIjp7fSwicmVhZGluZXNzUHJvYmUiOnsiZW5hYmxlZCI6dHJ1ZSwiZmFpbHVyZVRocmVzaG9sZCI6MjAwLCJpbml0aWFsRGVsYXlTZWNvbmRzIjoxMCwicGVyaW9kU2Vjb25kcyI6MTB9LCJyZXNvdXJjZXMiOnsibGltaXRzIjp7ImNwdSI6IjE1MDBtIiwibWVtb3J5IjoiMUdpIn0sInJlcXVlc3RzIjp7ImNwdSI6IjIwMG0iLCJtZW1vcnkiOiIzMDBNaSJ9fSwidG9sZXJhdGlvbnMiOltdfSwiZ2xvYmFsIjp7ImFkZGl0aW9uYWxMYWJlbHMiOnt9LCJjb250YWluZXJTZWN1cml0eUNvbnRleHQiOnsiYWxsb3dQcml2aWxlZ2VFc2NhbGF0aW9uIjpmYWxzZSwiY2FwYWJpbGl0aWVzIjp7ImRyb3AiOlsiQUxMIl19LCJwcml2aWxlZ2VkIjpmYWxzZSwicmVhZE9ubHlSb290RmlsZXN5c3RlbSI6dHJ1ZX0sImdyYWZhbmEiOnsiZG9tYWluTmFtZSI6ImNvc3QtYW5hbHl6ZXItZ3JhZmFuYS5kZWZhdWx0LnN2YyIsImVuYWJsZWQiOnRydWUsInByb3h5Ijp0cnVlLCJzY2hlbWUiOiJodHRwIn0sImludGVncmF0aW9ucyI6e30sIm5vdGlmaWNhdGlvbnMiOnt9LCJwbGF0Zm9ybXMiOnt9LCJwb2RBbm5vdGF0aW9ucyI6e30sInByb21ldGhldXMiOnsiZW5hYmxlZCI6dHJ1ZSwiZnFkbiI6Imh0dHA6Ly9jb3N0LWFuYWx5emVyLXByb21ldGhldXMtc2VydmVyLmRlZmF1bHQuc3ZjIn0sInNlY3VyaXR5Q29udGV4dCI6eyJmc0dyb3VwIjoxMDAxLCJmc0dyb3VwQ2hhbmdlUG9saWN5IjoiT25Sb290TWlzbWF0Y2giLCJydW5Bc0dyb3VwIjoxMDAxLCJydW5Bc05vblJvb3QiOnRydWUsInJ1bkFzVXNlciI6MTAwMSwic2VjY29tcFByb2ZpbGUiOnsidHlwZSI6IlJ1bnRpbWVEZWZhdWx0In19fSwiZ3JhZmFuYSI6eyJhZG1pblBhc3N3b3JkIjoic3Ryb25ncGFzc3dvcmQiLCJhZG1pblVzZXIiOiJhZG1pbiIsImFmZmluaXR5Ijp7fSwiYW5ub3RhdGlvbnMiOnt9LCJkYXNoYm9hcmRQcm92aWRlcnMiOnt9LCJkYXNoYm9hcmRzIjp7fSwiZGFzaGJvYXJkc0NvbmZpZ01hcHMiOnt9LCJkZXBsb3ltZW50U3RyYXRlZ3kiOiJSb2xsaW5nVXBkYXRlIiwiZG93bmxvYWREYXNoYm9hcmRzSW1hZ2UiOnsicHVsbFBvbGljeSI6IklmTm90UHJlc2VudCIsInJlcG9zaXRvcnkiOiJjdXJsaW1hZ2VzL2N1cmwiLCJ0YWciOiJsYXRlc3QifSwiZW52Ijp7fSwiZW52RnJvbVNlY3JldCI6IiIsImV4dHJhU2VjcmV0TW91bnRzIjpbXSwiZ3JhZmFuYS5pbmkiOnsiYW5hbHl0aWNzIjp7ImNoZWNrX2Zvcl91cGRhdGVzIjp0cnVlfSwiYXV0aC5hbm9ueW1vdXMiOnsiZW5hYmxlZCI6dHJ1ZSwib3JnX25hbWUiOiJNYWluIE9yZy4iLCJvcmdfcm9sZSI6IkVkaXRvciJ9LCJncmFmYW5hX25ldCI6eyJ1cmwiOiJodHRwczovL2dyYWZhbmEubmV0In0sImxvZyI6eyJtb2RlIjoiY29uc29sZSJ9LCJwYXRocyI6eyJkYXRhIjoiL3Zhci9saWIvZ3JhZmFuYS9kYXRhIiwibG9ncyI6Ii92YXIvbG9nL2dyYWZhbmEiLCJwbHVnaW5zIjoiL3Zhci9saWIvZ3JhZmFuYS9wbHVnaW5zIiwicHJvdmlzaW9uaW5nIjoiL2V0Yy9ncmFmYW5hL3Byb3Zpc2lvbmluZyJ9LCJzZXJ2ZXIiOnsicm9vdF91cmwiOiIlKHByb3RvY29sKXM6Ly8lKGRvbWFpbilzOiUoaHR0cF9wb3J0KXMvZ3JhZmFuYSIsInNlcnZlX2Zyb21fc3ViX3BhdGgiOmZhbHNlfX0sImltYWdlIjp7InB1bGxQb2xpY3kiOiJJZk5vdFByZXNlbnQiLCJyZXBvc2l0b3J5IjoiZ3JhZmFuYS9ncmFmYW5hIiwidGFnIjoiMTAuNC4zIn0sImxkYXAiOnsiY29uZmlnIjoiIiwiZXhpc3RpbmdTZWNyZXQiOiIifSwibGl2ZW5lc3NQcm9iZSI6eyJmYWlsdXJlVGhyZXNob2xkIjoxMCwiaHR0cEdldCI6eyJwYXRoIjoiL2FwaS9oZWFsdGgiLCJwb3J0IjozMDAwfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6NjAsInRpbWVvdXRTZWNvbmRzIjozMH0sIm5vZGVTZWxlY3RvciI6e30sInBsdWdpbnMiOltdLCJwb2RBbm5vdGF0aW9ucyI6e30sInByaW9yaXR5Q2xhc3NOYW1lIjoiIiwicmJhYyI6eyJjcmVhdGUiOnRydWV9LCJyZWFkaW5lc3NQcm9iZSI6eyJodHRwR2V0Ijp7InBhdGgiOiIvYXBpL2hlYWx0aCIsInBvcnQiOjMwMDB9fSwicmVwbGljYXMiOjEsInJlc291cmNlcyI6e30sInNlY3VyaXR5Q29udGV4dCI6e30sInNlcnZpY2UiOnsiYW5ub3RhdGlvbnMiOnt9LCJsYWJlbHMiOnt9LCJwb3J0Ijo4MCwidHlwZSI6IkNsdXN0ZXJJUCJ9LCJzZXJ2aWNlQWNjb3VudCI6eyJjcmVhdGUiOnRydWUsIm5hbWUiOiIifSwic2lkZWNhciI6eyJkYXNoYm9hcmRzIjp7ImFubm90YXRpb25zIjp7fSwiZW5hYmxlZCI6dHJ1ZSwiZXJyb3JfdGhyb3R0bGVfc2xlZXAiOjAsImZvbGRlciI6Ii90bXAvZGFzaGJvYXJkcyIsImxhYmVsIjoiZ3JhZmFuYV9kYXNoYm9hcmQiLCJsYWJlbFZhbHVlIjoiMSJ9LCJpbWFnZSI6eyJwdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwicmVwb3NpdG9yeSI6Imtpd2lncmlkL2s4cy1zaWRlY2FyIiwidGFnIjoiMS4yNy4yIn0sInJlc291cmNlcyI6e319LCJzbXRwIjp7ImV4aXN0aW5nU2VjcmV0IjoiIn0sInRvbGVyYXRpb25zIjpbXX0sImluaXRDaG93bkRhdGEiOnsicmVzb3VyY2VzIjp7fX0sImluaXRDaG93bkRhdGFJbWFnZSI6ImJ1c3lib3giLCJrdWJlY29zdERlcGxveW1lbnQiOnsiYW5ub3RhdGlvbnMiOnt9LCJsYWJlbHMiOnt9LCJyZXBsaWNhcyI6MX0sImt1YmVjb3N0RnJvbnRlbmQiOnsiZGVwbG95TWV0aG9kIjoic2luZ2xlcG9kIiwiZGVwbG95bWVudFN0cmF0ZWd5Ijp7fSwiZW5hYmxlZCI6dHJ1ZSwiaGFSZXBsaWNhcyI6MiwiaW1hZ2UiOiJnY3IuaW8va3ViZWNvc3QxL2Zyb250ZW5kIiwiaW1hZ2VQdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwiaXB2NiI6eyJlbmFibGVkIjp0cnVlfSwibGl2ZW5lc3NQcm9iZSI6eyJlbmFibGVkIjp0cnVlLCJmYWlsdXJlVGhyZXNob2xkIjo2LCJpbml0aWFsRGVsYXlTZWNvbmRzIjoxLCJwZXJpb2RTZWNvbmRzIjo1fSwicmVhZGluZXNzUHJvYmUiOnsiZW5hYmxlZCI6dHJ1ZSwiZmFpbHVyZVRocmVzaG9sZCI6NiwiaW5pdGlhbERlbGF5U2Vjb25kcyI6MSwicGVyaW9kU2Vjb25kcyI6NX0sInJlc291cmNlcyI6eyJyZXF1ZXN0cyI6eyJjcHUiOiIxMG0iLCJtZW1vcnkiOiI1NU1pIn19LCJ1c2VEZWZhdWx0RnFkbiI6ZmFsc2V9LCJrdWJlY29zdE1ldHJpY3MiOnt9LCJrdWJlY29zdE1vZGVsIjp7ImFsbG9jYXRpb24iOm51bGwsImNvbnRhaW5lclN0YXRzRW5hYmxlZCI6dHJ1ZSwiZXRsIjp0cnVlLCJldGxEYWlseVN0b3JlRHVyYXRpb25EYXlzIjo5MSwiZXRsRmlsZVN0b3JlRW5hYmxlZCI6dHJ1ZSwiZXRsSG91cmx5U3RvcmVEdXJhdGlvbkhvdXJzIjo0OSwiZXRsUmVhZE9ubHlNb2RlIjpmYWxzZSwiZXRsV2Vla2x5U3RvcmVEdXJhdGlvbldlZWtzIjo1MywiZXh0cmFBcmdzIjpbXSwiZXh0cmFQb3J0cyI6W10sImltYWdlIjoiZ2NyLmlvL2t1YmVjb3N0MS9jb3N0LW1vZGVsIiwiaW1hZ2VQdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwibGl2ZW5lc3NQcm9iZSI6eyJlbmFibGVkIjp0cnVlLCJmYWlsdXJlVGhyZXNob2xkIjoyMDAsImluaXRpYWxEZWxheVNlY29uZHMiOjEwLCJwZXJpb2RTZWNvbmRzIjoxMH0sIm1heFF1ZXJ5Q29uY3VycmVuY3kiOjUsInJlYWRpbmVzc1Byb2JlIjp7ImVuYWJsZWQiOnRydWUsImZhaWx1cmVUaHJlc2hvbGQiOjIwMCwiaW5pdGlhbERlbGF5U2Vjb25kcyI6MTAsInBlcmlvZFNlY29uZHMiOjEwfSwicmVzb3VyY2VzIjp7InJlcXVlc3RzIjp7ImNwdSI6IjIwMG0iLCJtZW1vcnkiOiI1NU1pIn19LCJ1dGNPZmZzZXQiOiIrMDA6MDAiLCJ3YXJtQ2FjaGUiOmZhbHNlfSwia3ViZWNvc3RUb2tlbiI6bnVsbCwibm9kZVNlbGVjdG9yIjp7fSwicGVyc2lzdGVudFZvbHVtZSI6eyJhbm5vdGF0aW9ucyI6e30sImRiUFZFbmFibGVkIjpmYWxzZSwiZGJTaXplIjoiMzIuMEdpIiwiZW5hYmxlZCI6dHJ1ZSwibGFiZWxzIjp7fSwic2l6ZSI6IjMyR2kifSwicHJvbWV0aGV1cyI6eyJhbGVydFJlbGFiZWxDb25maWdzIjpudWxsLCJhbGVydG1hbmFnZXJGaWxlcyI6eyJhbGVydG1hbmFnZXIueW1sIjp7Imdsb2JhbCI6e30sInJlY2VpdmVycyI6W3sibmFtZSI6ImRlZmF1bHQtcmVjZWl2ZXIifV0sInJvdXRlIjp7Imdyb3VwX2ludGVydmFsIjoiNW0iLCJncm91cF93YWl0IjoiMTBzIiwicmVjZWl2ZXIiOiJkZWZhdWx0LXJlY2VpdmVyIiwicmVwZWF0X2ludGVydmFsIjoiM2gifX19LCJjb25maWdtYXBSZWxvYWQiOnt9LCJleHRyYVNjcmFwZUNvbmZpZ3MiOiItIGpvYl9uYW1lOiBrdWJlY29zdFxuICBob25vcl9sYWJlbHM6IHRydWVcbiAgc2NyYXBlX2ludGVydmFsOiAxbVxuICBzY3JhcGVfdGltZW91dDogNjBzXG4gIG1ldHJpY3NfcGF0aDogL21ldHJpY3NcbiAgc2NoZW1lOiBodHRwXG4gIGRuc19zZF9jb25maWdzOlxuICAtIG5hbWVzOlxuICAgIC0ge3sgdGVtcGxhdGUgXCJjb3N0LWFuYWx5emVyLnNlcnZpY2VOYW1lXCIgLiB9fVxuICAgIHR5cGU6ICdBJ1xuICAgIHBvcnQ6IDkwMDNcbi0gam9iX25hbWU6IGt1YmVjb3N0LW5ldHdvcmtpbmdcbiAga3ViZXJuZXRlc19zZF9jb25maWdzOlxuICAgIC0gcm9sZTogcG9kXG4gIHJlbGFiZWxfY29uZmlnczpcbiAgIyBTY3JhcGUgb25seSB0aGUgdGhlIHRhcmdldHMgbWF0Y2hpbmcgdGhlIGZvbGxvd2luZyBtZXRhZGF0YVxuICAgIC0gc291cmNlX2xhYmVsczogW19fbWV0YV9rdWJlcm5ldGVzX3BvZF9sYWJlbF9hcHBfa3ViZXJuZXRlc19pb19pbnN0YW5jZV1cbiAgICAgIGFjdGlvbjoga2VlcFxuICAgICAgcmVnZXg6ICBrdWJlY29zdFxuICAgIC0gc291cmNlX2xhYmVsczogW19fbWV0YV9rdWJlcm5ldGVzX3BvZF9sYWJlbF9hcHBfa3ViZXJuZXRlc19pb19uYW1lXVxuICAgICAgYWN0aW9uOiBrZWVwXG4gICAgICByZWdleDogIG5ldHdvcmstY29zdHNcbi0gam9iX25hbWU6IGt1YmVjb3N0LWFnZ3JlZ2F0b3JcbiAgc2NyYXBlX2ludGVydmFsOiAxbVxuICBzY3JhcGVfdGltZW91dDogNjBzXG4gIG1ldHJpY3NfcGF0aDogL21ldHJpY3NcbiAgc2NoZW1lOiBodHRwXG4gIGRuc19zZF9jb25maWdzOlxuICAtIG5hbWVzOlxuICAgIC0ge3sgdGVtcGxhdGUgXCJhZ2dyZWdhdG9yLnNlcnZpY2VOYW1lXCIgLiB9fVxuICAgIHR5cGU6ICdBJ1xuICAgIHt7LSBpZiBvciAuVmFsdWVzLnNhbWwuZW5hYmxlZCAuVmFsdWVzLm9pZGMuZW5hYmxlZCB9fVxuICAgIHBvcnQ6IDkwMDhcbiAgICB7ey0gZWxzZSB9fVxuICAgIHBvcnQ6IDkwMDRcbiAgICB7ey0gZW5kIH19XG4iLCJpbWFnZVB1bGxTZWNyZXRzIjpudWxsLCJyYmFjIjp7ImNyZWF0ZSI6dHJ1ZX0sInNlcnZlciI6eyJhZmZpbml0eSI6e30sImFsZXJ0bWFuYWdlcnMiOltdLCJiYXNlVVJMIjoiIiwiY29uZmlnTWFwT3ZlcnJpZGVOYW1lIjoiIiwiY29uZmlnUGF0aCI6Ii9ldGMvY29uZmlnL3Byb21ldGhldXMueW1sIiwiY29udGFpbmVyU2VjdXJpdHlDb250ZXh0Ijp7fSwiZGVwbG95bWVudEFubm90YXRpb25zIjp7fSwiZW1wdHlEaXIiOnsic2l6ZUxpbWl0IjoiIn0sImVuYWJsZWQiOnRydWUsImVudiI6W10sImV4dHJhQXJncyI6eyJxdWVyeS5tYXgtY29uY3VycmVuY3kiOjEsInF1ZXJ5Lm1heC1zYW1wbGVzIjoxMDAwMDAwMDB9LCJleHRyYUNvbmZpZ21hcE1vdW50cyI6W10sImV4dHJhRmxhZ3MiOlsid2ViLmVuYWJsZS1saWZlY3ljbGUiXSwiZXh0cmFIb3N0UGF0aE1vdW50cyI6W10sImV4dHJhSW5pdENvbnRhaW5lcnMiOltdLCJleHRyYVNlY3JldE1vdW50cyI6W10sImV4dHJhVm9sdW1lTW91bnRzIjpbXSwiZXh0cmFWb2x1bWVzIjpbXSwiZ2xvYmFsIjp7ImV2YWx1YXRpb25faW50ZXJ2YWwiOiIxbSIsImV4dGVybmFsX2xhYmVscyI6eyJjbHVzdGVyX2lkIjoiY2x1c3Rlci1vbmUifSwic2NyYXBlX2ludGVydmFsIjoiMW0iLCJzY3JhcGVfdGltZW91dCI6IjYwcyJ9LCJpbWFnZSI6eyJwdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwicmVwb3NpdG9yeSI6InF1YXkuaW8vcHJvbWV0aGV1cy9wcm9tZXRoZXVzIiwidGFnIjoidjIuNTIuMCJ9LCJsaXZlbmVzc1Byb2JlRmFpbHVyZVRocmVzaG9sZCI6MywibGl2ZW5lc3NQcm9iZUluaXRpYWxEZWxheSI6NSwibGl2ZW5lc3NQcm9iZVN1Y2Nlc3NUaHJlc2hvbGQiOjEsImxpdmVuZXNzUHJvYmVUaW1lb3V0IjozLCJuYW1lIjoic2VydmVyIiwibm9kZVNlbGVjdG9yIjp7fSwicGVyc2lzdGVudFZvbHVtZSI6eyJhY2Nlc3NNb2RlcyI6WyJSZWFkV3JpdGVPbmNlIl0sImFubm90YXRpb25zIjp7fSwiZW5hYmxlZCI6dHJ1ZSwiZXhpc3RpbmdDbGFpbSI6IiIsIm1vdW50UGF0aCI6Ii9kYXRhIiwic2l6ZSI6IjMyR2kiLCJzdWJQYXRoIjoiIn0sInBvZEFubm90YXRpb25zIjp7fSwicG9kTGFiZWxzIjp7fSwicHJlZml4VVJMIjoiIiwicHJpb3JpdHlDbGFzc05hbWUiOiIiLCJyZWFkaW5lc3NQcm9iZUZhaWx1cmVUaHJlc2hvbGQiOjMsInJlYWRpbmVzc1Byb2JlSW5pdGlhbERlbGF5Ijo1LCJyZWFkaW5lc3NQcm9iZVN1Y2Nlc3NUaHJlc2hvbGQiOjEsInJlYWRpbmVzc1Byb2JlVGltZW91dCI6MywicmVtb3RlUmVhZCI6e30sInJlbW90ZVdyaXRlIjp7fSwicmVwbGljYUNvdW50IjoxLCJyZXNvdXJjZXMiOnt9LCJyZXRlbnRpb24iOiI5N2giLCJzZWN1cml0eUNvbnRleHQiOnt9LCJzZXJ2aWNlIjp7ImFubm90YXRpb25zIjp7fSwiY2x1c3RlcklQIjoiIiwiZXh0ZXJuYWxJUHMiOltdLCJsYWJlbHMiOnt9LCJsb2FkQmFsYW5jZXJJUCI6IiIsImxvYWRCYWxhbmNlclNvdXJjZVJhbmdlcyI6W10sInNlcnZpY2VQb3J0Ijo4MCwic2Vzc2lvbkFmZmluaXR5IjoiTm9uZSIsInR5cGUiOiJDbHVzdGVySVAifSwic2lkZWNhckNvbnRhaW5lcnMiOm51bGwsInN0cmF0ZWd5Ijp7InJvbGxpbmdVcGRhdGUiOm51bGwsInR5cGUiOiJSZWNyZWF0ZSJ9LCJ0ZXJtaW5hdGlvbkdyYWNlUGVyaW9kU2Vjb25kcyI6MzAwLCJ0b2xlcmF0aW9ucyI6W119LCJzZXJ2ZXJGaWxlcyI6eyJhbGVydGluZ19ydWxlcy55bWwiOnt9LCJhbGVydHMiOnt9LCJwcm9tZXRoZXVzLnltbCI6eyJydWxlX2ZpbGVzIjpbIi9ldGMvY29uZmlnL3JlY29yZGluZ19ydWxlcy55bWwiLCIvZXRjL2NvbmZpZy9hbGVydGluZ19ydWxlcy55bWwiLCIvZXRjL2NvbmZpZy9ydWxlcyIsIi9ldGMvY29uZmlnL2FsZXJ0cyJdLCJzY3JhcGVfY29uZmlncyI6W3siam9iX25hbWUiOiJwcm9tZXRoZXVzIiwic3RhdGljX2NvbmZpZ3MiOlt7InRhcmdldHMiOlsibG9jYWxob3N0OjkwOTAiXX1dfSx7ImJlYXJlcl90b2tlbl9maWxlIjoiL3Zhci9ydW4vc2VjcmV0cy9rdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3Rva2VuIiwiam9iX25hbWUiOiJrdWJlcm5ldGVzLW5vZGVzLWNhZHZpc29yIiwia3ViZXJuZXRlc19zZF9jb25maWdzIjpbeyJyb2xlIjoibm9kZSJ9XSwibWV0cmljX3JlbGFiZWxfY29uZmlncyI6W3siYWN0aW9uIjoia2VlcCIsInJlZ2V4IjoiKGNvbnRhaW5lcl9jcHVfdXNhZ2Vfc2Vjb25kc190b3RhbHxjb250YWluZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVzfGNvbnRhaW5lcl9uZXR3b3JrX3JlY2VpdmVfZXJyb3JzX3RvdGFsfGNvbnRhaW5lcl9uZXR3b3JrX3RyYW5zbWl0X2Vycm9yc190b3RhbHxjb250YWluZXJfbmV0d29ya19yZWNlaXZlX3BhY2tldHNfZHJvcHBlZF90b3RhbHxjb250YWluZXJfbmV0d29ya190cmFuc21pdF9wYWNrZXRzX2Ryb3BwZWRfdG90YWx8Y29udGFpbmVyX21lbW9yeV91c2FnZV9ieXRlc3xjb250YWluZXJfY3B1X2Nmc190aHJvdHRsZWRfcGVyaW9kc190b3RhbHxjb250YWluZXJfY3B1X2Nmc19wZXJpb2RzX3RvdGFsfGNvbnRhaW5lcl9mc191c2FnZV9ieXRlc3xjb250YWluZXJfZnNfbGltaXRfYnl0ZXN8Y29udGFpbmVyX2NwdV9jZnNfcGVyaW9kc190b3RhbHxjb250YWluZXJfZnNfaW5vZGVzX2ZyZWV8Y29udGFpbmVyX2ZzX2lub2Rlc190b3RhbHxjb250YWluZXJfZnNfdXNhZ2VfYnl0ZXN8Y29udGFpbmVyX2ZzX2xpbWl0X2J5dGVzfGNvbnRhaW5lcl9jcHVfY2ZzX3Rocm90dGxlZF9wZXJpb2RzX3RvdGFsfGNvbnRhaW5lcl9jcHVfY2ZzX3BlcmlvZHNfdG90YWx8Y29udGFpbmVyX25ldHdvcmtfcmVjZWl2ZV9ieXRlc190b3RhbHxjb250YWluZXJfbmV0d29ya190cmFuc21pdF9ieXRlc190b3RhbHxjb250YWluZXJfZnNfaW5vZGVzX2ZyZWV8Y29udGFpbmVyX2ZzX2lub2Rlc190b3RhbHxjb250YWluZXJfZnNfdXNhZ2VfYnl0ZXN8Y29udGFpbmVyX2ZzX2xpbWl0X2J5dGVzfGNvbnRhaW5lcl9zcGVjX2NwdV9zaGFyZXN8Y29udGFpbmVyX3NwZWNfbWVtb3J5X2xpbWl0X2J5dGVzfGNvbnRhaW5lcl9uZXR3b3JrX3JlY2VpdmVfYnl0ZXNfdG90YWx8Y29udGFpbmVyX25ldHdvcmtfdHJhbnNtaXRfYnl0ZXNfdG90YWx8Y29udGFpbmVyX2ZzX3JlYWRzX2J5dGVzX3RvdGFsfGNvbnRhaW5lcl9uZXR3b3JrX3JlY2VpdmVfYnl0ZXNfdG90YWx8Y29udGFpbmVyX2ZzX3dyaXRlc19ieXRlc190b3RhbHxjb250YWluZXJfZnNfcmVhZHNfYnl0ZXNfdG90YWx8Y2Fkdmlzb3JfdmVyc2lvbl9pbmZvfGt1YmVjb3N0X3B2X2luZm8pIiwic291cmNlX2xhYmVscyI6WyJfX25hbWVfXyJdfSx7ImFjdGlvbiI6InJlcGxhY2UiLCJyZWdleCI6IiguKykiLCJzb3VyY2VfbGFiZWxzIjpbImNvbnRhaW5lciJdLCJ0YXJnZXRfbGFiZWwiOiJjb250YWluZXJfbmFtZSJ9LHsiYWN0aW9uIjoicmVwbGFjZSIsInJlZ2V4IjoiKC4rKSIsInNvdXJjZV9sYWJlbHMiOlsicG9kIl0sInRhcmdldF9sYWJlbCI6InBvZF9uYW1lIn1dLCJyZWxhYmVsX2NvbmZpZ3MiOlt7ImFjdGlvbiI6ImxhYmVsbWFwIiwicmVnZXgiOiJfX21ldGFfa3ViZXJuZXRlc19ub2RlX2xhYmVsXyguKykifSx7InJlcGxhY2VtZW50Ijoia3ViZXJuZXRlcy5kZWZhdWx0LnN2Yzo0NDMiLCJ0YXJnZXRfbGFiZWwiOiJfX2FkZHJlc3NfXyJ9LHsicmVnZXgiOiIoLispIiwicmVwbGFjZW1lbnQiOiIvYXBpL3YxL25vZGVzLyQxL3Byb3h5L21ldHJpY3MvY2Fkdmlzb3IiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX25vZGVfbmFtZSJdLCJ0YXJnZXRfbGFiZWwiOiJfX21ldHJpY3NfcGF0aF9fIn1dLCJzY2hlbWUiOiJodHRwcyIsInRsc19jb25maWciOnsiY2FfZmlsZSI6Ii92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9jYS5jcnQiLCJpbnNlY3VyZV9za2lwX3ZlcmlmeSI6dHJ1ZX19LHsiYmVhcmVyX3Rva2VuX2ZpbGUiOiIvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvdG9rZW4iLCJqb2JfbmFtZSI6Imt1YmVybmV0ZXMtbm9kZXMiLCJrdWJlcm5ldGVzX3NkX2NvbmZpZ3MiOlt7InJvbGUiOiJub2RlIn1dLCJtZXRyaWNfcmVsYWJlbF9jb25maWdzIjpbeyJhY3Rpb24iOiJrZWVwIiwicmVnZXgiOiIoa3ViZWxldF92b2x1bWVfc3RhdHNfdXNlZF9ieXRlcykiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbmFtZV9fIl19XSwicmVsYWJlbF9jb25maWdzIjpbeyJhY3Rpb24iOiJsYWJlbG1hcCIsInJlZ2V4IjoiX19tZXRhX2t1YmVybmV0ZXNfbm9kZV9sYWJlbF8oLispIn0seyJyZXBsYWNlbWVudCI6Imt1YmVybmV0ZXMuZGVmYXVsdC5zdmM6NDQzIiwidGFyZ2V0X2xhYmVsIjoiX19hZGRyZXNzX18ifSx7InJlZ2V4IjoiKC4rKSIsInJlcGxhY2VtZW50IjoiL2FwaS92MS9ub2Rlcy8kMS9wcm94eS9tZXRyaWNzIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19ub2RlX25hbWUiXSwidGFyZ2V0X2xhYmVsIjoiX19tZXRyaWNzX3BhdGhfXyJ9XSwic2NoZW1lIjoiaHR0cHMiLCJ0bHNfY29uZmlnIjp7ImNhX2ZpbGUiOiIvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvY2EuY3J0IiwiaW5zZWN1cmVfc2tpcF92ZXJpZnkiOnRydWV9fSx7ImpvYl9uYW1lIjoia3ViZXJuZXRlcy1zZXJ2aWNlLWVuZHBvaW50cyIsImt1YmVybmV0ZXNfc2RfY29uZmlncyI6W3sicm9sZSI6ImVuZHBvaW50cyJ9XSwibWV0cmljX3JlbGFiZWxfY29uZmlncyI6W3siYWN0aW9uIjoia2VlcCIsInJlZ2V4IjoiKGNvbnRhaW5lcl9jcHVfYWxsb2NhdGlvbnxjb250YWluZXJfY3B1X3VzYWdlX3NlY29uZHNfdG90YWx8Y29udGFpbmVyX2ZzX2xpbWl0X2J5dGVzfGNvbnRhaW5lcl9mc193cml0ZXNfYnl0ZXNfdG90YWx8Y29udGFpbmVyX2dwdV9hbGxvY2F0aW9ufGNvbnRhaW5lcl9tZW1vcnlfYWxsb2NhdGlvbl9ieXRlc3xjb250YWluZXJfbWVtb3J5X3VzYWdlX2J5dGVzfGNvbnRhaW5lcl9tZW1vcnlfd29ya2luZ19zZXRfYnl0ZXN8Y29udGFpbmVyX25ldHdvcmtfcmVjZWl2ZV9ieXRlc190b3RhbHxjb250YWluZXJfbmV0d29ya190cmFuc21pdF9ieXRlc190b3RhbHxEQ0dNX0ZJX0RFVl9HUFVfVVRJTHxkZXBsb3ltZW50X21hdGNoX2xhYmVsc3xrdWJlX2RhZW1vbnNldF9zdGF0dXNfZGVzaXJlZF9udW1iZXJfc2NoZWR1bGVkfGt1YmVfZGFlbW9uc2V0X3N0YXR1c19udW1iZXJfcmVhZHl8a3ViZV9kZXBsb3ltZW50X3NwZWNfcmVwbGljYXN8a3ViZV9kZXBsb3ltZW50X3N0YXR1c19yZXBsaWNhc3xrdWJlX2RlcGxveW1lbnRfc3RhdHVzX3JlcGxpY2FzX2F2YWlsYWJsZXxrdWJlX2pvYl9zdGF0dXNfZmFpbGVkfGt1YmVfbmFtZXNwYWNlX2Fubm90YXRpb25zfGt1YmVfbmFtZXNwYWNlX2xhYmVsc3xrdWJlX25vZGVfaW5mb3xrdWJlX25vZGVfbGFiZWxzfGt1YmVfbm9kZV9zdGF0dXNfYWxsb2NhdGFibGV8a3ViZV9ub2RlX3N0YXR1c19hbGxvY2F0YWJsZV9jcHVfY29yZXN8a3ViZV9ub2RlX3N0YXR1c19hbGxvY2F0YWJsZV9tZW1vcnlfYnl0ZXN8a3ViZV9ub2RlX3N0YXR1c19jYXBhY2l0eXxrdWJlX25vZGVfc3RhdHVzX2NhcGFjaXR5X2NwdV9jb3Jlc3xrdWJlX25vZGVfc3RhdHVzX2NhcGFjaXR5X21lbW9yeV9ieXRlc3xrdWJlX25vZGVfc3RhdHVzX2NvbmRpdGlvbnxrdWJlX3BlcnNpc3RlbnR2b2x1bWVfY2FwYWNpdHlfYnl0ZXN8a3ViZV9wZXJzaXN0ZW50dm9sdW1lX3N0YXR1c19waGFzZXxrdWJlX3BlcnNpc3RlbnR2b2x1bWVjbGFpbV9pbmZvfGt1YmVfcGVyc2lzdGVudHZvbHVtZWNsYWltX3Jlc291cmNlX3JlcXVlc3RzX3N0b3JhZ2VfYnl0ZXN8a3ViZV9wb2RfY29udGFpbmVyX2luZm98a3ViZV9wb2RfY29udGFpbmVyX3Jlc291cmNlX2xpbWl0c3xrdWJlX3BvZF9jb250YWluZXJfcmVzb3VyY2VfbGltaXRzX2NwdV9jb3Jlc3xrdWJlX3BvZF9jb250YWluZXJfcmVzb3VyY2VfbGltaXRzX21lbW9yeV9ieXRlc3xrdWJlX3BvZF9jb250YWluZXJfcmVzb3VyY2VfcmVxdWVzdHN8a3ViZV9wb2RfY29udGFpbmVyX3Jlc291cmNlX3JlcXVlc3RzX2NwdV9jb3Jlc3xrdWJlX3BvZF9jb250YWluZXJfcmVzb3VyY2VfcmVxdWVzdHNfbWVtb3J5X2J5dGVzfGt1YmVfcG9kX2NvbnRhaW5lcl9zdGF0dXNfcmVzdGFydHNfdG90YWx8a3ViZV9wb2RfY29udGFpbmVyX3N0YXR1c19ydW5uaW5nfGt1YmVfcG9kX2NvbnRhaW5lcl9zdGF0dXNfdGVybWluYXRlZF9yZWFzb258a3ViZV9wb2RfbGFiZWxzfGt1YmVfcG9kX293bmVyfGt1YmVfcG9kX3N0YXR1c19waGFzZXxrdWJlX3JlcGxpY2FzZXRfb3duZXJ8a3ViZV9zdGF0ZWZ1bHNldF9yZXBsaWNhc3xrdWJlX3N0YXRlZnVsc2V0X3N0YXR1c19yZXBsaWNhc3xrdWJlY29zdF9jbHVzdGVyX2luZm98a3ViZWNvc3RfY2x1c3Rlcl9tYW5hZ2VtZW50X2Nvc3R8a3ViZWNvc3RfY2x1c3Rlcl9tZW1vcnlfd29ya2luZ19zZXRfYnl0ZXN8a3ViZWNvc3RfbG9hZF9iYWxhbmNlcl9jb3N0fGt1YmVjb3N0X25ldHdvcmtfaW50ZXJuZXRfZWdyZXNzX2Nvc3R8a3ViZWNvc3RfbmV0d29ya19yZWdpb25fZWdyZXNzX2Nvc3R8a3ViZWNvc3RfbmV0d29ya196b25lX2VncmVzc19jb3N0fGt1YmVjb3N0X25vZGVfaXNfc3BvdHxrdWJlY29zdF9wb2RfbmV0d29ya19lZ3Jlc3NfYnl0ZXNfdG90YWx8bm9kZV9jcHVfaG91cmx5X2Nvc3R8bm9kZV9jcHVfc2Vjb25kc190b3RhbHxub2RlX2Rpc2tfcmVhZHNfY29tcGxldGVkfG5vZGVfZGlza19yZWFkc19jb21wbGV0ZWRfdG90YWx8bm9kZV9kaXNrX3dyaXRlc19jb21wbGV0ZWR8bm9kZV9kaXNrX3dyaXRlc19jb21wbGV0ZWRfdG90YWx8bm9kZV9maWxlc3lzdGVtX2RldmljZV9lcnJvcnxub2RlX2dwdV9jb3VudHxub2RlX2dwdV9ob3VybHlfY29zdHxub2RlX21lbW9yeV9CdWZmZXJzX2J5dGVzfG5vZGVfbWVtb3J5X0NhY2hlZF9ieXRlc3xub2RlX21lbW9yeV9NZW1BdmFpbGFibGVfYnl0ZXN8bm9kZV9tZW1vcnlfTWVtRnJlZV9ieXRlc3xub2RlX21lbW9yeV9NZW1Ub3RhbF9ieXRlc3xub2RlX25ldHdvcmtfdHJhbnNtaXRfYnl0ZXNfdG90YWx8bm9kZV9yYW1faG91cmx5X2Nvc3R8bm9kZV90b3RhbF9ob3VybHlfY29zdHxwb2RfcHZjX2FsbG9jYXRpb258cHZfaG91cmx5X2Nvc3R8c2VydmljZV9zZWxlY3Rvcl9sYWJlbHN8c3RhdGVmdWxTZXRfbWF0Y2hfbGFiZWxzfGt1YmVjb3N0X3B2X2luZm98dXApIiwic291cmNlX2xhYmVscyI6WyJfX25hbWVfXyJdfV0sInJlbGFiZWxfY29uZmlncyI6W3siYWN0aW9uIjoia2VlcCIsInJlZ2V4Ijp0cnVlLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfYW5ub3RhdGlvbl9wcm9tZXRoZXVzX2lvX3NjcmFwZSJdfSx7ImFjdGlvbiI6ImtlZXAiLCJyZWdleCI6IiguKm5vZGUtZXhwb3J0ZXJ8a3ViZWNvc3QtbmV0d29yay1jb3N0cykiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX2VuZHBvaW50c19uYW1lIl19LHsiYWN0aW9uIjoicmVwbGFjZSIsInJlZ2V4IjoiKGh0dHBzPykiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfYW5ub3RhdGlvbl9wcm9tZXRoZXVzX2lvX3NjaGVtZSJdLCJ0YXJnZXRfbGFiZWwiOiJfX3NjaGVtZV9fIn0seyJhY3Rpb24iOiJyZXBsYWNlIiwicmVnZXgiOiIoLispIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX2Fubm90YXRpb25fcHJvbWV0aGV1c19pb19wYXRoIl0sInRhcmdldF9sYWJlbCI6Il9fbWV0cmljc19wYXRoX18ifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJyZWdleCI6IihbXjpdKykoPzo6XFxkKyk/OyhcXGQrKSIsInJlcGxhY2VtZW50IjoiJDE6JDIiLCJzb3VyY2VfbGFiZWxzIjpbIl9fYWRkcmVzc19fIiwiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9hbm5vdGF0aW9uX3Byb21ldGhldXNfaW9fcG9ydCJdLCJ0YXJnZXRfbGFiZWwiOiJfX2FkZHJlc3NfXyJ9LHsiYWN0aW9uIjoibGFiZWxtYXAiLCJyZWdleCI6Il9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfbGFiZWxfKC4rKSJ9LHsiYWN0aW9uIjoicmVwbGFjZSIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfbmFtZXNwYWNlIl0sInRhcmdldF9sYWJlbCI6Imt1YmVybmV0ZXNfbmFtZXNwYWNlIn0seyJhY3Rpb24iOiJyZXBsYWNlIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX25hbWUiXSwidGFyZ2V0X2xhYmVsIjoia3ViZXJuZXRlc19uYW1lIn0seyJhY3Rpb24iOiJyZXBsYWNlIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19wb2Rfbm9kZV9uYW1lIl0sInRhcmdldF9sYWJlbCI6Imt1YmVybmV0ZXNfbm9kZSJ9XX1dfSwicmVjb3JkaW5nX3J1bGVzLnltbCI6e30sInJ1bGVzIjp7Imdyb3VwcyI6W3sibmFtZSI6IkNQVSIsInJ1bGVzIjpbeyJleHByIjoic3VtKHJhdGUoY29udGFpbmVyX2NwdV91c2FnZV9zZWNvbmRzX3RvdGFse2NvbnRhaW5lciE9XCJcIn1bNW1dKSkiLCJyZWNvcmQiOiJjbHVzdGVyOmNwdV91c2FnZTpyYXRlNW0ifSx7ImV4cHIiOiJyYXRlKGNvbnRhaW5lcl9jcHVfdXNhZ2Vfc2Vjb25kc190b3RhbHtjb250YWluZXIhPVwiXCJ9WzVtXSkiLCJyZWNvcmQiOiJjbHVzdGVyOmNwdV91c2FnZV9ub3N1bTpyYXRlNW0ifSx7ImV4cHIiOiJhdmcoaXJhdGUoY29udGFpbmVyX2NwdV91c2FnZV9zZWNvbmRzX3RvdGFse2NvbnRhaW5lciE9XCJQT0RcIiwgY29udGFpbmVyIT1cIlwifVs1bV0pKSBieSAoY29udGFpbmVyLHBvZCxuYW1lc3BhY2UpIiwicmVjb3JkIjoia3ViZWNvc3RfY29udGFpbmVyX2NwdV91c2FnZV9pcmF0ZSJ9LHsiZXhwciI6InN1bShjb250YWluZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVze2NvbnRhaW5lciE9XCJQT0RcIixjb250YWluZXIhPVwiXCJ9KSBieSAoY29udGFpbmVyLHBvZCxuYW1lc3BhY2UpIiwicmVjb3JkIjoia3ViZWNvc3RfY29udGFpbmVyX21lbW9yeV93b3JraW5nX3NldF9ieXRlcyJ9LHsiZXhwciI6InN1bShjb250YWluZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVze2NvbnRhaW5lciE9XCJQT0RcIixjb250YWluZXIhPVwiXCJ9KSIsInJlY29yZCI6Imt1YmVjb3N0X2NsdXN0ZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVzIn1dfSx7Im5hbWUiOiJTYXZpbmdzIiwicnVsZXMiOlt7ImV4cHIiOiJzdW0oYXZnKGt1YmVfcG9kX293bmVye293bmVyX2tpbmQhPVwiRGFlbW9uU2V0XCJ9KSBieSAocG9kKSAqIHN1bShjb250YWluZXJfY3B1X2FsbG9jYXRpb24pIGJ5IChwb2QpKSIsImxhYmVscyI6eyJkYWVtb25zZXQiOiJmYWxzZSJ9LCJyZWNvcmQiOiJrdWJlY29zdF9zYXZpbmdzX2NwdV9hbGxvY2F0aW9uIn0seyJleHByIjoic3VtKGF2ZyhrdWJlX3BvZF9vd25lcntvd25lcl9raW5kPVwiRGFlbW9uU2V0XCJ9KSBieSAocG9kKSAqIHN1bShjb250YWluZXJfY3B1X2FsbG9jYXRpb24pIGJ5IChwb2QpKSAvIHN1bShrdWJlX25vZGVfaW5mbykiLCJsYWJlbHMiOnsiZGFlbW9uc2V0IjoidHJ1ZSJ9LCJyZWNvcmQiOiJrdWJlY29zdF9zYXZpbmdzX2NwdV9hbGxvY2F0aW9uIn0seyJleHByIjoic3VtKGF2ZyhrdWJlX3BvZF9vd25lcntvd25lcl9raW5kIT1cIkRhZW1vblNldFwifSkgYnkgKHBvZCkgKiBzdW0oY29udGFpbmVyX21lbW9yeV9hbGxvY2F0aW9uX2J5dGVzKSBieSAocG9kKSkiLCJsYWJlbHMiOnsiZGFlbW9uc2V0IjoiZmFsc2UifSwicmVjb3JkIjoia3ViZWNvc3Rfc2F2aW5nc19tZW1vcnlfYWxsb2NhdGlvbl9ieXRlcyJ9LHsiZXhwciI6InN1bShhdmcoa3ViZV9wb2Rfb3duZXJ7b3duZXJfa2luZD1cIkRhZW1vblNldFwifSkgYnkgKHBvZCkgKiBzdW0oY29udGFpbmVyX21lbW9yeV9hbGxvY2F0aW9uX2J5dGVzKSBieSAocG9kKSkgLyBzdW0oa3ViZV9ub2RlX2luZm8pIiwibGFiZWxzIjp7ImRhZW1vbnNldCI6InRydWUifSwicmVjb3JkIjoia3ViZWNvc3Rfc2F2aW5nc19tZW1vcnlfYWxsb2NhdGlvbl9ieXRlcyJ9XX1dfX0sInNlcnZpY2VBY2NvdW50cyI6eyJhbGVydG1hbmFnZXIiOnsiY3JlYXRlIjp0cnVlLCJuYW1lIjpudWxsfSwibm9kZUV4cG9ydGVyIjp7ImNyZWF0ZSI6dHJ1ZSwibmFtZSI6bnVsbH0sInB1c2hnYXRld2F5Ijp7ImNyZWF0ZSI6dHJ1ZSwibmFtZSI6bnVsbH0sInNlcnZlciI6eyJhbm5vdGF0aW9ucyI6e30sImNyZWF0ZSI6dHJ1ZSwibmFtZSI6bnVsbH19fSwicmVwb3J0aW5nIjp7ImVycm9yUmVwb3J0aW5nIjp0cnVlLCJsb2dDb2xsZWN0aW9uIjp0cnVlLCJwcm9kdWN0QW5hbHl0aWNzIjp0cnVlLCJ2YWx1ZXNSZXBvcnRpbmciOnRydWV9LCJzZXJ2aWNlIjp7ImFubm90YXRpb25zIjp7fSwibGFiZWxzIjp7fSwibm9kZVBvcnQiOnt9LCJwb3J0Ijo5MDkwLCJ0YXJnZXRQb3J0Ijo5MDkwLCJ0eXBlIjoiQ2x1c3RlcklQIn0sInNlcnZpY2VBY2NvdW50Ijp7ImFubm90YXRpb25zIjp7fSwiY3JlYXRlIjp0cnVlfSwic2lnVjRQcm94eSI6eyJleHRyYUVudiI6bnVsbCwiaG9zdCI6ImFwcy13b3Jrc3BhY2VzLnVzLXdlc3QtMi5hbWF6b25hd3MuY29tIiwiaW1hZ2UiOiJwdWJsaWMuZWNyLmF3cy9hd3Mtb2JzZXJ2YWJpbGl0eS9hd3Mtc2lndjQtcHJveHk6bGF0ZXN0IiwiaW1hZ2VQdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwibmFtZSI6ImFwcyIsInBvcnQiOjgwMDUsInJlZ2lvbiI6InVzLXdlc3QtMiIsInJlc291cmNlcyI6e319LCJzdXBwb3J0TkZTIjpmYWxzZSwidG9sZXJhdGlvbnMiOltdLCJ0b3BvbG9neVNwcmVhZENvbnN0cmFpbnRzIjpbXSwidXBncmFkZSI6eyJ0b1YyIjpmYWxzZX19
+            - name: LOG_LEVEL
+              value: info
             - name: READ_ONLY
               value: "false"
             - name: PROMETHEUS_SERVER_ENDPOINT
@@ -23320,14 +23644,6 @@ spec:
               value: /var/db/
             - name: CLUSTER_PROFILE
               value: production
-            - name: EMIT_POD_ANNOTATIONS_METRIC
-              value: "false"
-            - name: EMIT_NAMESPACE_ANNOTATIONS_METRIC
-              value: "false"
-            - name: EMIT_KSM_V1_METRICS
-              value: "true"
-            - name: EMIT_KSM_V1_METRICS_ONLY # ONLY emit KSM v1 metrics that do not exist in KSM 2 by default
-              value: "false"
             - name: LOG_COLLECTION_ENABLED
               value: "true"
             - name: PRODUCT_ANALYTICS_ENABLED
@@ -23338,12 +23654,6 @@ spec:
               value: "true"
             - name: SENTRY_DSN
               value: "https://71964476292e4087af8d5072afe43abd@o394722.ingest.sentry.io/5245431"
-            - name: LEGACY_EXTERNAL_API_DISABLED
-              value: "false"
-            - name: CACHE_WARMING_ENABLED
-              value: "false"
-            - name: SAVINGS_ENABLED
-              value: "true"
             - name: ETL_RESOLUTION_SECONDS
               value: "300"
             - name: ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES
@@ -23352,22 +23662,12 @@ spec:
               value: "91"
             - name: ETL_HOURLY_STORE_DURATION_HOURS
               value: "49"
-            - name: ETL_WEEKLY_STORE_DURATION_WEEKS
-              value: "53"
-            - name: ETL_FILE_STORE_ENABLED
+            - name: CONTAINER_STATS_ENABLED
               value: "true"
-            - name: ETL_ASSET_RECONCILIATION_ENABLED
-              value: "true"
-            - name: RECONCILE_NETWORK
-              value: "true"
-            - name: KUBECOST_METRICS_POD_ENABLED
-              value: "false"
             - name: PV_ENABLED
               value: "true"
             - name: MAX_QUERY_CONCURRENCY
               value: "5"
-            - name: UTC_OFFSET
-              value: "+00:00"
             - name: CLUSTER_ID
               value: cluster-one
             - name: COST_EVENTS_AUDIT_ENABLED
@@ -23390,7 +23690,7 @@ spec:
               value: "true"
             - name: DIAGNOSTICS_RUN_IN_COST_MODEL
               value: "false"
-        - image: gcr.io/kubecost1/frontend:prod-2.3.3
+        - image: gcr.io/kubecost1/frontend:prod-2.7.2
           env:
             - name: GET_HOSTS_FROM
               value: dns
@@ -23405,6 +23705,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: tmp
+              mountPath: /var/lib/nginx/tmp
+            - name: tmp
+              mountPath: /var/run
+            - name: log
+              mountPath: /var/log/nginx
             - name: nginx-conf
               mountPath: /etc/nginx/conf.d/
           resources:
@@ -23426,8 +23732,8 @@ spec:
             initialDelaySeconds: 1
             periodSeconds: 5
             failureThreshold: 6
-
-
+        
+        
         - name: aggregator
           securityContext:
             allowPrivilegeEscalation: false
@@ -23436,7 +23742,7 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/kubecost1/cost-model:prod-2.3.3
+          image: gcr.io/kubecost1/cost-model:prod-2.7.2
           readinessProbe:
             httpGet:
               path: /healthz
@@ -23459,7 +23765,7 @@ spec:
             - name: CLUSTER_ID
               value: cluster-one
             - name: NUM_DB_COPY_CHUNKS
-              value: "1"
+              value: "25"
             - name: CONFIG_PATH
               value: /var/configs/
             - name: CLOUD_PROVIDER_API_KEY
@@ -23470,24 +23776,28 @@ spec:
               value: "false"
             - name: LOG_LEVEL
               value: info
-            - name: DB_COPY_FULL
-              value: "false"
             - name: DB_READ_THREADS
-              value: "1"
+              value: "0"
             - name: DB_WRITE_THREADS
               value: "1"
             - name: DB_CONCURRENT_INGESTION_COUNT
               value: "1"
             - name: ETL_DAILY_STORE_DURATION_DAYS
               value: "91"
+            - name: ETL_HOURLY_STORE_DURATION_HOURS
+              value: "49"
+            - name: CONTAINER_RESOURCE_USAGE_RETENTION_DAYS
+              value: "1"
             - name: DB_TRIM_MEMORY_ON_CLOSE
               value: "true"
             - name: KUBECOST_NAMESPACE
               value: kubecost
-
+            - name: GRAFANA_ENABLED
+              value: "true"
+        
         - name: cloud-cost
-          image: gcr.io/kubecost1/cost-model:prod-2.3.3
-
+          image: gcr.io/kubecost1/cost-model:prod-2.7.2
+          
           readinessProbe:
             httpGet:
               path: /healthz
@@ -23534,7 +23844,7 @@ metadata:
   name: kubecost-forecasting
   namespace: kubecost
   labels:
-    helm.sh/chart: cost-analyzer-2.3.3
+    helm.sh/chart: cost-analyzer-2.7.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: forecasting
     app.kubernetes.io/instance: kubecost
@@ -23620,7 +23930,7 @@ spec:
         emptyDir:
           sizeLimit: 500Mi
 ---
-# Source: cost-analyzer/templates/grafana-deployment.yaml
+# Source: cost-analyzer/templates/grafana/grafana-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23655,7 +23965,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: grafana-sc-dashboard
-          image: "ghcr.io/kiwigrid/k8s-sidecar:1.28.1"
+          image: "ghcr.io/kiwigrid/k8s-sidecar:1.30.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -23675,7 +23985,7 @@ spec:
             - name: sc-dashboard-volume
               mountPath: "/tmp/dashboards"
         - name: grafana
-          image: "grafana/grafana:10.4.3"
+          image: "grafana/grafana:11.6.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -23688,9 +23998,6 @@ spec:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"
               subPath: grafana.ini
-            - name: ldap
-              mountPath: "/etc/grafana/ldap.toml"
-              subPath: ldap.toml
             - name: config
               mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
               subPath: datasources.yaml
@@ -23736,12 +24043,6 @@ spec:
         - name: config
           configMap:
             name: kubecost-grafana
-        - name: ldap
-          secret:
-            secretName: kubecost-grafana
-            items:
-              - key: ldap-toml
-                path: ldap.toml
         - name: storage
           emptyDir: {}
         - name: sc-dashboard-volume
@@ -23750,10 +24051,11 @@ spec:
           configMap:
             name: kubecost-grafana-config-dashboards
 ---
-# Source: cost-analyzer/templates/prometheus-server-deployment.yaml
+# Source: cost-analyzer/templates/prometheus/prometheus-server-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
   labels:
     component: "server"
     app: prometheus
@@ -23773,6 +24075,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        checksum/configs: 94efe14b6d552763f575fc2e59e0ffe829dc64011940e47b4785990b90ea9534
       labels:
         component: "server"
         app: prometheus
@@ -23783,7 +24087,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.55.1"
+          image: "quay.io/prometheus/prometheus:v3.3.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=97h


### PR DESCRIPTION
update kubecost.yaml to 2.7.2

update chart.yaml to version to 0.0.0 to make it more obvious that this isn't a released version. this is updated by release scripts.

## Release Notes Headline
NA

## Commentary for Reviewers
Had a user ask about kubecost.yaml last week. 2.3.3 is a bit dated at this point. No harm in keeping kubecost.yaml for simple testing.

## Testing
![image](https://github.com/user-attachments/assets/468ac657-49e2-4e28-b0f3-8ae6030093ab)

Manually compared kubecost.yaml to previous version.