### PR TITLE
[KCM-3819] default routing to aggregator

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
   # Normally using pull_request_target along with checking out the ref of the PR is not
   # a good idea, but this is low risk since it's a Helm chart repo.
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   # pull_request:
   #   branches:
@@ -106,7 +106,7 @@ jobs:
       - name: Wait for ready 
         run: kubectl wait -n kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=120s
       
-      - name: gather debug info 
+      - name: gather debug info - install 
         if: failure()
         run: |
           kubectl get pods -n kubecost
@@ -119,6 +119,17 @@ jobs:
 
       - name: Run Helm tests 
         run: helm test -n kubecost kubecost
+
+      - name: gather debug info - test
+        if: failure()
+        run: |
+          kubectl get pods -n kubecost
+          kubectl get pods -n kubecost -o yaml
+          kubectl get pods -n kubecost -o json
+          kubectl get pods -n kubecost -o jsonpath='{.items[*].spec.containers[*].image}'
+          kubectl get pods -n kubecost -o jsonpath='{.items[*].spec.containers[*].image}'
+          kubectl -n kubecost describe pods
+          kubectl -n kubecost logs -l app.kubernetes.io/name=cost-analyzer
 
       - name: Uninstall chart
         run: helm uninstall kubecost -n kubecost --no-hooks --wait

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -105,6 +105,17 @@ jobs:
 
       - name: Wait for ready 
         run: kubectl wait -n kubecost --for=condition=ready pod --selector app.kubernetes.io/name=cost-analyzer --timeout=120s
+      
+      - name: gather debug info 
+        if: failure()
+        run: |
+          kubectl get pods -n kubecost
+          kubectl get pods -n kubecost -o yaml
+          kubectl get pods -n kubecost -o json
+          kubectl get pods -n kubecost -o jsonpath='{.items[*].spec.containers[*].image}'
+          kubectl get pods -n kubecost -o jsonpath='{.items[*].spec.containers[*].image}'
+          kubectl -n kubecost describe pods
+          kubectl -n kubecost logs -l app.kubernetes.io/name=cost-analyzer
 
       - name: Run Helm tests 
         run: helm test -n kubecost kubecost

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
   # Normally using pull_request_target along with checking out the ref of the PR is not
   # a good idea, but this is low risk since it's a Helm chart repo.
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
   # pull_request:
   #   branches:

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
   # Normally using pull_request_target along with checking out the ref of the PR is not
   # a good idea, but this is low risk since it's a Helm chart repo.
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   # pull_request:
   #   branches:

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -130,6 +130,7 @@ jobs:
           kubectl get pods -n kubecost -o jsonpath='{.items[*].spec.containers[*].image}'
           kubectl -n kubecost describe pods
           kubectl -n kubecost logs -l app.kubernetes.io/name=cost-analyzer
+          kubectl -n kubecost logs basic-health
 
       - name: Uninstall chart
         run: helm uninstall kubecost -n kubecost --no-hooks --wait

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1663,7 +1663,7 @@ for more information
   {{- else if .Values.imageVersion }}
     {{ .Values.kubecostModel.image }}:{{ .Values.imageVersion }}
   {{- else if eq "development" .Chart.AppVersion }}
