### PR TITLE
fix cluster-controller CVE

### DIFF
--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1907,7 +1907,7 @@ clusterController:
   enabled: false
   image:
     repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.18
+    tag: v0.16.19
   imagePullPolicy: IfNotPresent
   extraEnv: []
   # - name: EXTRA_ENV_VAR


### PR DESCRIPTION
- Fixed cluster controller CVE-2025-22874 by updating Go toolchain to version 1.23.10

## Changes

### Security Fixes

- Updated `go.mod` to use Go 1.23.10, addressing CVE-2025-22874
- Removed redundant toolchain specification

## Test Plan

- [x] Verify Go security vulnerability is resolved
- [x] Test build script with both AMD64 and ARM64 architectures  
- [x] Confirm container images build and push successfully
- [x] Validate security scanning with Trivy
- [x] Deployed to qa-eks3

## Security Impact

This update addresses CVE-2025-22874 in the Go toolchain, ensuring the cluster-controller is built with the latest secure Go version.
<img width="810" alt="image" src="https://github.com/user-attachments/assets/cd90688f-52a2-4c94-b207-ee5aa0871544" />
