### PR TITLE
Runner debug wip

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   check_labels:
     name: Check labels
-    runs-on: Kubecost-Linux-Small-x86
+    runs-on: ubuntu-latest
     steps:
       - id: check-labels
         uses: mheap/github-action-required-labels@v5

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1723,10 +1723,10 @@ kubecostAggregator:
 
   resources:
     limits:
-      memory: 5Gi
+      memory: 2Gi
     requests:
       cpu: 1000m
-      memory: 5Gi
+      memory: 1Gi
 
   readinessProbe:
     enabled: true

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1721,10 +1721,12 @@ kubecostAggregator:
     storageClass: ""  # default storage class
     storageRequest: 128Gi
 
-  resources: {}
-    # requests:
-    #   cpu: 1000m
-    #   memory: 1Gi
+  resources:
+    limits:
+      memory: 5Gi
+    requests:
+      cpu: 1000m
+      memory: 5Gi
 
   readinessProbe:
     enabled: true


### PR DESCRIPTION
## Release Notes Headline
N/A

## Commentary for Reviewers
This PR changes the runner for the `Check Labels` job from the unavailable `Kubecost-Linux-Small-x86` runner to the `ubuntu-latest` runner. The `Kubecost-Linux-Small-x86` runner is not configured for the `cost-analyzer-helm-chart` repo. 

## Links to Issues or Tickets
N/A - Troubleshooting https://github.com/kubecost/cost-analyzer-helm-chart/pull/4066/files#r2089165762 and https://kubecost.slack.com/archives/C044PFZN7SN/p1747216862744319. 

## User Impact and Risks
N/A

## Testing
- Successfully ran the `Check Labels` job on the `ubuntu-latest` runner when I opened the PR.

## Documentation Updates
N/A
