### PR TITLE
existingSecretName rename

### DIFF
--- a/.github/ci-helmValues/helmValues-federated-store.yaml
+++ b/.github/ci-helmValues/helmValues-federated-store.yaml
@@ -1,12 +1,9 @@
-kubecostModel:
-  federatedStorageConfig: |-
-    type: S3
-    config:
-      bucket: "kubecost-helm-testing-metrics"
-      endpoint: "s3.amazonaws.com"
-      region: "us-east-2"
-kubecostProductConfigs:
-  clusterName: helm-testing
-finops-agent:
-  enabled: true
-  clusterId: cluster-one
+global:
+  federatedStorage:
+    config: |-
+      type: S3
+      config:
+        bucket: "kubecost-helm-testing-metrics"
+        endpoint: "s3.amazonaws.com"
+        region: "us-east-2"
+  clusterId: helm-testing

--- a/kubecost/ci/aggregator-values.yaml
+++ b/kubecost/ci/aggregator-values.yaml
@@ -1,4 +1,5 @@
 global:
+  clusterId: helm-testing
   federatedStorage:
     existingSecret: federated-storage-config
 aggregator:
@@ -16,12 +17,3 @@ cloudCost:
   cloudIntegrationSecret: cloud-integration
 finops-agent:
   enabled: false
-  clusterId: cluster-one
-kubecostProductConfigs:
-  clusterName: CLUSTER_NAME
-prometheus:
-  server:
-    global:
-      external_labels:
-        # cluster_id should be unique for all clusters and the same value as .kubecostProductConfigs.clusterName
-        cluster_id: CLUSTER_NAME  # keeping for backward compatibility testing

--- a/kubecost/ci/federatedetl-primary-netcosts-values.yaml
+++ b/kubecost/ci/federatedetl-primary-netcosts-values.yaml
@@ -1,8 +1,7 @@
 global:
   federatedStorage:
     existingSecret: federated-storage-config
-kubecostProductConfigs:
-  clusterName: CLUSTER_NAME
+  clusterId: helm-testing
 #  cloudCost:
 #  cloudIntegrationSecret: cloud-integration
 serviceAccount:  # this example uses AWS IRSA, which creates a service account with rights to the s3 bucket. If using keys+secrets in the federated storage, set create: true
@@ -25,4 +24,3 @@ aggregator:
       memory: 10Gi
 finops-agent:
   enabled: false
-  clusterId: cluster-one

--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -5,7 +5,6 @@
 {{- include "kubecost.cloudCost.gcpBigQuery.CloudIntegrationCheck" . -}}
 {{- include "kubecost.cloudCost.azureStorage.CloudIntegrationCheck" . -}}
 {{- include "kubecost.federatedStorage.secret.check" . -}}
-{{- include "kubecost.federatedStorage.source.check" . -}}
 {{- include "kubecost.clusterId.check" . -}}
 {{- include "kubecost.caCertsSecretConfig.check" . -}}
 {{- include "kubecost.actionsStorageSourceCheck" . -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -495,7 +495,7 @@ federated storage config helpers
 
 {{- define "kubecost.federatedStorage.secretName" }}
   {{- if .Values.global.federatedStorage.existingSecret  }}
-    {{ .Values.global.federatedStorage.existingSecret }}
+    {{- .Values.global.federatedStorage.existingSecret }}
   {{- else -}}
     {{- .Release.Name }}-federated-storage-config
   {{- end }}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -90,15 +90,15 @@ Verify that the global cluster id is set
 */}}
 {{- define "kubecost.clusterId.check" -}}
   {{- if ((((.Values.prometheus).server).global).external_labels).cluster_id }}
-    {{ fail "\n\nIn Kubecost 3.0, `.Values.prometheus.server.global.external_labels.cluster_id` is no longer required.\nWhen it is set, it is used for backwards compatibility. \nSee TODO for more information.\n" }}
+    {{ fail "\n\nIn Kubecost 3.0, `.Values.prometheus.server.global.external_labels.cluster_id` has been moved to `.Values.global.clusterId`\n" }}
   {{- end }}
   {{- if (.Values.kubecostProductConfigs).clusterName }}
-    {{ fail "\n\nIn Kubecost 3.0, `.Values.kubecostProductConfigs.clusterName` is no longer required.\nWhen it is set, it is used for backwards compatibility. \nSee TODO for more information.\n" }}
+    {{ fail "\n\nIn Kubecost 3.0, `.Values.kubecostProductConfigs.clusterName` has been moved to `.Values.global.clusterId`\n" }}
   {{- end }}
   {{- if not .Values.global.clusterId }}
     {{- fail "\n\nIn Kubecost 3.0, `.Values.global.clusterId` is required to be set"}}
   {{- end }}
-  {{- if or (.Values.global.federatedStorage).existingSecret ((.Values.federatedStorage).secret).config }}
+  {{- if or .Values.global.federatedStorage.existingSecret .Values.global.federatedStorage.config }}
     {{- if eq .Values.global.clusterId "cluster-one" }}
       {{- printf "\n\nWarning: it is recommended to specify a unique `.Values.global.clusterId` for each cluster.\nNote this must be a globally unique identifier in multi-cluster environments.\n" -}}
     {{- end -}}
@@ -124,14 +124,6 @@ example, does not support templating a chart which uses the lookup function.
 {{- end -}}
 {{- end -}}
 
