### PR TITLE
add heartbeat flag and retention

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -485,6 +485,12 @@ spec:
             - name: DIAGNOSTICS_RETENTION
               value: {{ .Values.diagnostics.retention | quote }}
             {{- end }}
+            {{- if .Values.heartbeat.enabled }}
+            - name: HEARTBEAT_ENABLED
+              value: "true"
+            - name: HEARTBEAT_RETENTION
+              value: {{ .Values.heartbeat.retention | quote }}
+            {{- end }}
             {{- if (.Values.aggregator).standardDiscount }}
             {{- if .Values.ingestionConfigmapName }}
             - name: INGESTION_CONFIGMAP_NAME

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1033,7 +1033,11 @@ aggregator:
 ## retention: deletes data beyond specified retention period
 diagnostics:
   enabled: true
-  retention: 90d
+  retention: 30d
+
+heartbeat:
+  enabled: true
+  retention: 7d
 
 ## TODO change this comment, what are we doing with service acounts
 ## Creates a new container/pod to retrieve CloudCost data. By default it uses

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1037,7 +1037,7 @@ diagnostics:
 
 heartbeat:
   enabled: true
-  retention: 7d
+  retention: 30d
 
 ## TODO change this comment, what are we doing with service acounts
 ## Creates a new container/pod to retrieve CloudCost data. By default it uses


### PR DESCRIPTION
## Release Notes Headline
Add heartbeat enabled flag and config for setting heartbeat retention

## Commentary for Reviewers

## Links to Issues or Tickets


## User Impact and Risks
Users will be able to disable heartbeat and set retention for it

## Testing
used helm template cmd to check if the envs were getting populated in the output manifest

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
