### PR TITLE
Investigate issue with Kubecost-Linux-Small-x86 runner in this repo

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -109,6 +109,18 @@ jobs:
       - name: Run Helm tests 
         run: helm test -n kubecost kubecost
 
+      - name: Collect cluster logs
+        if: always()
+        run: |
+          echo "=== Pod Status ==="
+          kubectl get pods -A
+          echo "=== Cost Analyzer Pod Logs ==="
+          kubectl logs -n kubecost -l app.kubernetes.io/name=cost-analyzer
+          echo "=== Cost Analyzer Pod Description ==="
+          kubectl describe pod -n kubecost -l app.kubernetes.io/name=cost-analyzer
+          echo "=== Events in kubecost namespace ==="
+          kubectl get events -n kubecost
+
       - name: Uninstall chart
         run: helm uninstall kubecost -n kubecost --no-hooks --wait
 
@@ -190,6 +202,17 @@ jobs:
         run: kubectl wait -n kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=120s
       - name: Run Helm tests 
         run: helm test -n kubecost kubecost
+      - name: Collect cluster logs
+        if: always()
+        run: |
+          echo "=== Pod Status ==="
+          kubectl get pods -A
+          echo "=== Cost Analyzer Pod Logs ==="
+          kubectl logs -n kubecost -l app.kubernetes.io/name=cost-analyzer
+          echo "=== Cost Analyzer Pod Description ==="
+          kubectl describe pod -n kubecost -l app.kubernetes.io/name=cost-analyzer
+          echo "=== Events in kubecost namespace ==="
+          kubectl get events -n kubecost
       - name: Remove Cluster
         id: remove-cluster
         uses: replicatedhq/compatibility-actions/remove-cluster@v1
@@ -243,6 +266,17 @@ jobs:
         run: kubectl wait -n kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=120s
       - name: Run Helm tests 
         run: helm test -n kubecost kubecost
+      - name: Collect cluster logs
+        if: always()
+        run: |
+          echo "=== Pod Status ==="
+          kubectl get pods -A
+          echo "=== Cost Analyzer Pod Logs ==="
+          kubectl logs -n kubecost -l app.kubernetes.io/name=cost-analyzer
+          echo "=== Cost Analyzer Pod Description ==="
+          kubectl describe pod -n kubecost -l app.kubernetes.io/name=cost-analyzer
+          echo "=== Events in kubecost namespace ==="
+          kubectl get events -n kubecost
       - name: Remove Cluster
         id: remove-cluster
         uses: replicatedhq/compatibility-actions/remove-cluster@v1

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -118,8 +118,16 @@ jobs:
           kubectl logs -n kubecost -l app.kubernetes.io/name=cost-analyzer
           echo "=== Cost Analyzer Pod Description ==="
           kubectl describe pod -n kubecost -l app.kubernetes.io/name=cost-analyzer
+          echo "=== Test Pod Logs ==="
+          kubectl logs -n kubecost -l test=basic-health
+          echo "=== Test Pod Description ==="
+          kubectl describe pod -n kubecost -l test=basic-health
           echo "=== Events in kubecost namespace ==="
           kubectl get events -n kubecost
+          echo "=== Service Status ==="
+          kubectl get svc -n kubecost
+          echo "=== Endpoint Status ==="
+          kubectl get endpoints -n kubecost
 
       - name: Uninstall chart
         run: helm uninstall kubecost -n kubecost --no-hooks --wait
@@ -211,8 +219,16 @@ jobs:
           kubectl logs -n kubecost -l app.kubernetes.io/name=cost-analyzer
           echo "=== Cost Analyzer Pod Description ==="
           kubectl describe pod -n kubecost -l app.kubernetes.io/name=cost-analyzer
+          echo "=== Test Pod Logs ==="
+          kubectl logs -n kubecost -l test=basic-health
+          echo "=== Test Pod Description ==="
+          kubectl describe pod -n kubecost -l test=basic-health
           echo "=== Events in kubecost namespace ==="
           kubectl get events -n kubecost
+          echo "=== Service Status ==="
+          kubectl get svc -n kubecost
+          echo "=== Endpoint Status ==="
+          kubectl get endpoints -n kubecost
       - name: Remove Cluster
         id: remove-cluster
         uses: replicatedhq/compatibility-actions/remove-cluster@v1
@@ -275,8 +291,16 @@ jobs:
           kubectl logs -n kubecost -l app.kubernetes.io/name=cost-analyzer
           echo "=== Cost Analyzer Pod Description ==="
           kubectl describe pod -n kubecost -l app.kubernetes.io/name=cost-analyzer
+          echo "=== Test Pod Logs ==="
+          kubectl logs -n kubecost -l test=basic-health
+          echo "=== Test Pod Description ==="
+          kubectl describe pod -n kubecost -l test=basic-health
           echo "=== Events in kubecost namespace ==="
           kubectl get events -n kubecost
+          echo "=== Service Status ==="
+          kubectl get svc -n kubecost
+          echo "=== Endpoint Status ==="
+          kubectl get endpoints -n kubecost
       - name: Remove Cluster
         id: remove-cluster
         uses: replicatedhq/compatibility-actions/remove-cluster@v1

--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   check_labels:
     name: Check labels
-    runs-on: Kubecost-Linux-Small-x86
+    runs-on: ubuntu-latest
     steps:
       - id: check-labels
         uses: mheap/github-action-required-labels@v5

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2508,5 +2508,5 @@ extraObjects: []
 #               number: 80
 
 # -- Optional override for the image used for the basic health test container
-# basicHealth:
-#   fullImageName: alpine/k8s:1.26.9
+basicHealth:
+  fullImageName: alpine/k8s:1.32.4

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1723,10 +1723,10 @@ kubecostAggregator:
 
   resources:
     limits:
-      memory: 5Gi
+      memory: 2Gi
     requests:
       cpu: 1000m
-      memory: 5Gi
+      memory: 1Gi
 
   readinessProbe:
     enabled: true

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -2509,4 +2509,4 @@ extraObjects: []
 
 # -- Optional override for the image used for the basic health test container
 basicHealth:
-  fullImageName: alpine/k8s:1.32.4
+  fullImageName: alpine/k8s:1.26.9

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1721,10 +1721,12 @@ kubecostAggregator:
     storageClass: ""  # default storage class
     storageRequest: 128Gi
 
-  resources: {}
-    # requests:
-    #   cpu: 1000m
-    #   memory: 1Gi
+  resources:
+    limits:
+      memory: 5Gi
+    requests:
+      cpu: 1000m
+      memory: 5Gi
 
   readinessProbe:
     enabled: true


### PR DESCRIPTION
## Release Notes Headline
N/A

## Commentary for Reviewers
This PR changes the runner for the `Check Labels` job from the unavailable `Kubecost-Linux-Small-x86` runner to the `ubuntu-latest` runner. The `Kubecost-Linux-Small-x86` runner is not configured for the `cost-analyzer-helm-chart` repo. 

## Links to Issues or Tickets
N/A - Troubleshooting https://github.com/kubecost/cost-analyzer-helm-chart/pull/4066/files#r2089165762 and https://kubecost.slack.com/archives/C044PFZN7SN/p1747216862744319. 

## User Impact and Risks
N/A

## Testing
- Successfully ran the `Check Labels` job on the `ubuntu-latest` runner when I opened the PR.

## Documentation Updates
N/A
