### PR TITLE
Add tenMinuteRetention field to /productConfigs

### DIFF
--- a/cost-analyzer/templates/frontend-configmap-template.yaml
+++ b/cost-analyzer/templates/frontend-configmap-template.yaml
@@ -517,7 +517,8 @@ data:
                 "hideCloudIntegrationsUI": "{{ default false ((.Values.kubecostProductConfigs).hideCloudIntegrationsUI) }}",
                 "hideBellIcon": "{{ default true ((.Values.kubecostProductConfigs).hideBellIcon) }}",
                 "hideTeams": "{{ default false ((.Values.kubecostProductConfigs).hideTeams) }}",
-                "legacyModeEnabled": "{{ .Values.kubecostAggregator.legacyMode }}"
+                "legacyModeEnabled": "{{ .Values.kubecostAggregator.legacyMode }}",
+                "tenMinuteRetention": "{{ .Values.kubecostAggregator.tenMinuteRetention }}"
                 }
             ';
         }


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
Add `tenMinuteRetention` to `/productConfigs` response.

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
@nikovacevic I do not believe that there actually is a `aggregator.tenMinuteRetention` value in `values.yaml` (yet). Where should this response value be drawn from?

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Closes https://apptio.atlassian.net/browse/KCM-4216

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
