### PR TITLE
Pass currency code from Helm to Kubecost Aggregator

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1224,10 +1224,10 @@ Begin Kubecost 2.0 templates
     - name: ACTIONS_BUCKET_CONFIG
       value: /var/configs/actions/storage/actions-store.yaml
     {{- end }}
-    {{- if ((.Values.kubecostProductConfigs).currencyCode) }}
+    {{- if and .Values.kubecostProductConfigs .Values.kubecostProductConfigs.currencyCode }}
     - name: DISPLAY_CURRENCY
-     value: .Values.kubecostProductConfigs.currencyCode
-    {{- end}}
+      value: {{ .Values.kubecostProductConfigs.currencyCode }}
+    {{- end }}
 {{- end }}
 
 

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1224,6 +1224,10 @@ Begin Kubecost 2.0 templates
     - name: ACTIONS_BUCKET_CONFIG
       value: /var/configs/actions/storage/actions-store.yaml
     {{- end }}
+    {{- if ((.Values.kubecostProductConfigs).currencyCode) }}
+    - name: DISPLAY_CURRENCY
+     value: .Values.kubecostProductConfigs.currencyCode
+    {{- end}}
 {{- end }}
 
 


### PR DESCRIPTION
## Release Notes Headline

The `.Values.kubecostProductConfigs.currencyCode` is not passed to the Kubecost aggregator, so costs are displayed in the correct currency in reports. 

## Commentary for Reviewers

Minor change to the Aggregator's Helm container spec to pass the `currencyCode` via env as `DISPLAY_CURRENCY` 

## Links to Issues or Tickets

Closes https://apptio.atlassian.net/browse/KCM-4296

## User Impact and Risks

Low-impact change

## Testing

Deployed Kubecost `v2.8.0`, switching the currency between USD and EUR. Confirmed that the costs shown in reports bear the appropriate currency code marking and that conversions between currencies took place over time. 

Additionally, tested using `helm template . --set kubecostProductConfigs.currencyCode=EUR > full.yaml`

## Documentation Updates

None - `currencyCode` is already documented in the IBM documentation here: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=installation-first-time-user-guide#ariaid-title3