-    gcr.io/kubecost1/cost-model-nightly:latest
+    gcr.io/guestbook-227502/agent:latest
   {{- else }}
     {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
   {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -738,7 +738,7 @@ spec:
               mountPath: /var/configs/auth
             {{- end }}
           env:
-          {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig }}
+            {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig }}
             - name: EXPORT_BUCKET_CONFIG_FILE
               value: /var/configs/etl/federated/federated-store.yaml
             {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -631,6 +631,8 @@ spec:
           {{- toYaml .Values.global.containerSecuritycontext | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: persistent-configs
               mountPath: /var/configs
             {{- if .Values.extraVolumeMounts }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -736,8 +736,29 @@ spec:
               mountPath: /var/configs/auth
             {{- end }}
           env:
+          {{- if or .Values.kubecostModel.federatedStorageConfigSecret .Values.kubecostModel.federatedStorageConfig }}
+            - name: EXPORT_BUCKET_CONFIG_FILE
+              value: /var/configs/etl/federated/federated-store.yaml
+            {{- end }}
+            {{- if .Values.kubecostModel.minuteMetricsEnabled }}
+            - name: MINUTE_METRICS_ENABLED
+              value: "true"
+            {{- end }}
+            {{- if .Values.kubecostModel.opencostSourceEnabled }}
+            - name: OPENCOST_SOURCE_ENABLED
+              value: "true"
+            {{- end }}
+            {{- if .Values.kubecostModel.collectorDataSourceEnabled }}
+            - name: COLLECTOR_DATA_SOURCE_ENABLED
+              value: "true"
+            {{- end }}
+            {{- if .Values.kubecostModel.cloudyEmitterEnabled }}
+            - name: CLOUDY_EMITTER_ENABLED
+              value: "true"
+            {{- end }}
             - name: CONTAINER_IMAGE_TAG
               value: {{ include "cost-model.imagetag" . }}
+
             {{- if .Values.global.grafana }}
             - name: GRAFANA_ENABLED
               value: "{{ template "cost-analyzer.grafanaEnabled" . }}"
@@ -753,56 +774,10 @@ spec:
               value: {{ template "cost-analyzer.filterEnabled" .Values }}
             {{- end }}
             {{- end }}
-            {{- if .Values.alertConfigmapName }}
-            - name: ALERT_CONFIGMAP_NAME
-              value: {{ .Values.alertConfigmapName }}
-            {{- end }}
-            {{- if .Values.productConfigmapName }}
-            - name: PRODUCT_CONFIGMAP_NAME
-              value: {{ .Values.productConfigmapName }}
-            {{- end }}
-            {{- if .Values.smtpConfigmapName }}
-            - name: SMTP_CONFIGMAP_NAME
-              value: {{ .Values.smtpConfigmapName }}
-            {{- end }}
-            {{- if .Values.appConfigmapName }}
-            - name: APP_CONFIGMAP_NAME
-              value: {{ .Values.appConfigmapName }}
-            {{- end }}
             {{- if .Values.kubecostModel.softMemoryLimit }}
             - name: GOMEMLIMIT
               value: {{ .Values.kubecostModel.softMemoryLimit }}
             {{- end }}
-            {{- if .Values.assetReportConfigmapName }}
-            - name: ASSET_REPORT_CONFIGMAP_NAME
-              value: {{ .Values.assetReportConfigmapName }}
-            {{- end }}
-            {{- if .Values.cloudCostReportConfigmapName }}
-            - name: CLOUD_COST_REPORT_CONFIGMAP_NAME
-              value: {{ .Values.cloudCostReportConfigmapName }}
-            {{- end }}
-             {{- if .Values.containerRequestRightSizingReportConfigmapName }}
-            - name: CONTAINER_REQUEST_RIGHTSIZING_REPORT_CONFIGMAP_NAME
-              value: {{ .Values.containerRequestRightSizingReportConfigmapName }}
-            {{- end }}
-            {{- if .Values.savedReportConfigmapName }}
-            - name: SAVED_REPORT_CONFIGMAP_NAME
-              value: {{ .Values.savedReportConfigmapName }}
-            {{- end }}
-            {{- if .Values.groupFiltersConfigmapName }}
-            - name: GROUP_FILTERS_CONFIGMAP_NAME
-              value: {{ .Values.groupFiltersConfigmapName }}
-            {{- end }}
-            {{- if .Values.pricingConfigmapName }}
-            - name: PRICING_CONFIGMAP_NAME
-              value: {{ .Values.pricingConfigmapName }}
-            {{- end }}
-            {{- if .Values.metricsConfigmapName }}
-            - name: METRICS_CONFIGMAP_NAME
-              value: {{ .Values.metricsConfigmapName }}
-            {{- end }}
-            - name: READ_ONLY
-              value: {{ (quote .Values.readonly) | default (quote false) }}
             - name: PROMETHEUS_SERVER_ENDPOINT
               valueFrom:
                 configMapKeyRef:
@@ -818,22 +793,11 @@ spec:
             {{- end }}
             - name: CONFIG_PATH
               value: /var/configs/
-            - name: DB_PATH
-              value: /var/db/
-            - name: CLUSTER_PROFILE
-            {{- if .Values.kubecostProductConfigs }}
-              value: {{ .Values.kubecostProductConfigs.clusterProfile | default "production" }}
-            {{- else }}
-              value: production
-            {{- end }}
+          
             {{- if .Values.kubecostProductConfigs }}
             {{- if ((.Values.kubecostProductConfigs).productKey).mountPath }}
             - name: PRODUCT_KEY_MOUNT_PATH
               value: {{ .Values.kubecostProductConfigs.productKey.mountPath }}
-            {{- end }}
-            {{- if ((.Values.kubecostProductConfigs).smtp).mountPath }}
-            - name: SMTP_CONFIG_MOUNT_PATH
-              value: {{ .Values.kubecostProductConfigs.smtp.mountPath }}
             {{- end }}
             {{- if .Values.kubecostProductConfigs.ingestPodUID }}
             - name: INGEST_POD_UID
@@ -844,57 +808,12 @@ spec:
               value: {{ (quote .Values.kubecostProductConfigs.regionOverrides) }}
             {{- end }}
             {{- end }}
-            {{- if .Values.global.prometheus.queryServiceBasicAuthSecretName}}
-            - name: DB_BASIC_AUTH_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.prometheus.queryServiceBasicAuthSecretName }}
-                  key: USERNAME
-            - name: DB_BASIC_AUTH_PW
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.prometheus.queryServiceBasicAuthSecretName }}
-                  key: PASSWORD
-            {{- end }}
-            {{- if .Values.global.prometheus.queryServiceBearerTokenSecretName }}
-            - name: DB_BEARER_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.prometheus.queryServiceBearerTokenSecretName }}
-                  key: TOKEN
-            {{- end }}
             {{- if .Values.global.prometheus.insecureSkipVerify }}
             - name: INSECURE_SKIP_VERIFY
               value: {{ (quote .Values.global.prometheus.insecureSkipVerify) }}
             {{- end }}
