### PR TITLE
hardcode getConfigs to use helm values

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1631,7 +1631,7 @@ data:
                 "carbonEstimatesEnabled": "{{ template "carbonEstimatesEnabled" . }}",
                 "clusterControllerEnabled": "{{ template "clusterControllerEnabled" . }}",
                 "forecastingEnabled": "{{ template "forecastingEnabled" . }}",
-                "chartVersion": "2.8.2",
+                "chartVersion": "2.8.3",
                 "hourlyDataRetention": "{{ (.Values.kubecostAggregator.etlHourlyStoreDurationHours) }}",
                 "dailyDataRetention": "{{ (.Values.kubecostAggregator.etlDailyStoreDurationDays) }}",
                 "hideDiagnostics": "{{ default false ((.Values.kubecostProductConfigs).hideDiagnostics) }}",
@@ -1646,6 +1646,25 @@ data:
                 "DBv3Enabled": "{{ .Values.kubecostAggregator.useDBv3 }}"
                 }
             ';
+        }
+
+        location = /model/getConfigs {
+            default_type 'application/json';
+            return 200 '{
+                "code": 200,
+                "status": "success",
+                "data": {
+               
+                    "defaultIdle": "{{ .Values.kubecostProductConfigs.defaultIdle }}",
+                    "currencyCode": "{{ .Values.kubecostProductConfigs.currencyCode }}",
+                    "negotiatedDiscount": "{{ .Values.kubecostProductConfigs.negotiatedDiscount }}",
+                    "sharedOverhead": "{{ .Values.kubecostProductConfigs.sharedOverhead }}",
+                    "sharedNamespaces": "{{ .Values.kubecostProductConfigs.sharedNamespaces }}",
+                    "sharedLabelNames": "{{ .Values.kubecostProductConfigs.sharedLabelNames }}",
+                    "sharedLabelValues": "{{ .Values.kubecostProductConfigs.sharedLabelValues }}",
+                    "shareTenancyCosts": "{{ .Values.kubecostProductConfigs.shareTenancyCosts }}"
+                }
+            }';
         }
     }
 


### PR DESCRIPTION
## Release Notes Headline
Set `/getConfigs` response to use hardcoded helm values
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
In v2.8 and v3.0 we deleted the costmodel.go file that powered a number of endpoints that were no longer needed. The `/updateConfigByKey` endpoint was one of those removed, but it caused issues in the settings UI. A decision was made to make the settings UI read only for shared cost fields, discounts, currency code, and default idle. These settings can now only be configured via helm. In 3.0, we added this `/model/getConfigs` hardcoding to the helm chart, but this was not added to v2.8 so I've ported it back in this PR.
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
Closes https://apptio.atlassian.net/browse/KCM-4269
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
Minimal. This just allows us to populate the settings page with the values that were set in the helm chart
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
`/getConfigs` returns values directly from the helm chart
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
