### PR TITLE
fix: render prometheus recording rules

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-prometheusrule-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-prometheusrule-template.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.prometheus }}
 {{- if .Values.prometheus.serverFiles }}
-{{- if .Values.prometheus.serverFiles.rules }}
+{{- if (index .Values.prometheus.serverFiles "recording_rules.yml") }}
 {{- if .Values.prometheusRule }}
 {{- if .Values.prometheusRule.enabled }}
 apiVersion: monitoring.coreos.com/v1
@@ -14,7 +14,7 @@ metadata:
     {{ toYaml .Values.prometheusRule.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
-  {{ toYaml .Values.prometheus.serverFiles.rules | nindent 2 }}
+  {{ toYaml (index .Values.prometheus.serverFiles "recording_rules.yml") | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Release Notes Headline

Restore the creation of the bundled prometheus recording rules when enabled in the values file (`.Values.prometheusRule.enabled`).

## Commentary for Reviewers

Rendering of the prometheus recording rules was broken with this commit https://github.com/kubecost/cost-analyzer-helm-chart/commit/a1ace4405f68e150b28ef05ff5d49c814334c439. 

## Links to Issues or Tickets

N/A

## User Impact and Risks

No risks, the intended functionality was restored.

## Testing

I've tested the changes by rendering out the templates and confirming the recording rule gets rendered according to the value of `.Values.prometheusRule.enabled`.

## Documentation Updates

N/A
