### PR TITLE
Alerts in version 3.0 is only health alert tied to Multi cluster diagnostic

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -36,3 +36,4 @@ kubecost.me.com
 https://kubecost.myorganization.com
 https://support.kubecost.com
 https://example.okta.com/app/EXAMPLE/sso/saml/metadata
+https://kubecost.mycorp.org

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -53,7 +53,7 @@ global:
       adaptSecurityContext: auto
 
   ## Kubecost Alerting
-  ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=ui-alerts
+  ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=ui-alerts
   notifications:
   #   alertConfigs:
   #     frontendUrl: http://localhost:9090/  # Optional

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -31,59 +31,25 @@ global:
   # - "image-pull-secret"
 
   ## Kubecost Alerting
-  ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=ui-alerts
-  ##
+  ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=ui-alerts
   notifications:
-    # alertConfigs:
-    #   frontendUrl: http://localhost:9090  # Optional
-    #   globalSlackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
-    #   globalMsTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
-    #   globalAlertEmails:
-    #     - recipient@example.com
-    #     - additionalRecipient@example.com
-    #   globalEmailSubject: Custom Subject
-    #   alerts:
-    #     # Daily namespace budget alert on namespace `kubecost`
-    #     - type: budget                # supported: budget, recurringUpdate
-    #       threshold: 50               # optional, required for budget alerts
-    #       window: daily               # or 1d
-    #       aggregation: namespace
-    #       filter: kubecost
-    #       ownerContact:               # optional, overrides globalAlertEmails default
-    #         - owner@example.com
-    #         - owner2@example.com
-    #       slackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
-    #       msTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
-    #     # Daily cluster budget alert on cluster `cluster-one`
-    #     - type: budget
-    #       threshold: 200.8        # optional, required for budget alerts
-    #       window: daily           # or 1d
-    #       aggregation: cluster
-    #       filter: cluster-one     # does not accept csv
-    #     # Recurring weekly update (weeklyUpdate alert)
-    #     - type: recurringUpdate
-    #       window: weekly          # or 7d
-    #       aggregation: namespace
-    #       filter: '*'
-    #     # Recurring weekly namespace update on kubecost namespace
-    #     - type: recurringUpdate
-    #       window: weekly # or 7d
-    #       aggregation: namespace
-    #       filter: kubecost
-    #     # Spend Change Alert
-    #     - type: spendChange         # change relative to moving avg
-    #       relativeThreshold: 0.20   # Proportional change relative to baseline. Must be greater than -1 (can be negative)
-    #       window: 1d                # accepts ‘d’, ‘h’
-    #       baselineWindow: 30d       # previous window, offset by window
-    #       aggregation: namespace
-    #       filter: kubecost, default # accepts csv
-    #     # Health Score Alert
-    #     - type: health              # Alerts when health score changes by a threshold
-    #       window: 10m
-    #       threshold: 5              # Send Alert if health scores changes by 5 or more
-    #     # Kubecost Health Diagnostic
-    #     - type: diagnostic          # Alerts when kubecost is unable to compute costs - ie: unreachable metric sources
-    #       window: 10m
+  #   alertConfigs:
+  #     frontendUrl: http://localhost:9090/  # Optional
+  #     globalSlackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
+  #     globalMsTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
+  #     globalAlertEmails:
+  #       - recipient@example.com
+  #       - additionalRecipient@example.com
+  #     globalEmailSubject: Custom Subject
+  #     alerts:
+  #       # Application health alerts are reported. 
+  #       - type: health    # Currently supports Multi Cluster diagnostic related alerts and further application alerts can be added
+  #         window: 1h      # how often do you want alert system to poll for health related alerts.
+  #         ownerContact:   # optional, adds email address to notify in addition to globalAlertEmails.
+  #           - owner@example.com
+  #           - owner2@example.com
+  #         slackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, adds slack webhook to notify in addition to globalSlackWebhookUrl.
+  #         msTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, , adds MS teams webhook to notify in addition to globalMsTeamsWebhookUrl.
 
   ## Kubecost Saved Reports
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=ui-reports

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -70,7 +70,7 @@ global:
     #       ownerContact:   # optional, adds email address to notify in addition to globalAlertEmails.
     #         - owner@example.com
     #         - owner2@example.com
