### PR TITLE
Add and mount values configmap to aggregator

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -76,6 +76,9 @@ spec:
         - name: aggregator-staging
           emptyDir:
             sizeLimit: {{ .Values.aggregator.stagingEmptyDirSizeLimit }}
+        - name: user-helm-values
+          configMap:
+            name: helm-values
         - name: federated-storage-config
           secret:
             defaultMode: 420
@@ -302,6 +305,8 @@ spec:
           volumeMounts:
             - name: persistent-configs
               mountPath: /var/configs
+            - name: user-helm-values
+              mountPath: /var/configs/values
             - name: federated-storage-config
               mountPath: /var/configs/federated-store.yaml
               subPath: {{ include "kubecost.federatedStorage.fileName" . }}

--- a/kubecost/templates/aggregator/aggregator-values-configmap.yaml
+++ b/kubecost/templates/aggregator/aggregator-values-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: helm-values
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+    {{- include "kubecost.commonLabels" . | nindent 4 }}
 data:
   user-values.json: |
     {{- .Values | toJson | nindent 4 }}

--- a/kubecost/templates/cost-analyzer-values-configmap.yaml
+++ b/kubecost/templates/cost-analyzer-values-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: helm-values
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cost-analyzer.commonLabels" . | nindent 4 }}
+data:
+  user-values.json: |
+    {{- .Values | toJson | nindent 4 }}


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

Mounts a configmap containing user-configured helm values to the aggregator. This replaces the `HELM_VALUES` env variable that used to be present in the cost-analyzer, so as to serve a `/helmValues` endpoint.

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
https://apptio.atlassian.net/browse/KCM-3879

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
This potentially exposes values that would have been auto-added to secrets as values in this configmap. From my understanding, this is no different from the `HELM_VALUES` variable and is the desired state from the ask.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
Tested on new cluster install by upgrading using local helm chart and though exec into container.
Tested through helm template.
Tested in conjunction with new helm endpoint to encode/send via GET.

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
