### PR TITLE
remove hard-coded aggregator resource limits

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -953,9 +953,9 @@ aggregator:
     limits: {}
       # memory: ""
       # cpu: ""
-    requests: {}
-      # memory: ""
-      # cpu: ""
+    requests:
+      memory: 3Gi
+      cpu: 100m
   readinessProbe:
     enabled: true
     initialDelaySeconds: 10

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -949,14 +949,13 @@ aggregator:
   aggregatorDbStorage:
     storageClass: ""  # default storage class
     storageRequest: 128Gi
-
   resources:
-    limits:
-      memory: 5Gi
-    requests:
-      cpu: 2000m
-      memory: 5Gi
-
+    limits: {}
+      # memory: ""
+      # cpu: ""
+    requests: {}
+      # memory: ""
+      # cpu: ""
   readinessProbe:
     enabled: true
     initialDelaySeconds: 10


### PR DESCRIPTION
reverts hard-coded limits to reduce risks during upgrades to 3.0.