### PR TITLE
MCD missing `else` statement

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1516,6 +1516,8 @@ are both running, and when the federated storage config is present.
   {{- else -}}
     {{- printf "false" -}}
   {{- end -}}
+{{- else -}}
+  {{- printf "false" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## Release Notes Headline

Fixes `/model/multi-cluster-diagnostics-enabled` to ensure a "true" or "false" is always returned.

## Commentary for Reviewers

In a scenario where a user has explicitly disabled `.Values.diagnostics.enabled` or `.Values.diagnostics.primary.enabled`, this endpoint would return an empty response:

```
{"multiClusterDiagnosticsEnabled": }
```

Here are the related regions of code:

https://github.com/kubecost/cost-analyzer-helm-chart/blob/8f33817d79aa2c4452e7533de964a644ff974984/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml#L1577-L1580

https://github.com/kubecost/cost-analyzer-helm-chart/blob/8f33817d79aa2c4452e7533de964a644ff974984/cost-analyzer/templates/_helpers.tpl#L1508-L1520

## Links to Issues or Tickets

- Fixes https://github.com/kubecost/cost-analyzer-helm-chart/pull/3933

## User Impact and Risks

By default, most users will not run into this bug unless they explicitly set `.Values.diagnostics.enabled=false` or `.Values.diagnostics.primary.enabled=false`. This change is minimal and I think rink is minimal.

## Testing

```yaml
# values.yaml
kubecostModel:
  federatedStorageConfig: "STORAGE_CONFIG_HERE"
prometheus:
  server:
    global:
      external_labels:
        cluster_id: "MCD_CLUSTER_1"
diagnostics:
  enabled: false
```

### Before

```
$ helm template ./cost-analyzer -f mcd.yaml --debug > out.yaml
...

        location /model/multi-cluster-diagnostics-enabled {
            default_type 'application/json';
            return 200 '{"multiClusterDiagnosticsEnabled": }';
        }
```

### After

```
$ helm template ./cost-analyzer -f mcd.yaml --debug > out.yaml
...

        location /model/multi-cluster-diagnostics-enabled {
            default_type 'application/json';
            return 200 '{"multiClusterDiagnosticsEnabled": false}';
        }
```

## Documentation Updates

N/A
<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
