### PR TITLE
TODO: fix comments on federated store

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -14,7 +14,7 @@ global:
   federatedStorage:
     config: ""
     # A federated storage config can be provided via a secret or via helm values.
-    # If both are provided, the federatedStorageConfig take precedence.
+    # If both are provided, the federatedStorage: key on the root values takes precedence.
     # Example:
     # federatedStorage:
     #   config: |-
@@ -538,6 +538,7 @@ finops-agent:
 
 
 federatedStorage:
+  config: ""
   ## federated storage config can be supplied via a secret or the yaml block
   ## below when using the block below, only a single provider is supported,
   ## others are for example purposes.


### PR DESCRIPTION
https://github.com/kubecost/kubecost/pull/4185

I tested:
```
global:
  federatedStorage:
    config: |-
 ```
creates correctly with the `config`  key uncommented for federatedStorage on the root