### PR TITLE
Fix scope of if statement on cloud cost

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Kubecost 2.0 preconditions
 {{/*
 Cloud integration source contents check. Either the Secret must be specified or the JSON, not both.
 Additionally, for upgrade protection, certain individual values populated under the kubecostProductConfigs map, if found,
-will result in failure. Users are asked to select one of the two presently-available sources for cloud integration information.
+will result in failure. Users are asked to select one of the three presently-available sources for cloud integration information.
 */}}
 {{- define "cloudIntegrationSourceCheck" -}}
   {{- if and (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON -}}
@@ -155,6 +155,16 @@ will result in failure. Users are asked to select one of the two presently-avail
 {{- if and (.Values.kubecostProductConfigs).cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaBucketName) }}
     {{- fail "\nkubecostProductConfigs.cloudIntegrationJSON and kubecostProductConfigs.athena* values are mutually exclusive. Please specifiy only one." -}}
   {{- end -}}
+{{- end -}}
+
+{{/*
+A cloud integration secret is required for cloud cost to function as a dedicated pod.
+UI based configuration is not supported for cloud cost with aggregator.
+*/}}
+{{- define "cloudIntegrationSourceConfiguredCheck" -}}
+  {{- if not ( or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaBucketName)) }}
+    {{- fail "\n\nA cloud-integration secret is required when using the aggregator statefulset and cloudCost is enabled." }}
+  {{- end }}
 {{- end -}}
 
 {{/*

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -1,12 +1,6 @@
 {{- if eq (include "aggregator.deployMethod" .) "statefulset" }}
 {{- if ((.Values.kubecostAggregator).cloudCost).enabled }}
-{{/*
-  A cloud integration secret is required for cloud cost to function as a dedicated pod.
-  UI based configuration is not supported for cloud cost with aggregator.
-*/}}
-{{- if not ( or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaBucketName)) }}
-{{- fail "\n\nA cloud-integration secret is required when using the aggregator statefulset and cloudCost is enabled." }}
-{{- end }}
+{{- include "cloudIntegrationSourceConfiguredCheck" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -1,13 +1,11 @@
 {{- if eq (include "aggregator.deployMethod" .) "statefulset" }}
-
+{{- if ((.Values.kubecostAggregator).cloudCost).enabled }}
 {{/*
   A cloud integration secret is required for cloud cost to function as a dedicated pod.
   UI based configuration is not supported for cloud cost with aggregator.
 */}}
-{{- if ((.Values.kubecostAggregator).cloudCost).enabled }}
 {{- if not ( or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaBucketName)) }}
 {{- fail "\n\nA cloud-integration secret is required when using the aggregator statefulset and cloudCost is enabled." }}
-{{- end }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment
@@ -211,4 +209,5 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/cost-analyzer/templates/aggregator-cloud-cost-service-account.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-service-account.yaml
@@ -1,12 +1,7 @@
 {{- if eq (include "aggregator.deployMethod" .) "statefulset" }}
-
-{{/*
-  A cloud integration secret is required for cloud cost to function as a dedicated pod.
-  UI based configuration is not supported for cloud cost with aggregator.
-*/}}
-
-{{- if or (.Values.kubecostProductConfigs).cloudIntegrationSecret (.Values.kubecostProductConfigs).cloudIntegrationJSON ((.Values.kubecostProductConfigs).athenaBucketName) }}
+{{- if ((.Values.kubecostAggregator).cloudCost).enabled }}
 {{- if and .Values.serviceAccount.create .Values.kubecostAggregator.cloudCost.serviceAccountName }}
+{{- include "cloudIntegrationSourceConfiguredCheck" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
The scope of the if statement which cloudCost.enabled controlled was incorrect in that disabling it only disabled the check on the existence of the secret. I have fixed the scope so that it completely turns off the deployment, and added a helper that checks for cloud cost configuration.

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Tested using `helm template`
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
