### PR TITLE
fix federated-store

### DIFF
--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -548,21 +548,24 @@ federated storage config helpers
   {{- end }}
 {{- end -}}
 
+    {{/*
+    NOTE: added kubecostModel for backward compatibility
+    */}}
 {{- define "kubecost.federatedStorage.config" }}
   {{- if (.Values.kubecostModel).federatedStorageConfig -}}
-    {{- (.Values.kubecostModel).federatedStorageConfig -}}
-  {{- else if (.Values.federatedStorage).config }}
-    {{- (.Values.federatedStorage).config -}}
+    {{- toYaml (.Values.kubecostModel).federatedStorageConfig -}}
+  {{- else if (.Values.federatedStorage).config -}}
+    {{- toYaml (.Values.federatedStorage).config -}}
   {{- else if (.Values.global.federatedStorage).federatedStorageConfig -}}
-    {{- (.Values.global.federatedStorage).federatedStorageConfig -}}
-  {{ else }}
+    {{- toYaml (.Values.global.federatedStorage).federatedStorageConfig -}}
+  {{- else -}}
     {{/*
     TODO:Default federated storage config 
     for single cluster environments
     */}}
-    {{- printf "localClusterBucket" }}
-  {{- end }}
-{{- end }}
+    {{- printf "localClusterBucket" -}}
+  {{- end -}}
+{{- end -}}
 
 {{- define "kubecost.federatedStorage.fileName" -}}
 {{ default "federated-store.yaml" (.Values.global.federatedStorage).fileName }}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -548,16 +548,16 @@ federated storage config helpers
   {{- end }}
 {{- end -}}
 
-    {{/*
-    NOTE: added kubecostModel for backward compatibility
-    */}}
-{{- define "kubecost.federatedStorage.config" }}
+{{/*
+NOTE: added kubecostModel for backward compatibility
+*/}}
+{{- define "kubecost.federatedStorage.config-b64" }}
   {{- if (.Values.kubecostModel).federatedStorageConfig -}}
-    {{- toYaml (.Values.kubecostModel).federatedStorageConfig -}}
+    {{- (.Values.kubecostModel).federatedStorageConfig | b64enc -}}
   {{- else if (.Values.federatedStorage).config -}}
-    {{- toYaml (.Values.federatedStorage).config -}}
-  {{- else if (.Values.global.federatedStorage).federatedStorageConfig -}}
-    {{- toYaml (.Values.global.federatedStorage).federatedStorageConfig -}}
+    {{- (.Values.federatedStorage).config | b64enc -}}
+  {{- else if (.Values.global.federatedStorage).config -}}
+    {{- (.Values.global.federatedStorage).config | b64enc -}}
   {{- else -}}
     {{/*
     TODO:Default federated storage config 

--- a/kubecost/templates/kubecost-federated-storage-config-secret.yaml
+++ b/kubecost/templates/kubecost-federated-storage-config-secret.yaml
@@ -8,5 +8,5 @@ metadata:
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 data:
-  {{- include "kubecost.federatedStorage.fileName" . | nindent 2}}: {{ (include "kubecost.federatedStorage.config" . ) | b64enc }}
+  {{- include "kubecost.federatedStorage.fileName" . | nindent 2}}: {{ (include "kubecost.federatedStorage.config-b64" . ) }}
 {{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -13,10 +13,9 @@ global:
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=cluster-long-term-federated-storage-configuration
   federatedStorage:
     config: ""
-    # A federated storage config can be provided via a secret or via helm values.
-    # If both are provided, the federatedStorageConfig take precedence.
+    # A federated storage config can be provided via an existingSecretName or via a string in helm values.
+    # If both are provided, the string in helm values take precedence.
     # Example:
-    # federatedStorage:
     #   config: |-
     #     type: S3
     #     config:
@@ -25,7 +24,6 @@ global:
     #       region: us-west-2
     #       access_key: xxx
     #       secret_key: xxx
-    # see federatedStorage: below for more examples
     existingSecretName: ""
     # If you want to use a different file name for the federated storage config, you can set the fileName value.
     fileName: federated-store.yaml  # set this value to change what the file name for the yaml config is

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -12,8 +12,20 @@ global:
   ## The contents should be stored under a key named storage-config.yaml by default.
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=cluster-long-term-federated-storage-configuration
   federatedStorage:
+    config: ""
     # A federated storage config can be provided via a secret or via helm values.
     # If both are provided, the federatedStorageConfig take precedence.
+    # Example:
+    # federatedStorage:
+    #   config: |-
+    #     type: S3
+    #     config:
+    #       bucket: ibm-kubecost-unified-agent-demo-data
+    #       endpoint: s3.amazonaws.com
+    #       region: us-west-2
+    #       access_key: xxx
+    #       secret_key: xxx
+    # see federatedStorage: below for more examples
     existingSecretName: ""
     federatedStorageConfig: ""  # Use this to include the federated storage config via helm values.
     # If you want to use a different file name for the federated storage config, you can set the fileName value.

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -27,7 +27,6 @@ global:
     #       secret_key: xxx
     # see federatedStorage: below for more examples
     existingSecretName: ""
-    federatedStorageConfig: ""  # Use this to include the federated storage config via helm values.
     # If you want to use a different file name for the federated storage config, you can set the fileName value.
     fileName: federated-store.yaml  # set this value to change what the file name for the yaml config is
   ## If global.imageRegistry is set, it will override all kubecost images to allow air-gapped and self-hosted registries.


### PR DESCRIPTION
Added toYaml and comment on backward compatibility.

I will say that the lack of consistency here is not ideal (config: vs federatedStorageConfig) but this isn't critical to me.

@thomasvn do you have concerns?

tested. format is working properly for all 3 options.

```yaml
kubecostModel:
  federatedStorageConfig: |-
    type: S3
    config:
      bucket: demo-data
      endpoint: s3.amazonaws.com
      region: us-west-2
```
```yaml
federatedStorage:
  config: |-
    type: S3
    config:
      bucket: demo-data
      endpoint: s3.amazonaws.com
      region: us-west-2
```
```yaml
global:
  federatedStorage:
    config: |-
      type: S3
      config:
        bucket: demo-data
        endpoint: s3.amazonaws.com
        region: us-west-2
```

