### PR TITLE
Adding a Service Account to Forecasting Deployment 

### DIFF
--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -51,6 +51,9 @@ spec:
         fsGroup: 1001
       {{- end }}
       restartPolicy: Always
+      {{- if .Values.forecasting.serviceAccountName }}
+      serviceAccountName: {{ .Values.forecasting.serviceAccountName }}
+      {{- end }}
       containers:
         - name: forecasting
           {{- if .Values.forecasting.fullImageName }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -848,7 +848,10 @@ forecasting:
     repository: gcr.io/kubecost1/kubecost-modeling
     tag: v0.1.27
   imagePullPolicy: IfNotPresent
-
+  
+  # Set Service Account For Forecast # optional 
+  # serviceAccountName: ""
+  
   # Resource specification block for the forecasting container.
   resources:
     requests:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -850,7 +850,7 @@ forecasting:
   imagePullPolicy: IfNotPresent
 
   # Set Service Account For Forecast # optional
-  # serviceAccountName: ""
+  serviceAccountName: ""
 
   # Resource specification block for the forecasting container.
   resources:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -848,10 +848,10 @@ forecasting:
     repository: gcr.io/kubecost1/kubecost-modeling
     tag: v0.1.27
   imagePullPolicy: IfNotPresent
-  
-  # Set Service Account For Forecast # optional 
+
+  # Set Service Account For Forecast # optional
   # serviceAccountName: ""
-  
+
   # Resource specification block for the forecasting container.
   resources:
     requests:


### PR DESCRIPTION
## Release Notes Headline
Adding a service account for forecasting deployment 

## Commentary for Reviewers
An Option to add a service account to forecasting deployment. 

Service accounts should be added to every Kubernetes deployment to implement the principle of least privilege, ensuring each application only has access to the specific resources it needs rather than using the shared default service account with potentially broad permissions. This approach provides better security isolation by limiting the blast radius if a container is compromised, preventing attackers from accessing resources beyond what that specific application requires. Additionally, dedicated service accounts enable proper audit trails and compliance by making it possible to track which application performed specific actions within the cluster. 

## Links to Issues or Tickets
N/A 

## User Impact and Risks
No impact, this is an optional field to add. 

## Testing
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates
<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
