### PR TITLE
Add a Github Action that will require PRs to have a label for the target version of the product

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -1,0 +1,30 @@
+name: Label Checker
+on:
+    pull_request:
+        branches:
+            - develop
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - labeled
+            - unlabeled
+    merge_group:
+      types: [checks_requested]
+
+jobs:
+  check_labels:
+    name: Check labels
+    runs-on: Kubecost-Linux-Small-x86
+    steps:
+      - id: check-labels
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          add_comment: true
+          message: "This PR requires a version label that you want the PRd feature to be released in, in the form of vMAJOR.MINOR"
+          use_regex: true
+          labels: | 
+              ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)
+              dependencies


### PR DESCRIPTION

## Release Notes Headline
N/A

## Commentary for Reviewers
Add a Github Action that will require PRs to have a label for the target version of the product.

## Links to Issues or Tickets

N/A

## User Impact and Risks
The impact will be to repo contributors. All pull requests will be required to set a label of the format `v$MAJOR.$MINOR`, denoting which major/minor release the PR is targeting. At least one of these must be set for all PRs.

## Testing

N/A

## Documentation Updates
N/A