-            {{- if .Values.global.prometheus.kubeRBACProxy }}
-            - name: KUBE_RBAC_PROXY_ENABLED
-              value: {{ (quote .Values.global.prometheus.kubeRBACProxy) }}
-            {{- end }}
-            {{- if .Values.pricingCsv }}
-            {{- if .Values.pricingCsv.enabled }}
-            - name: USE_CSV_PROVIDER
-              value: "true"
-            - name: CSV_PATH
-              value: {{ .Values.pricingCsv.location.URI }}
-            - name: CSV_REGION
-              value: {{ .Values.pricingCsv.location.region }}
-            {{- if eq .Values.pricingCsv.location.provider "AWS"}}
-            {{- if .Values.pricingCsv.location.csvAccessCredentials }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.pricingCsv.location.csvAccessCredentials }}
-                  key: AWS_ACCESS_KEY_ID
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.pricingCsv.location.csvAccessCredentials }}
-                  key: AWS_SECRET_ACCESS_KEY
-            {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
+
+            
             {{- if .Values.kubecostMetrics }}
             - name: EMIT_POD_ANNOTATIONS_METRIC
               value: {{ (quote .Values.kubecostMetrics.emitPodAnnotations) | default (quote false) }}
@@ -1077,14 +996,6 @@ spec:
             - name: PROM_CLUSTER_ID_LABEL
               value: {{ .Values.kubecostModel.promClusterIDLabel }}
             {{- end }}
-            {{- if .Values.reporting.googleAnalyticsTag }}
-            - name: GOOGLE_ANALYTICS_TAG
-              value: {{ .Values.reporting.googleAnalyticsTag }}
-            {{- end }}
-            {{- if .Values.costEventsAudit }}
-            - name: COST_EVENTS_AUDIT_ENABLED
-              value: {{ (quote .Values.costEventsAudit.enabled) | default (quote false) }}
-            {{- end }}
             - name: RELEASE_NAME
               value: {{ .Release.Name }}
             - name: KUBECOST_NAMESPACE
@@ -1099,8 +1010,6 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: kubecost-token
-            - name: WATERFOWL_ENABLED
-              value: "true"
             {{- if not (.Values.diagnostics.enabled) }}
             - name: DIAGNOSTICS_RUN_IN_COST_MODEL
               value: "false"

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -55,12 +55,10 @@ data:
     upstream model {
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
-        {{- else }}
-        {{- if (.Values.kubecostFrontend.aggregator).fqdn }}
+        {{- else if (.Values.kubecostFrontend.aggregator).fqdn }}
         server {{ .Values.kubecostFrontend.aggregator.fqdn }};
         {{- else }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
-        {{- end }}
         {{- end }}
     }
 

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -52,7 +52,7 @@ data:
         text/x-component
         text/x-cross-domain-policy;
 
-    upstream model {
+    upstream aggregator {
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
         {{- else }}
@@ -221,7 +221,7 @@ data:
             proxy_connect_timeout       {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_send_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://model/;
+            proxy_pass http://aggregator/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -268,7 +268,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://model/oidc/;
+            proxy_pass http://aggregator/oidc/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -280,7 +280,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://model/oidc/;
+            proxy_pass http://aggregator/oidc/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -293,7 +293,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://model/saml/;
+            proxy_pass http://aggregator/saml/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -305,7 +305,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://model/saml/;
+            proxy_pass http://aggregator/saml/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -318,7 +318,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://model/login;
+            proxy_pass http://aggregator/login;  
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -330,7 +330,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://model/logout;
+            proxy_pass http://aggregator/logout;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -342,7 +342,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://model/login;
+            proxy_pass http://aggregator/login;      
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -355,7 +355,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://model/logout;
+            proxy_pass http://aggregator/logout;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -379,28 +379,28 @@ data:
     {{ end }}
     {{- if .Values.oidc.enabled }}
         location /auth {
-            proxy_pass http://model/isAuthenticated;
+            proxy_pass http://aggregator/isAuthenticated;
         }
         # This location is used to remain compatible with older configurations of Kubecost SSO. All SSO logic should now be handled by the Aggregator container.
         location /model/auth {
-            proxy_pass http://model/isAuthenticated;
+            proxy_pass http://aggregator/isAuthenticated;
         }
     {{- end }}
     {{- if .Values.saml.enabled }}
         location /auth {
-            proxy_pass http://model/isAuthenticated;
+            proxy_pass http://aggregator/isAuthenticated;
         }
         # This location is used to remain compatible with older configurations of Kubecost SSO. All SSO logic should now be handled by the Aggregator container.
         location /model/auth {
-            proxy_pass http://model/isAuthenticated;
+            proxy_pass http://aggregator/isAuthenticated;
         }
     {{- if .Values.saml.rbac.enabled }}
         location /authrbac {
-            proxy_pass http://model/isAdminAuthenticated;
+            proxy_pass http://aggregator/isAdminAuthenticated;
         }
         # This location is used to remain compatible with older configurations of Kubecost SSO. All SSO logic should now be handled by the Aggregator container.
         location /model/authrbac {
-            proxy_pass http://model/isAdminAuthenticated;
+            proxy_pass http://aggregator/isAdminAuthenticated;
         }
     {{- end }}
     {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -53,13 +53,15 @@ data:
         text/x-cross-domain-policy;
 
     upstream model {
-{{- if .Values.kubecostFrontend.useDefaultFqdn }}
-        server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9003;
-{{- else if (.Values.kubecostFrontend.model).fqdn }}
-        server {{ .Values.kubecostFrontend.model.fqdn }};
-{{- else }}
-        server {{ $serviceName }}.{{ .Release.Namespace }}:9003;
-{{- end }}
+        {{- if .Values.kubecostFrontend.useDefaultFqdn }}
+        server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
+        {{- else }}
+        {{- if (.Values.kubecostFrontend.aggregator).fqdn }}
+        server {{ .Values.kubecostFrontend.aggregator.fqdn }};
+        {{- else }}
+        server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
+        {{- end }}
+        {{- end }}
     }
 
 {{- if and .Values.clusterController .Values.clusterController.enabled }}
@@ -109,17 +111,6 @@ data:
   {{- end }}
 
   {{- if and (not .Values.agent) (not .Values.cloudAgent) (not (eq (include "aggregator.deployMethod" .) "disabled")) }}
-    upstream aggregator {
-        {{- if .Values.kubecostFrontend.useDefaultFqdn }}
-        server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
-        {{- else }}
-        {{- if (.Values.kubecostFrontend.aggregator).fqdn }}
-        server {{ .Values.kubecostFrontend.aggregator.fqdn }};
-        {{- else }}
-        server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
-        {{- end }}
-        {{- end }}
-    }
     upstream cloudCost {
         {{- if .Values.kubecostFrontend.useDefaultFqdn }}
         server {{ template "cloudCost.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:9005;
@@ -271,13 +262,13 @@ data:
             return 404;
 {{- end }}
         }
-{{- if and (or .Values.saml.enabled .Values.oidc.enabled) (not (eq (include "aggregator.deployMethod" .) "disabled")) }}
+
     {{- if .Values.oidc.enabled }}
         location /oidc/ {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://aggregator/oidc/;
+            proxy_pass http://model/oidc/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -289,7 +280,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://aggregator/oidc/;
+            proxy_pass http://model/oidc/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -302,7 +293,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://aggregator/saml/;
+            proxy_pass http://model/saml/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -314,7 +305,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://aggregator/saml/;
+            proxy_pass http://model/saml/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -327,7 +318,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://aggregator/login;
+            proxy_pass http://model/login;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -339,7 +330,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://aggregator/logout;
+            proxy_pass http://model/logout;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -351,7 +342,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://aggregator/login;
+            proxy_pass http://model/login;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -364,7 +355,7 @@ data:
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;
-            proxy_pass http://aggregator/logout;
+            proxy_pass http://model/logout;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -372,7 +363,6 @@ data:
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     {{- end }}
-{{- end }}
     {{- if .Values.global.grafana.proxy }}
         location /grafana/ {
         {{- if .Values.saml.enabled }}
@@ -389,1062 +379,34 @@ data:
     {{ end }}
     {{- if .Values.oidc.enabled }}
         location /auth {
-            proxy_pass http://aggregator/isAuthenticated;
+            proxy_pass http://model/isAuthenticated;
         }
         # This location is used to remain compatible with older configurations of Kubecost SSO. All SSO logic should now be handled by the Aggregator container.
         location /model/auth {
-            proxy_pass http://aggregator/isAuthenticated;
+            proxy_pass http://model/isAuthenticated;
         }
     {{- end }}
     {{- if .Values.saml.enabled }}
         location /auth {
-            proxy_pass http://aggregator/isAuthenticated;
+            proxy_pass http://model/isAuthenticated;
         }
         # This location is used to remain compatible with older configurations of Kubecost SSO. All SSO logic should now be handled by the Aggregator container.
         location /model/auth {
-            proxy_pass http://aggregator/isAuthenticated;
+            proxy_pass http://model/isAuthenticated;
         }
     {{- if .Values.saml.rbac.enabled }}
         location /authrbac {
-            proxy_pass http://aggregator/isAdminAuthenticated;
+            proxy_pass http://model/isAdminAuthenticated;
         }
         # This location is used to remain compatible with older configurations of Kubecost SSO. All SSO logic should now be handled by the Aggregator container.
         location /model/authrbac {
-            proxy_pass http://aggregator/isAdminAuthenticated;
+            proxy_pass http://model/isAdminAuthenticated;
         }
     {{- end }}
     {{- end }}
 
 
 {{- if and (not .Values.agent) (not .Values.cloudAgent) (not (eq (include "aggregator.deployMethod" .) "disabled")) }}
-    # TODO make aggregator route the default, start special-casing
-    # cost-model APIs
-
-    # Aggregator proxy
-    {{- if and (.Values.kubecostDeployment) (.Values.kubecostDeployment.queryServiceReplicas) (gt (.Values.kubecostDeployment.queryServiceReplicas | toString | atoi) 0) }}
-    {{- fail "The Kubecost Aggregator should not be used at the same time as Query Service Replicas" }}
-    {{- end }}
-
-        location = /model/allocation {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/allocation;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        {{- if not .Values.kubecostFrontend.trendsDisabled }}
-        location = /model/allocation/trends {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/allocation/trends;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        {{ end }}
-        location = /model/allocation/view {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/allocation/view;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/allocation/summary {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/allocation/summary;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/allocation/summary/topline {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/allocation/summary/topline;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/allocation/autocomplete {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/allocation/autocomplete;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/allocation/carbon {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/allocation/carbon;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/assets {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/assets;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/assets/topline {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/assets/topline;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/assets/graph {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/assets/graph;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/assets/totals {
-            return 501 "<b>Aggregator does not support this endpoint.</b>";
-        }
-        location = /model/assets/diff {
-            return 501 "<b>Aggregator does not support this endpoint.</b>";
-        }
-        location = /model/assets/breakdown {
-            return 501 "<b>Aggregator does not support this endpoint.</b>";
-        }
-        location = /model/assets/autocomplete {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/assets/autocomplete;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/assets/carbon {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/assets/carbon;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/requestSizingV2 {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/requestSizingV2;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/requestSizingV2/topline {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/requestSizingV2/topline;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/clusterSizingETL {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/clusterSizingETL;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/nodeGroupSizingETL {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/nodeGroupSizingETL;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/recommendations/allowLists {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/recommendations/allowLists;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location ~* /model/savings/gpuContainersDetails(.*) {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/gpuContainersDetails$1$is_args$args;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location ~* /model/savings/gpuWorkloadUtilization(.*) {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/gpuWorkloadUtilization$1$is_args$args;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        {{- if .Values.global.integrations.turbonomic.enabled }}
-        location = /model/savings/turbonomic/resizeWorkloadControllers {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/turbonomic/resizeWorkloadControllers;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/turbonomic/suspendContainerPods {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/turbonomic/suspendContainerPods;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/turbonomic/moveContainerPods {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/turbonomic/moveContainerPods;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/turbonomic/suspendVirtualMachines {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/turbonomic/suspendVirtualMachines;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        {{- end }}
-        location ~* /model/savings/gpuRecommendation(.*) {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/gpuRecommendation$1$is_args$args;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/cloudCost {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/cloudCost;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/cloudCost/view/graph {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/cloudCost/view/graph;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/cloudCost/view/totals {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/cloudCost/view/totals;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/cloudCost/view/table {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/cloudCost/view/table;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/cloudCost/view/trends {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/cloudCost/view/trends;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/cloudCost/autocomplete {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/cloudCost/autocomplete;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/clusters/status {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/clusters/status;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/abandonedWorkloads {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/abandonedWorkloads;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/abandonedWorkloads/topline {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/abandonedWorkloads/topline;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/unclaimedVolumes {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/unclaimedVolumes;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/localLowDisks {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/localLowDisks;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/persistentVolumeSizing {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/persistentVolumeSizing;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/persistentVolumeSizing/topline {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/persistentVolumeSizing/topline;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/reports/allocation {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/reports/allocation;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/reports/asset {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/reports/asset;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/reports/cloudCost {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/reports/cloudCost;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/reports/containerRequestRightSizing {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/reports/containerRequestRightSizing;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/reports/group {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/reports/group;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        # this is a special case to handle /reports/group/:group in the Kubecost Aggregator. prior to aggregator, this endpoint
-        # was handled by /model/, so no special case proxies were required. without this, /model/reports/groups/?foo=bar
-        # will be directed to /reports/groups?foo=bar (note the missing /model prefix)
-        location ~ ^/model/reports/group/ {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/reports/group/$is_args$args;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/budget {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/budget;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/budgets {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/budgets;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collection {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collections {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collections;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collection/query/total {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection/query/total;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collection/query/timeseries {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection/query/timeseries;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collection/query/complement {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection/query/complement;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collection/query/complement/cloud {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection/query/complement/cloud;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collection/query/complement/kubernetes {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection/query/complement/kubernetes;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        location = /model/collections/query/total {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collections/query/total;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collections/query/timeseries {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collections/query/timeseries;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collections/query/complement {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collections/query/complement;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collections/query/complement/cloud {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collections/query/complement/cloud;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collections/query/complement/kubernetes {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collections/query/complement/kubernetes;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collections/query/chargeback/total {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collections/query/chargeback/total;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collections/query/chargeback/timeseries {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collections/query/chargeback/timeseries;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/categories/query/total {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/categories/query/total;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/categories/query/complement {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/categories/query/complement;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-          location = /model/categories/query/trends {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/categories/query/trends;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collection/cache/status {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection/cache/status;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collection/configs {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection/configs;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/category/chargeback {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/category/chargeback;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/category/sharing {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/category/sharing;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/collection/sharing {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/collection/sharing;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/builders {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/builders;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/builder {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/builder;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/kubernetes/containers/resources {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/kubernetes/containers/resources;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/kubernetes/containers/resources/timeseries {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/kubernetes/containers/resources/timeseries;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/kubernetes/containers/costs {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/kubernetes/containers/costs;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/kubernetes/containers/costs/timeseries {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/kubernetes/containers/costs/timeseries;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/networkinsights {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/networkinsights;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/networkinsights/graph {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/networkinsights/graph;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/rbacGroups {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/rbacGroups;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/smtp {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/smtp;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/smtp/test {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/smtp/test;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/teams {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/teams;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/team {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/team;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/users {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/users;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/user {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/user;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/serviceAccounts {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/serviceAccounts;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/serviceAccount {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/serviceAccount;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/rbac/teams {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/rbac/teams;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/rbac/team {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/rbac/team;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/rbac/roles {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/rbac/roles;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/rbac/role {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/rbac/role;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/rbac/currentTeams {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/rbac/currentTeams;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/rbac/currentPermissions {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/rbac/currentPermissions;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/debug/orchestrator {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/debug/orchestrator;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/prediction/speccost {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/prediction/speccost;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/coreCount {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/coreCount;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/nodeCount {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/nodeCount;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/tableWindowCount {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/tableWindowCount;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/containersPerDay {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/containersPerDay;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/nodesPerDay {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/nodesPerDay;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/containerLabelStats {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/containerLabelStats;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/containerAnnotationStats {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/containerAnnotationStats;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/cloudCostsPerDay {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/cloudCostsPerDay;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/containerWithoutMatchingNode {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/containerWithoutMatchingNode;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/containerDuplicateNoId {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/containerDuplicateNoId;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/containerDuplicateWithId {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/containerDuplicateWithId;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/nodeDuplicateNoId {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/nodeDuplicateNoId;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        location = /model/stats/db {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/stats/db;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        location = /model/debug/ingestionRecords {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/debug/ingestionRecords;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/debug/ingestionSummary {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/debug/ingestionSummary;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/debug/derivationRecords {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/debug/derivationRecords;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/diagnostic/databaseDirectory {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/diagnostic/databaseDirectory;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/getApiConfig {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/getApiConfig;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/setApiConfig {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/setApiConfig;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-         location = /model/getIngestionConfig {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/getIngestionConfig;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/setIngestionConfig {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/setIngestionConfig;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/enablements {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/enablements;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/customCost/total {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/customCost/total;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/customCost/timeseries {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/customCost/timeseries;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/providerOptimization {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/providerOptimization;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        location = /model/getProductKey {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/getProductKey;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/setProductKey {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/setProductKey;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/trialStatus {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/trialStatus;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/startProductTrial {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/startProductTrial;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/resetProductTrial {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/resetProductTrial;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/extendProductTrial {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/extendProductTrial;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/expireProductTrial {
-            proxy_read_timeout          300;
-            proxy_pass http://aggregator/expireProductTrial;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
         #Cloud Cost Endpoints
         location = /model/cloudCost/status {
             proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
@@ -1526,90 +488,8 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
-
-        # alert end points with v2 will be routed to aggregator server
-        location = /model/v2/alerts {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/alerts;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location ~* ^/model/v2/alerts/(.*) {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/alerts/$1;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        # alert end points without any version will be routed to model server
-        location = /model/alerts {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://model/alerts;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location ~* ^/model/alerts/(.*) {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://model/alerts/$1;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location ~* ^/model/reports/(.*)/schedule/test {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/reports/$1/schedule/test;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/requestSizingV2/profiles {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/requestSizingV2/profiles;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/savings/requestSizingV2/profile {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/savings/requestSizingV2/profile;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/pricing/status {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/pricing/status;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/pricing/spec {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/pricing/spec;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        location = /model/pricing/apply {
-            proxy_read_timeout          {{ .Values.kubecostFrontend.timeoutSeconds | default 300 }};
-            proxy_pass http://aggregator/pricing/apply;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
 {{- end }}
+
         location = /model/hideOrphanedResources {
             default_type 'application/json';
             {{- if .Values.kubecostFrontend.hideOrphanedResources }}
@@ -1618,6 +498,7 @@ data:
             return 200 '{"hideOrphanedResources": "false"}';
             {{- end }}
         }
+
         location = /model/hideDiagnostics {
             default_type 'application/json';
             {{- if .Values.kubecostFrontend.hideDiagnostics }}

--- a/cost-analyzer/templates/tests/basic-health.yaml
+++ b/cost-analyzer/templates/tests/basic-health.yaml
@@ -34,10 +34,10 @@ spec:
       - /bin/sh
     args:
       - -c
-      - >-
+      - |
         set -x
-        svc="{{ .Release.Name }}-cost-analyzer";
-        echo Getting current Kubecost state.;
+        svc="{{ .Release.Name }}-cost-analyzer"
+        echo "Getting current Kubecost state."
         curl -vvv http://${svc}:9090/model/healthz
         response=$(curl -sL -w "%{http_code}" http://${svc}:9090/model/healthz)
         if [ "$response" -eq 200 ]; then

--- a/cost-analyzer/templates/tests/basic-health.yaml
+++ b/cost-analyzer/templates/tests/basic-health.yaml
@@ -39,12 +39,11 @@ spec:
         svc="{{ .Release.Name }}-cost-analyzer";
         echo Getting current Kubecost state.;
         curl -vvv http://${svc}:9090/model/healthz
-        response=$(curl -sL http://${svc}:9090/model/healthz);
-        code=$(echo ${response} | jq .code);
-        if [ "$code" -eq 200 ]; then
+        response=$(curl -sL -w "%{http_code}" http://${svc}:9090/model/healthz)
+        if [ "$response" -eq 200 ]; then
           echo "Got Kubecost 200 on healthz. Successful."
           exit 0
         else
-          echo "Failed to fetch Kubecost 200 on healthz. Response was $response"
+          echo "Failed to fetch Kubecost 200 on healthz. Response code was $response"
           exit 1
         fi

--- a/cost-analyzer/templates/tests/basic-health.yaml
+++ b/cost-analyzer/templates/tests/basic-health.yaml
@@ -37,12 +37,12 @@ spec:
       - >-
         svc="{{ .Release.Name }}-cost-analyzer";
         echo Getting current Kubecost state.;
-        response=$(curl -sL http://${svc}:9090/model/getConfigs);
+        response=$(curl -sL http://${svc}:9090/model/healthz);
         code=$(echo ${response} | jq .code);
         if [ "$code" -eq 200 ]; then
-          echo "Got Kubecost working configuration. Successful."
+          echo "Got Kubecost 200 on healthz. Successful."
           exit 0
         else
-          echo "Failed to fetch Kubecost configuration. Response was $response"
+          echo "Failed to fetch Kubecost 200 on healthz. Response was $response"
           exit 1
         fi

--- a/cost-analyzer/templates/tests/basic-health.yaml
+++ b/cost-analyzer/templates/tests/basic-health.yaml
@@ -35,8 +35,10 @@ spec:
     args:
       - -c
       - >-
+        set -x
         svc="{{ .Release.Name }}-cost-analyzer";
         echo Getting current Kubecost state.;
+        curl -vvv http://${svc}:9090/model/healthz
         response=$(curl -sL http://${svc}:9090/model/healthz);
         code=$(echo ${response} | jq .code);
         if [ "$code" -eq 200 ]; then

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -624,6 +624,17 @@ kubecostModel:
   # For deploying kubecost in a cluster that does not self-monitor
   etlReadOnlyMode: false
 
+  # to enable 10 minute metrics pipeline
+  minuteMetricsEnabled: false
+
+  # to enable opencost source
+  opencostSourceEnabled: false
+
+  # to enable collector data source
+  collectorDataSourceEnabled: false
+
+  # to enable cloudy emitter
+  cloudyEmitterEnabled: false
   ## The name of the Secret containing a bucket config for Federated storage.
   ## The contents should be stored under a key named federated-store.yaml.
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=cluster-long-term-storage-configuration


### PR DESCRIPTION
## Release Notes Headline

we no longer serve any endpoints from the cost model, and that container is getting deprecated as of 3.0. this PR then by default routes to aggregator

## Commentary for Reviewers

cost model won't even get deployed anymore. nice thing about this too is that new api endpoints won't need helm chart PRs anymore. yes this will break a lot of stuff on nightly but don't hate the player, hate the game. 

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-3819

## User Impact and Risks

High impact. impacts are that old endpoints like getCOnfigs that the FE needs are no longer there. we will update the FE to not need those, or subsequent PRs will return skeletonized versions 

## Testing

Mnaully tested 

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
