### PR TITLE
Add unified agent access needs to cluster role

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
@@ -39,10 +39,7 @@ rules:
     resources:
       - configmaps
       - nodes
-      - nodes/spec
       - pods
-      - jobs
-      - cronjobs
       - events
       - services
       - resourcequotas
@@ -52,46 +49,39 @@ rules:
       - persistentvolumes
       - namespaces
       - endpoints
-      - deployments
-      - replicasets
-      - daemonsets
     verbs:
       - get
       - list
       - watch
   - apiGroups:
       - ''
+    verbs:
+      - get
+      - list
     resources:
       - services/proxy
       - pods/proxy
       - nodes/proxy
-      - nodes/stats
-      - nodes/metrics
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
-      - extensions
-      - apps
       - batch
     resources:
-      - namespaces
-      - replicationcontrollers
-      - services
-      - nodes
-      - nodes/spec
-      - pods
-      - jobs
       - cronjobs
-      - persistentvolumes
-      - persistentvolumeclaims
-      - deployments
-      - replicasets
-      - daemonsets
+      - jobs
     verbs:
       - get
-      - watch
       - list
+      - watch
   - apiGroups:
       - autoscaling
     resources:

--- a/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
@@ -59,8 +59,6 @@ rules:
       - get
       - list
     resources:
-      - services/proxy
-      - pods/proxy
       - nodes/proxy
   - apiGroups:
       - apps

--- a/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
@@ -39,7 +39,10 @@ rules:
     resources:
       - configmaps
       - nodes
+      - nodes/spec
       - pods
+      - jobs
+      - cronjobs
       - events
       - services
       - resourcequotas
@@ -49,30 +52,46 @@ rules:
       - persistentvolumes
       - namespaces
       - endpoints
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - statefulsets
       - deployments
-      - daemonsets
       - replicasets
+      - daemonsets
     verbs:
       - get
       - list
       - watch
   - apiGroups:
+      - ''
+    resources:
+      - services/proxy
+      - pods/proxy
+      - nodes/proxy
+      - nodes/stats
+      - nodes/metrics
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - extensions
+      - apps
       - batch
     resources:
-      - cronjobs
+      - namespaces
+      - replicationcontrollers
+      - services
+      - nodes
+      - nodes/spec
+      - pods
       - jobs
+      - cronjobs
+      - persistentvolumes
+      - persistentvolumeclaims
+      - deployments
+      - replicasets
+      - daemonsets
     verbs:
       - get
-      - list
       - watch
+      - list
   - apiGroups:
       - autoscaling
     resources:


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
This change updates the Cluster Role for Cost-Analyzer to support the access needs of the unified agent
These changes were made using these permissions:
```
- verbs:
      - get
      - watch
      - list
    apiGroups:
      - ''
      - extensions
      - apps
      - batch
    resources:
      - namespaces
      - replicationcontrollers
      - services
      - nodes
      - nodes/spec
      - pods
      - jobs
      - cronjobs
      - persistentvolumes
      - persistentvolumeclaims
      - deployments
      - replicasets
      - daemonsets
  - verbs:
      - get
      - list
    apiGroups:
      - ''
    resources:
      - services/proxy
      - pods/proxy
      - nodes/proxy
      - nodes/stats
      - nodes/metrics
```
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
