### PR TITLE
fix a number of DAST scan alerts

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -15,6 +15,7 @@ metadata:
     {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
 data:
   nginx.conf: |
+    server_tokens off;
     gzip_static  on;
 
     # Enable gzip encoding for content of the provided types of 50kb and higher.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -576,8 +576,9 @@ kubecostFrontend:
     server:
       - "'Access-Control-Allow-Origin' '*' always;"
       - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
-      - "Content-Security-Policy \"default-src 'self' 'unsafe-inline' http: https: ws: data:; frame-ancestors 'none';\";"
+      - "Content-Security-Policy \"default-src 'self' 'unsafe-inline' data: api.userway.com cdn.userway.com api.mixpanel.com; frame-ancestors 'none'; form-action 'self';\";"
       - Cache-Control "must-revalidate";
+      - "X-Content-Type-Options \"nosniff\";"
 
 # Kubecost Metrics deploys a separate pod which will emit kubernetes specific metrics required
 # by the cost-model. This pod is designed to remain active and decoupled from the cost-model itself.

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -576,7 +576,7 @@ kubecostFrontend:
     server:
       - "'Access-Control-Allow-Origin' '*' always;"
       - "'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, OPTIONS' always;"
-      - "Content-Security-Policy \"default-src 'self' 'unsafe-inline' data: api.userway.com cdn.userway.com api.mixpanel.com; frame-ancestors 'none'; form-action 'self';\";"
+      - "Content-Security-Policy \"default-src 'self' data: api.userway.com cdn.userway.com api.mixpanel.com; connect-src http: https:; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; form-action 'self';\";"
       - Cache-Control "must-revalidate";
       - "X-Content-Type-Options \"nosniff\";"
 


### PR DESCRIPTION
## Release Notes Headline
Improve security of basic kubecost install
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
Improves the default kubecost install to be more secure. All configs under `nginxHeaders.server` are intended for users to overwrite with more secure configs. As an example, setting `"Content-Security-Policy \"default-src 'self' data: api.userway.com cdn.userway.com api.mixpanel.com; connect-src http: https:; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; form-action 'self';\";"` will allow connections from all domains, so users should set this to a value that will allow for the use of context switching to known domains.
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
Closes https://apptio.atlassian.net/browse/KCM-3837
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
All configs under `nginxHeaders.server` are intended for users to overwrite with more secure configs. As an example, setting `"Content-Security-Policy \"default-src 'self' data: api.userway.com cdn.userway.com api.mixpanel.com; connect-src http: https:; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; form-action 'self';\";"` will allow connections from all domains, so users should set this to a value that will allow for the use of context switching to known domains.
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Ran these changes against a local install of kubecost, observed the UI was functional. Ran ZAP scanner against this install and it did not come back with any alerts.
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
