### PR TITLE
[cherry-pick] Bump Prometheus to v3.4.0

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -918,7 +918,7 @@ prometheus:
       rollingUpdate: null
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v3.3.0
+      tag: v3.4.0
       pullPolicy: IfNotPresent
     priorityClassName: ""
     prefixURL: ""


### PR DESCRIPTION
Cherry-pick of https://github.com/kubecost/cost-analyzer-helm-chart/pull/4077 into v2.8 branch