### PR TITLE
[KCM-4057,4059,4060] Add routes for Builder APIs

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -976,6 +976,22 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/builders {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/builders;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location = /model/builder {
+            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
+            proxy_pass http://aggregator/builder;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/kubernetes/containers/resources {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_pass http://aggregator/kubernetes/containers/resources;


### PR DESCRIPTION
## Release Notes Headline

Add routes for Builder APIs

## Commentary for Reviewers

Routes for the following APIs:
- `GET /builders`
- `GET /builder?id=`
- `POST /builders`
that have been set up in https://github.com/kubecost/kubecost-cost-model/pull/3347

## Links to Issues or Tickets

Together with:
- https://github.com/kubecost/kubecost-cost-model/pull/3347
- https://github.com/kubecost/kubecost-core/pull/159

Closes
- https://apptio.atlassian.net/browse/KCM-4057
- https://apptio.atlassian.net/browse/KCM-4059
- https://apptio.atlassian.net/browse/KCM-4060

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A