-    #       slackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, adds slack webhook to notify in addition to globalSlackWebhookUrl.
+    #       slackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional. Adds a Slack webhook specific to this alert. Is additive to globalSlackWebhookUrl.
     #       msTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional. Adds a Microsoft Teams webhook specific to this alert. Is additive to globalMsTeamsWebhookUrl.
   chartName: "kubecost"
   ## Kubecost Saved Reports

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -66,7 +66,7 @@ global:
     #   alerts:
     #     # Application health alerts are reported. 
     #     - type: health    # Monitors Kubecost health based on multi-cluster diagnostics.
-    #       window: 1h      # how often do you want alert system to poll for health related alerts.
+    #       window: 1h      # The frequency to poll for alert status.
     #       ownerContact:   # optional, adds email address to notify in addition to globalAlertEmails.
     #         - owner@example.com
     #         - owner2@example.com

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -64,7 +64,7 @@ global:
     #     - additionalRecipient@example.com
     #   globalEmailSubject: Custom Subject
     #   alerts:
-    #     # Application health alerts are reported. 
+    #     # Application health alerts are reported.
     #     - type: health    # Monitors Kubecost health based on multi-cluster diagnostics.
     #       window: 1h      # The frequency to poll for alert status.
     #       ownerContact:   # Optional. Adds email address specific to this alert. Is additive to globalAlertEmails.

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -55,6 +55,7 @@ global:
   ## Kubecost Alerting
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=ui-alerts
   notifications:
+  chartName: "kubecost"
   #   alertConfigs:
   #     frontendUrl: http://localhost:9090/  # Optional
   #     globalSlackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -55,7 +55,6 @@ global:
   ## Kubecost Alerting
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=ui-alerts
   notifications:
-  chartName: "kubecost"
   #   alertConfigs:
   #     frontendUrl: http://localhost:9090/  # Optional
   #     globalSlackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
@@ -73,7 +72,7 @@ global:
   #           - owner2@example.com
   #         slackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, adds slack webhook to notify in addition to globalSlackWebhookUrl.
   #         msTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, , adds MS teams webhook to notify in addition to globalMsTeamsWebhookUrl.
-
+  chartName: "kubecost"
   ## Kubecost Saved Reports
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=ui-reports
   ##

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -56,7 +56,7 @@ global:
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=ui-alerts
   notifications:
     # alertConfigs:
-    #   frontendUrl: http://localhost:9090/  # Optional
+    #   frontendUrl: http://localhost:9090  # Optional. When configured, the alert message includes a link to the page you want to visit for analyzing the alert.
     #   globalSlackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
     #   globalMsTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
     #   globalAlertEmails:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -56,7 +56,7 @@ global:
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=ui-alerts
   notifications:
     # alertConfigs:
-    #   frontendUrl: http://localhost:9090  # Optional. When configured, the alert message includes a link to the page you want to visit for analyzing the alert.
+    #   frontendUrl: http://localhost:9090  # Optional. When configured, alert notifications will include a link back to the Kubecost web portal. Value should be the publicly-accessible URL of Kubecost with no path included. Ex., https://kubecost.mycorp.org
     #   globalSlackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
     #   globalMsTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
     #   globalAlertEmails:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -65,7 +65,7 @@ global:
     #   globalEmailSubject: Custom Subject
     #   alerts:
     #     # Application health alerts are reported. 
-    #     - type: health    # Currently supports Multi Cluster diagnostic related alerts and further application alerts can be added
+    #     - type: health    # Monitors Kubecost health based on multi-cluster diagnostics.
     #       window: 1h      # how often do you want alert system to poll for health related alerts.
     #       ownerContact:   # optional, adds email address to notify in addition to globalAlertEmails.
     #         - owner@example.com

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -71,7 +71,7 @@ global:
     #         - owner@example.com
     #         - owner2@example.com
     #       slackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, adds slack webhook to notify in addition to globalSlackWebhookUrl.
