### PR TITLE
update applyRetroactively

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1276,7 +1276,7 @@ Begin Kubecost 2.0 templates
     - name: ENTERPRISE_CUSTOM_PRICING_CSV_LOCATION_URI
       value: {{ (quote .Values.enterpriseCustomPricing.location.URI) }}
     - name: ENTERPRISE_CUSTOM_PRICING_APPLY_RETROACTIVELY
-      value: {{ (quote .Values.enterpriseCustomPricing.applyRetroactively) }}
+      value: "true"
     {{- end }}
 {{- end }}
 

--- a/cost-analyzer/values-enterprise-custom-pricing.yaml
+++ b/cost-analyzer/values-enterprise-custom-pricing.yaml
@@ -14,8 +14,3 @@ enterpriseCustomPricing:
   # The file name (e.g. pricing.csv) needs to match the file name used to make the ConfigMap (above)
   location:
     URI: /var/configs/enterprise-pricing/pricing.csv
-  # Enterprise Custom Pricing will update all prices that match the labels in the CSV
-  # and this is the only supported method as of kubecost 2.8.0. Please reach out to support 
-  # if forward-only pricing is required and it will be considered for a future release.
-  # Note that cloud provider reconciliation always wins if there is a matching resource ID.
-  applyRetroactively: true  # true is the only supported value as of kubecost 2.8.0

--- a/cost-analyzer/values-enterprise-custom-pricing.yaml
+++ b/cost-analyzer/values-enterprise-custom-pricing.yaml
@@ -14,7 +14,8 @@ enterpriseCustomPricing:
   # The file name (e.g. pricing.csv) needs to match the file name used to make the ConfigMap (above)
   location:
     URI: /var/configs/enterprise-pricing/pricing.csv
-  # By default, enterprise custom pricing takes effect moving forward from when
-  # it is enabled. To price all historic data according to the given pricing
-  # file, set "applyRetroactively" to true, below.
-  applyRetroactively: false
+  # Enterprise Custom Pricing will update all prices that match the labels in the CSV
+  # and this is the only supported method as of kubecost 2.8.0. Please reach out to support 
+  # if forward-only pricing is required and it will be considered for a future release.
+  # Note that cloud provider reconciliation always wins if there is a matching resource ID.
+  applyRetroactively: true  # true is the only supported value as of kubecost 2.8.0

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -376,11 +376,6 @@ enterpriseCustomPricing:
   # The file name (e.g. pricing.csv) needs to match the file name used to make the ConfigMap (above)
   location:
     URI: /var/configs/enterprise-pricing/pricing.csv
-  # Enterprise Custom Pricing will update all prices that match the labels in the CSV
-  # and this is the only supported method as of kubecost 2.8.0. Please reach out to support 
-  # if forward-only pricing is required and it will be considered for a future release.
-  # Note that cloud provider reconciliation always wins if there is a matching resource ID.
-  applyRetroactively: true  # true is the only supported value as of kubecost 2.8.0
 
 ## Kubecost SAML (enterprise key required)
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=configuration-user-management-saml

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -376,10 +376,11 @@ enterpriseCustomPricing:
   # The file name (e.g. pricing.csv) needs to match the file name used to make the ConfigMap (above)
   location:
     URI: /var/configs/enterprise-pricing/pricing.csv
-  # By default, enterprise custom pricing takes effect moving forward from when
-  # it is enabled. To price all historic data according to the given pricing
-  # spec, set "applyRetroactively" to true, below.
-  applyRetroactively: false
+  # Enterprise Custom Pricing will update all prices that match the labels in the CSV
+  # and this is the only supported method as of kubecost 2.8.0. Please reach out to support 
+  # if forward-only pricing is required and it will be considered for a future release.
+  # Note that cloud provider reconciliation always wins if there is a matching resource ID.
+  applyRetroactively: true  # true is the only supported value as of kubecost 2.8.0
 
 ## Kubecost SAML (enterprise key required)
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=configuration-user-management-saml


### PR DESCRIPTION
Force applyRetroactively to true per product team discussion.

## Release Notes Headline

NA, was not released previously. use ECP docs for guidance.

## Testing

always true:

```sh
helm upgrade ecp ~/git/cost-analyzer-helm-chart/cost-analyzer -f helmValues-kubecost-ecp.yaml --dry-run=server |grep ENTERPRISE_CUSTOM_PRICING_APPLY_RETROACTIVELY -A1
            - name: ENTERPRISE_CUSTOM_PRICING_APPLY_RETROACTIVELY
              value: "true"
```

Signed-off-by: jesse goodier <31039225+jessegoodier@users.noreply.github.com>