### PR TITLE
Investigate issue with Kubecost-Linux-Small-x86 runner in this repo

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -15,7 +15,8 @@ on:
 jobs:
   check_labels:
     name: Check labels
-    runs-on: Kubecost-Linux-Small-x86
+    # runs-on: Kubecost-Linux-Small-x86
+    runs-on: ubuntu-latest
     steps:
       - id: check-labels
         uses: mheap/github-action-required-labels@v5

--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -15,7 +15,6 @@ on:
 jobs:
   check_labels:
     name: Check labels
-    # runs-on: Kubecost-Linux-Small-x86
     runs-on: ubuntu-latest
     steps:
       - id: check-labels

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -528,9 +528,11 @@ kubecostFrontend:
   # securityContext:
   #   readOnlyRootFilesystem: true
   resources:
+    limits:
+      memory: 200Mi
     requests:
-      cpu: "10m"
-      memory: "55Mi"
+      cpu: 50m
+      memory: 10Mi
   deploymentStrategy: {}
   readinessProbe:
     enabled: true
@@ -722,12 +724,11 @@ kubecostModel:
   # max number of concurrent Prometheus queries
   maxQueryConcurrency: 5
   resources:
+    limits:
+      memory: 1Gi
     requests:
-      cpu: "200m"
-      memory: "55Mi"
-    # limits:
-    #   cpu: "800m"
-    #   memory: "256Mi"
+      cpu: 50m
+      memory: 100Mi
 
   readinessProbe:
     enabled: true
@@ -1721,10 +1722,12 @@ kubecostAggregator:
     storageClass: ""  # default storage class
     storageRequest: 128Gi
 
-  resources: {}
-    # requests:
-    #   cpu: 1000m
-    #   memory: 1Gi
+  resources:
+    limits:
+      memory: 10Gi
+    requests:
+      cpu: 3000m
+      memory: 10Gi
 
   readinessProbe:
     enabled: true

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -136,7 +136,7 @@ global:
     #     # Spend Change Alert
     #     - type: spendChange         # change relative to moving avg
     #       relativeThreshold: 0.20   # Proportional change relative to baseline. Must be greater than -1 (can be negative)
-    #       window: 1d                # accepts ‘d’, ‘h’
+    #       window: 1d                # accepts 'd', 'h'
     #       baselineWindow: 30d       # previous window, offset by window
     #       aggregation: namespace
     #       filter: kubecost, default # accepts csv
@@ -722,12 +722,11 @@ kubecostModel:
   # max number of concurrent Prometheus queries
   maxQueryConcurrency: 5
   resources:
+    limits:
+      memory: 1Gi
     requests:
-      cpu: "200m"
-      memory: "55Mi"
-    # limits:
-    #   cpu: "800m"
-    #   memory: "256Mi"
+      cpu: 50m
+      memory: 100Mi
 
   readinessProbe:
     enabled: true
@@ -1721,10 +1720,13 @@ kubecostAggregator:
     storageClass: ""  # default storage class
     storageRequest: 128Gi
 
-  resources: {}
-    # requests:
-    #   cpu: 1000m
-    #   memory: 1Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
 
   readinessProbe:
     enabled: true


### PR DESCRIPTION
## Release Notes Headline
N/A

## Commentary for Reviewers
This PR changes the runner for the `Check Labels` job from the unavailable `Kubecost-Linux-Small-x86` runner to the `ubuntu-latest` runner. The `Kubecost-Linux-Small-x86` runner is not configured for the `cost-analyzer-helm-chart` repo. 

## Links to Issues or Tickets
N/A - Troubleshooting https://github.com/kubecost/cost-analyzer-helm-chart/pull/4066/files#r2089165762

## User Impact and Risks
N/A

## Testing
Successfully ran the `Check Labels` job on the `ubuntu-latest` runner when I opened the PR.

## Documentation Updates
N/A