-    #       msTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, , adds MS teams webhook to notify in addition to globalMsTeamsWebhookUrl.
+    #       msTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional. Adds a Microsoft Teams webhook specific to this alert. Is additive to globalMsTeamsWebhookUrl.
   chartName: "kubecost"
   ## Kubecost Saved Reports
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=ui-reports

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -67,7 +67,7 @@ global:
     #     # Application health alerts are reported. 
     #     - type: health    # Monitors Kubecost health based on multi-cluster diagnostics.
     #       window: 1h      # The frequency to poll for alert status.
-    #       ownerContact:   # optional, adds email address to notify in addition to globalAlertEmails.
+    #       ownerContact:   # Optional. Adds email address specific to this alert. Is additive to globalAlertEmails.
     #         - owner@example.com
     #         - owner2@example.com
     #       slackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional. Adds a Slack webhook specific to this alert. Is additive to globalSlackWebhookUrl.

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -55,23 +55,23 @@ global:
   ## Kubecost Alerting
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=ui-alerts
   notifications:
-  #   alertConfigs:
-  #     frontendUrl: http://localhost:9090/  # Optional
-  #     globalSlackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
-  #     globalMsTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
-  #     globalAlertEmails:
-  #       - recipient@example.com
-  #       - additionalRecipient@example.com
-  #     globalEmailSubject: Custom Subject
-  #     alerts:
-  #       # Application health alerts are reported. 
-  #       - type: health    # Currently supports Multi Cluster diagnostic related alerts and further application alerts can be added
-  #         window: 1h      # how often do you want alert system to poll for health related alerts.
-  #         ownerContact:   # optional, adds email address to notify in addition to globalAlertEmails.
-  #           - owner@example.com
-  #           - owner2@example.com
-  #         slackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, adds slack webhook to notify in addition to globalSlackWebhookUrl.
-  #         msTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, , adds MS teams webhook to notify in addition to globalMsTeamsWebhookUrl.
+    # alertConfigs:
+    #   frontendUrl: http://localhost:9090/  # Optional
+    #   globalSlackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
+    #   globalMsTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional
+    #   globalAlertEmails:
+    #     - recipient@example.com
+    #     - additionalRecipient@example.com
+    #   globalEmailSubject: Custom Subject
+    #   alerts:
+    #     # Application health alerts are reported. 
+    #     - type: health    # Currently supports Multi Cluster diagnostic related alerts and further application alerts can be added
+    #       window: 1h      # how often do you want alert system to poll for health related alerts.
+    #       ownerContact:   # optional, adds email address to notify in addition to globalAlertEmails.
+    #         - owner@example.com
+    #         - owner2@example.com
+    #       slackWebhookUrl: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, adds slack webhook to notify in addition to globalSlackWebhookUrl.
+    #       msTeamsWebhookUrl: https://xxxxx.webhook.office.com/webhookb2/XXXXXXXXXXXXXXXXXXXXXXXX/IncomingWebhook/XXXXXXXXXXXXXXXXXXXXXXXX  # Optional, , adds MS teams webhook to notify in addition to globalMsTeamsWebhookUrl.
   chartName: "kubecost"
   ## Kubecost Saved Reports
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=ui-reports


### PR DESCRIPTION
## Release Notes Headline
Only kubecost health alert is supported in Kubecost version 3.0. Rest of the alerts are dropped.
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
Based on product ask all the other alerts are not support except kubecost health alert. Kubecost health alert is tied to Multi cluster diagnostic.
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-4417
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
None , refer testing notes in KCM PR https://github.com/kubecost/kubecost-cost-model/pull/3618
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Refer KCM PR https://github.com/kubecost/kubecost-cost-model/pull/3618
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates
Needed for 3.X
<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
