### PR TITLE
Pass currency code from Helm to Kubecost Aggregator (#4148)

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1278,6 +1278,10 @@ Begin Kubecost 2.0 templates
     - name: ENTERPRISE_CUSTOM_PRICING_APPLY_RETROACTIVELY
       value: "true"
     {{- end }}
+    {{- if and .Values.kubecostProductConfigs .Values.kubecostProductConfigs.currencyCode }}
+    - name: DISPLAY_CURRENCY
+      value: {{ .Values.kubecostProductConfigs.currencyCode }}
+    {{- end }}
 {{- end }}
 
 


### PR DESCRIPTION
## Release Notes Headline

The `.Values.kubecostProductConfigs.currencyCode` is not passed to the Kubecost aggregator, so costs are displayed in the correct currency in reports. 

## Commentary for Reviewers

Minor change to the Aggregator's Helm container spec to pass the `currencyCode` via env as `DISPLAY_CURRENCY` 

## Links to Issues or Tickets

"N/A"

## User Impact and Risks

Low-impact change

## Testing

Deployed Kubecost `v2.8.0`, switching the currency between USD and EUR. Confirmed that the costs shown in reports bear the appropriate currency code marking and that conversions between currencies took place over time. 

Additionally, tested using `helm template . --set kubecostProductConfigs.currencyCode=EUR > full.yaml`

<img width="481" height="80" alt="image" src="https://github.com/user-attachments/assets/4528076e-00ab-4b55-913c-eba578c4847f" />
<img width="1242" height="200" alt="image" src="https://github.com/user-attachments/assets/cf032af7-6b10-4428-83d6-2f9a80bf11ae" />
<img width="1002" height="280" alt="image" src="https://github.com/user-attachments/assets/6c28e3df-98b0-4b2c-9804-3f893df336f3" />
<img width="532" height="96" alt="image" src="https://github.com/user-attachments/assets/86b44ce1-acb5-4190-bacb-42a85aa45591" />

## Documentation Updates

None - `currencyCode` is already documented in the IBM documentation here: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=installation-first-time-user-guide#ariaid-title3