### PR TITLE
KCM-4211 Added imagePullSecrets for Grafana Mimir

### DIFF
--- a/cost-analyzer/templates/mimir-proxy-deployment-template.yaml
+++ b/cost-analyzer/templates/mimir-proxy-deployment-template.yaml
@@ -46,6 +46,12 @@ spec:
         - mountPath: /etc/nginx/conf.d
           name: default-conf
           readOnly: true
+    {{- if .Values.global.mimirProxy.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.global.mimirProxy.imagePullSecrets }}
+        - name: {{ .name }}
+      {{- end }}
+    {{- end }}
       volumes:
       - name: default-conf
         configMap:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -73,7 +73,7 @@ global:
       # password: pwd
     # imagePullSecrets:
       # - name: "image-pull-secret"
-    
+
   ## Azure Monitor Managed Service for Prometheus
   ## Ref: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/prometheus-remote-write-virtual-machines
   ##

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -71,9 +71,9 @@ global:
     basicAuth:
       # username: user
       # password: pwd
-    # imagePullSecrets: 
+    # imagePullSecrets:
       # - name: "image-pull-secret"
-      
+    
   ## Azure Monitor Managed Service for Prometheus
   ## Ref: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/prometheus-remote-write-virtual-machines
   ##

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -71,7 +71,9 @@ global:
     basicAuth:
       # username: user
       # password: pwd
-
+    # imagePullSecrets: 
+      # - name: "image-pull-secret"
+      
   ## Azure Monitor Managed Service for Prometheus
   ## Ref: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/prometheus-remote-write-virtual-machines
   ##

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -71,7 +71,7 @@ global:
     basicAuth:
       # username: user
       # password: pwd
-    # imagePullSecrets:
+    imagePullSecrets: []
       # - name: "image-pull-secret"
 
   ## Azure Monitor Managed Service for Prometheus


### PR DESCRIPTION
## Release Notes Headline

The Grafana Mimir Proxy's deployment supports custom `imagePullSecrets` for the container image.  

## Commentary for Reviewers

N/A

## Links to Issues or Tickets

Closes https://apptio.atlassian.net/browse/KCM-4211

## User Impact and Risks

Low risk/impact.

## Testing

Used `helm template --validate` to ensure the Grafana Mimir Proxy's deployment spec meets the Kube API's validation checks. 

Inspected the generated `mainfest.yaml` and confirmed the `imagePullSecrets` are where they're expected.

![Deployment Spec w/o imagePullSecrets](https://github.com/user-attachments/assets/b6146f54-afe0-45c7-8388-c32e9c16a873)
![Deployment Spec w/ imagePullSecrets](https://github.com/user-attachments/assets/5956ab27-4869-49b3-aaa6-8a177dd50e68)


## Documentation Updates

N/A
