### PR TITLE
expose if turbonomics is enabled

### DIFF
--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -422,6 +422,14 @@ kubecost.costEventsAudit.enabled flag for nginx configmap
 {{- end -}}
 {{- end -}}
 
+{{- define "kubecost.turbonomic.enabled" }}
+{{- if ((.Values.global.integrations.turbonomic).enabled) }}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "false" -}}
+{{- end -}}
+{{- end -}}
+
 {{- /*
   Compute a checksum based on the rendered content of specific ConfigMaps and Secrets.
 */ -}}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -505,6 +505,7 @@ data:
                 "carbonEstimatesEnabled": "{{ include "kubecost.carbonEstimates.enabled" . }}",
                 "clusterControllerEnabled": "{{ include "kubecost.clusterController.enabled" . }}",
                 "forecastingEnabled": "{{ include "kubecost.forecasting.enabled" . }}",
+                "turbonomicEnabled": "{{include "kubecost.turbonomic.enabled" .}}"
                 "chartVersion": "DEVELOP_BRANCH",
                 "hourlyDataRetention": "{{ (.Values.kubecost.retention1h) }}",
                 "dailyDataRetention": "{{ (.Values.kubecost.retention1d) }}",

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -505,7 +505,7 @@ data:
                 "carbonEstimatesEnabled": "{{ include "kubecost.carbonEstimates.enabled" . }}",
                 "clusterControllerEnabled": "{{ include "kubecost.clusterController.enabled" . }}",
                 "forecastingEnabled": "{{ include "kubecost.forecasting.enabled" . }}",
-                "turbonomicEnabled": "{{include "kubecost.turbonomic.enabled" .}}",
+                "turbonomicEnabled": "{{ include "kubecost.turbonomic.enabled" . }}",
                 "chartVersion": "DEVELOP_BRANCH",
                 "hourlyDataRetention": "{{ (.Values.kubecost.retention1h) }}",
                 "dailyDataRetention": "{{ (.Values.kubecost.retention1d) }}",

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -505,7 +505,7 @@ data:
                 "carbonEstimatesEnabled": "{{ include "kubecost.carbonEstimates.enabled" . }}",
                 "clusterControllerEnabled": "{{ include "kubecost.clusterController.enabled" . }}",
                 "forecastingEnabled": "{{ include "kubecost.forecasting.enabled" . }}",
-                "turbonomicEnabled": "{{include "kubecost.turbonomic.enabled" .}}"
+                "turbonomicEnabled": "{{include "kubecost.turbonomic.enabled" .}}",
                 "chartVersion": "DEVELOP_BRANCH",
                 "hourlyDataRetention": "{{ (.Values.kubecost.retention1h) }}",
                 "dailyDataRetention": "{{ (.Values.kubecost.retention1d) }}",


### PR DESCRIPTION
## Release Notes Headline

N/A

## Commentary for Reviewers

Exposes if the turbonomic integration is enabled via `/productConfigs`

## Links to Issues or Tickets

## User Impact and Risks

## Testing

Used `helm template` with test values.yaml files with turbo enabled, disabled, and missing. Validated `frontend-configmap.yaml > data > nginx.conf` had the correct return for `location /model/productConfigs`

## Documentation Updates

