### PR TITLE
Reverts configmap for custom instances

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -202,11 +202,6 @@ spec:
           configMap:
             name: {{ .Values.enterpriseCustomPricing.configMapName }}
         {{- end }}
-        {{- if (.Values.instanceTypes).enabled }}
-        - name: custom-instance-types
-          configMap:
-            name: {{ .Values.instanceTypes.custom.configMapName }}
-        {{- end }}
         {{- if ((.Values.kubecostProductConfigs).actions).config }}
         - name: actions-config
           configMap:

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -383,10 +383,6 @@ spec:
             - name: kubecost-enterprise-pricing
               mountPath: /var/configs/enterprise-pricing
             {{- end }}
-            {{- if and (.Values.instanceTypes.enabled) (.Values.instanceTypes.custom) }}
-            - name: custom-instance-types
-              mountPath: /var/configs/instance-types
-            {{- end }}
             {{- if ((.Values.kubecostProductConfigs).actions).config }}
             - name: actions-config
               mountPath: /var/configs/actions
@@ -607,11 +603,7 @@ spec:
             - name: ENTERPRISE_CUSTOM_PRICING_APPLY_RETROACTIVELY
               value: "true"
             {{- end }}
-            {{- if (.Values.instanceTypes).enabled }}
-            - name: CUSTOM_TYPE_INSTANCES_URI
-              value: {{ (quote .Values.instanceTypes.custom.location.URI) }}
-            {{- end }}
-           {{- if ((.Values.kubecostProductConfigs).actions).enabled }}
+            {{- if ((.Values.kubecostProductConfigs).actions).enabled }}
             - name: ACTIONS_ENABLED
               value: "true"
             - name: ACTIONS_BUCKET_CONFIG

--- a/kubecost/values-instance-types.yaml
+++ b/kubecost/values-instance-types.yaml
@@ -1,7 +1,0 @@
-instanceTypes:
-  enabled: true
-  #  kubectl create configmap -n kubecost custom-instance-types --from-file custom.json
-  custom:
-    configMapName: custom-instance-types
-    location:
-      URI: /var/configs/instance-types/custom.json

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -300,14 +300,6 @@ enterpriseCustomPricing:
   location:
     URI: /var/configs/enterprise-pricing/pricing.csv
 
-instanceTypes:
-  enabled: false
-  #  kubectl create configmap -n kubecost custom-instance-types --from-file custom.json
-  custom:
-    configMapName: custom-instance-types
-    location:
-      URI: /var/configs/instance-types/custom.json
-
 ## Kubecost SAML (enterprise key required)
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=configuration-user-management-saml
 saml:


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
N/A
## Commentary for Reviewers
In our discussion , custom instance uploads wasnt asked so during the revert undoing changes from PR https://github.com/kubecost/kubecost/pull/4090

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-4343
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
None
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Currently helm is broken but this wont create a configmap upload to KCM container. 
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates
NR
<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
