### PR TITLE
[KCM-3819] return only version info in installInfo response

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -585,9 +585,8 @@ data:
                 }
             ';
         }
-    }
 
-    location /model/installInfo {
+        location /model/installInfo {
             default_type 'application/json';
             return 200 '\n
                 {
@@ -595,6 +594,8 @@ data:
                 }
             ';
         }
+    }
+
 
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -587,5 +587,14 @@ data:
         }
     }
 
+    location /model/installInfo {
+            default_type 'application/json';
+            return 200 '\n
+                {
+                    "version": "{{ .Chart.Version }}"
+                }
+            ';
+        }
+
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Release Notes Headline

return helm chart info in installinfo. this is the bare minimum of what the FE needs to check API version compatibility. We will get this information from release time variables, rather than reading a container

## Commentary for Reviewers

should help the FE boot

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-3819

## User Impact and Risks

minimal, should restore some functionality to the FE 

## Testing

tested via curl, FE will adjust to accommodate 

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
