### PR TITLE
add the cluster profile to productConfigs

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -519,6 +519,7 @@ data:
                 "hideTeams": "{{ default false ((.Values.kubecostProductConfigs).hideTeams) }}",
                 "legacyModeEnabled": "{{ .Values.aggregator.legacyMode }}",
                 "clusterId": "{{ include "kubecost.clusterId" . }}"
+                "defaultSavingsProfile": "{{ default "production" ((.Values.kubecostProductConfigs).clusterProfile)}}"
                 }
             ';
         }


### PR DESCRIPTION
## Release Notes Headline
 
N/A

## Commentary for Reviewers

Expose the `clusterProfile` as the `defaultSavingsProfile` in `/productConfigs`.

This might be an abuse of that value, let me know if we need to add a new value to cover this use case.

## Links to Issues or Tickets

- https://apptio.atlassian.net/browse/KCM-4370

## User Impact and Risks


## Testing

`helm template` with test values with and without `clusterProfile` defined. Validated `frontend-configmap.yaml > data > nginx.conf` had the correct return for `location /model/productConfigs ` 

## Documentation Updates