-{{/*
-federated storage source check. Either the Secret must be specified or the JSON, not both.
-*/}}
-{{- define "kubecost.federatedStorage.source.check" -}}
-  {{- if and ((.Values.global).federatedStorage).existingSecret ((.Values.federatedStorage).secret).config -}}
-    {{- fail "\n.Values.global.federatedStorage.existingSecret and .Values.federatedStorage.secret.config both set, please specify only one." -}}
-  {{- end -}}
-{{- end -}}
 
 {{/*
 Actions Storage source contents check. Either the Secret must be specified or the YAML, not both.
@@ -502,9 +494,7 @@ federated storage config helpers
 */}}
 
 {{- define "kubecost.federatedStorage.secretName" }}
-  {{- if (.Values.kubecostModel).federatedStorageConfigSecret }}
-    {{- .Values.kubecostModel.federatedStorageConfigSecret }}
-  {{- else if (.Values.global.federatedStorage).existingSecret -}}
+  {{- if .Values.global.federatedStorage.existingSecret  }}
     {{ .Values.global.federatedStorage.existingSecret }}
   {{- else -}}
     {{- .Release.Name }}-federated-storage-config
@@ -515,12 +505,8 @@ federated storage config helpers
 NOTE: added kubecostModel for backward compatibility
 */}}
 {{- define "kubecost.federatedStorage.config" }}
-  {{- if (.Values.kubecostModel).federatedStorageConfig -}}
-    {{- (.Values.kubecostModel).federatedStorageConfig -}}
-  {{- else if (.Values.federatedStorage).config -}}
-    {{- (.Values.federatedStorage).config -}}
-  {{- else if (.Values.global.federatedStorage).config -}}
-    {{- (.Values.global.federatedStorage).config -}}
+  {{- if .Values.global.federatedStorage.config -}}
+    {{- .Values.global.federatedStorage.config -}}
   {{- else }}
     type: cluster
     config:

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -10,7 +10,7 @@ Kubecost 3.0 preconditions
   {{- if (.Values.kubecostModel).federatedStorageConfig -}}
     {{ fail "\n\n--- `.Values.kubecostModel.federatedStorageConfig` is no longer supported. Please use `.Values.global.federatedStorage.config` instead. ---" }}
   {{- else if (.Values.kubecostModel).federatedStorageConfigSecret -}}
-    {{ fail "\n\n--- `.Values.kubecostModel.federatedStorageConfigSecret` is no longer supported. Please use `.Values.kubecostModel.federatedStorage.existingSecretName` instead. ---" }}
+    {{ fail "\n\n--- `.Values.kubecostModel.federatedStorageConfigSecret` is no longer supported. Please use `.Values.kubecostModel.federatedStorage.existingSecret` instead. ---" }}
   {{- end -}}
 {{- end -}}
 

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -401,7 +401,7 @@ spec:
               mountPath: /var/configs/actions/storage
             {{- end }}
             {{- if ((.Values.kubecostProductConfigs).actions).storageConfigSecret }}
-            {{- if eq ((.Values.kubecostProductConfigs).actions).storageConfigSecret (.Values.kubecostModel).federatedStorageConfigSecret }}
+            {{- if eq ((.Values.kubecostProductConfigs).actions).storageConfigSecret .Values.global.federatedStorage.existingSecret  }}
             - name: actions-storage
               mountPath: /var/configs/actions/storage
             - name: federated-storage-config

--- a/kubecost/templates/local-store/_helpers.tpl
+++ b/kubecost/templates/local-store/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "kubecost.localStore.enabled" -}}
   {{- if .Values.global.federatedStorage.config -}}
     {{- "disabled" -}}
-  {{- else if .Values.global.federatedStorage.existingSecretName -}}
+  {{- else if .Values.global.federatedStorage.existingSecret -}}
     {{- "disabled" -}}
   {{- else if not .Values.localStore.enabled -}}
     {{- "disabled" -}}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -12,7 +12,7 @@ global:
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=cluster-long-term-federated-storage-configuration
   federatedStorage:
     config: ""
-    # A federated storage config can be provided via an existingSecretName or via a string in helm values.
+    # A federated storage config can be provided via an existingSecret or via a string in helm values.
     # If both are provided, the string in helm values take precedence.
     # Example:
     #   config: |-
@@ -23,14 +23,14 @@ global:
     #       region: us-west-2
     #       access_key: xxx
     #       secret_key: xxx
-    existingSecretName: ""
+    existingSecret: ""
     # If you want to use a different file name for the federated storage config, you can set the fileName value.
     fileName: federated-store.yaml  # set this value to change what the file name for the yaml config is
-    ## @param cspPricingApiKey.existingSecretName The name of an existing secret to use for the GCP API key. If this is set, the secret will be used. Leave empty to create a new secret.
+    ## @param cspPricingApiKey.existingSecret The name of an existing secret to use for the GCP API key. If this is set, the secret will be used. Leave empty to create a new secret.
     ## @param cspPricingApiKey.apiKey The GCP API key value. If this is set, the secret will be created. Leave empty to use an existing secret.
     ## This is currently only used for GCP.
   cspPricingApiKey:
-    existingSecretName: ""
+    existingSecret: ""
     apiKey: ""
   ## @param global.imageRegistry The image registry to use for the finops agent
   imageRegistry: ""


### PR DESCRIPTION
Fix existingSecretName
related to https://github.com/kubecost/kubecost/pull/4194

## Testing
kind cluster:
<img width="552" height="140" alt="image" src="https://github.com/user-attachments/assets/c2d3b729-497c-4013-8f86-6970be733422" />

upgrade oidc-entraid (removed local store pod)

<img width="547" height="94" alt="image" src="https://github.com/user-attachments/assets/52233bb5-70e1-4a0d-aa51-299d06d8d07f" />

linting:

```sh
ct lint --chart-dirs=kubecost/ --charts kubecost/ --validate-maintainers=false
All charts linted successfully
```