### PR TITLE
update matrix

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -61,16 +61,14 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - name: v1.28
-            version: v1.28.13
-          - name: v1.29
-            version: v1.29.14
           - name: v1.30
-            version: v1.30.10
+            version: v1.30.13
           - name: v1.31
-            version: v1.31.6
+            version: v1.31.9
           - name: v1.32
-            version: v1.32.3
+            version: v1.32.5
+          - name: v1.33
+            version: v1.33.1
     needs: test-chart
     name: ${{ matrix.k8s-version.name }} test
     steps:
@@ -85,7 +83,7 @@ jobs:
       - name: Create KinD cluster
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: v0.20.0
+          version: v0.29.0
           node_image: kindest/node:${{ matrix.k8s-version.version }}
           kubectl_version: ${{ matrix.k8s-version.version }}
 
@@ -170,12 +168,12 @@ jobs:
     strategy:
       matrix:
         cluster:
+        # - distribution: openshift
+        #   version: 4.15.0-okd
+        # - distribution: openshift
+        #   version: 4.16.0-okd
         - distribution: openshift
-          version: 4.15.0-okd
-        - distribution: openshift
-          version: 4.16.0-okd
-        - distribution: openshift
-          version: 4.17.0-okd
+          version: 4.18.0-okd
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -226,10 +224,10 @@ jobs:
     strategy:
       matrix:
         cluster:
-        - distribution: eks
-          version: v1.30
-        - distribution: eks
-          version: v1.31
+        # - distribution: eks
+        #   version: v1.30
+        # - distribution: eks
+        #   version: v1.31
         - distribution: eks
           version: v1.32
     steps:


### PR DESCRIPTION
Updates GitHub Actions workflow testing matrix for Kubernetes versions and platform distributions.

## Release Notes Headline

Update test matrix to use newer Kubernetes versions and consolidate CI test coverage.

## Commentary for Reviewers

This PR updates the CI/CD workflow matrix configuration:
- **Kubernetes versions**: Removed testing for v1.28 and v1.29, updated patch versions for v1.30-v1.32, added v1.33.1
- **KinD version**: Updated from v0.20.0 to v0.29.0 for better compatibility  
- **OpenShift testing**: Consolidated to only test v4.18.0-okd (commented out v4.15.0 and v4.16.0)
- **EKS testing**: Consolidated to only test v1.32 (commented out v1.30 and v1.31)

The changes reduce CI execution time while maintaining coverage of the most current and relevant Kubernetes versions.

## Links to Issues or Tickets

N/A

## User Impact and Risks

Low risk - this only affects CI testing matrix and does not change the actual Helm chart functionality. Users should see no impact as the chart continues to support the same Kubernetes version ranges.

## Testing

Changes will be validated through the updated CI pipeline execution on this PR.

## Documentation Updates

N/A