### PR TITLE
bump version, add LOG_LEVEL

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1589,7 +1589,7 @@ forecasting:
   fullImageName: ""
   image:
     repository: gcr.io/kubecost1/kubecost-modeling
-    tag: v0.1.26
+    tag: v0.1.27
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.
@@ -1606,7 +1606,7 @@ forecasting:
     # -t is the worker timeout which primarily affects model training time;
     # if it is not high enough, training workers may die mid training
     "GUNICORN_CMD_ARGS": "--log-level info -t 1200"
-
+    "LOG_LEVEL": "info"
   priority:
     enabled: false
     name: ""


### PR DESCRIPTION
## Release Notes Headline

Fix CVEs in modeling
Add LOG_LEVEL to modeling and default to info

## Commentary for Reviewers

tested on nightly and kc28 QA env.

## User Impact and Risks

Minimal risk. Works in QA.

## Testing

ENV VAR:
```yaml
spec:
  automountServiceAccountToken: false
  containers:
  - env:
    - name: CONFIG_PATH
      value: /var/configs/
    - name: KCM_BASE_URL
      value: http://saml-entraid-aggregator:9008
    - name: MODEL_STORAGE_PATH
      value: /tmp/localrun/models
    - name: PAGE_ITEM_LIMIT
      value: "1000"
    - name: GUNICORN_CMD_ARGS
      value: --log-level info -t 1200
    - name: LOG_LEVEL
      value: info
    image: gcr.io/kubecost1/kubecost-modeling:8da6931
```

logs:


```log
kl deployments/saml-entraid-forecasting            
[2025-06-20 17:39:07 +0000] [1] [INFO] Starting gunicorn 23.0.0
[2025-06-20 17:39:07 +0000] [1] [INFO] Listening at: http://0.0.0.0:5000 (1)
[2025-06-20 17:39:07 +0000] [1] [INFO] Using worker: gevent
[2025-06-20 17:39:07 +0000] [6] [INFO] Booting worker with pid: 6
/app/kcmodeling/blueprints/anomaly.py:31: SyntaxWarning: invalid escape sequence '\d'
  RELATIVE_WINDOW_REGEX = re.compile("\d+[dh]")
[2025-06-20 17:39:16 +0000] [6] [INFO] KCM_BASE_URL = http://saml-entraid-aggregator:9008
[2025-06-20 17:39:16 +0000] [6] [INFO] MODEL_STORAGE_PATH = /tmp/localrun/models
[2025-06-20 17:39:16 +0000] [6] [INFO] Performing first time model training
[2025-06-20 17:39:16 +0000] [6] [INFO] Starting Web Server
[2025-06-20 17:39:16 +0000] [6] [INFO] Pulling training data for: (cloudCost, arima, all)
[2025-06-20 17:41:32 +0000] [6] [ERROR] Unable to retrieve training with code 400 for: (cloudCost, arima)
[2025-06-20 17:41:32 +0000] [6] [INFO] Pulling training data for: (allocation, arima, all)
[2025-06-20 17:41:32 +0000] [6] [ERROR] Unable to retrieve training with code 400 for: (allocation, arima)
[2025-06-20 17:41:32 +0000] [6] [INFO] Pulling training data for: (assets, arima, all)
[2025-06-20 17:41:34 +0000] [6] [ERROR] Unable to retrieve training with code 500 for: (assets, arima)
```


## Documentation Updates

NA