### PR TITLE
Fix Actions config for storageConfigSecret

### DIFF
--- a/kubecost/templates/aggregator/_helpers.tpl
+++ b/kubecost/templates/aggregator/_helpers.tpl
@@ -42,8 +42,8 @@ app: aggregator
 {{- end }}
 
 {{- define "kubecost.actions.secretName" -}}
-{{- if ((.Values.kubecostProductConfigs).actions).storageConfig.secret }}
-{{- ((.Values.kubecostProductConfigs).actions).storageConfig.secret }}
+{{- if ((.Values.kubecostProductConfigs).actions).storageConfigSecret }}
+{{- ((.Values.kubecostProductConfigs).actions).storageConfigSecret }}
 {{- else }}
 {{ .Release.Name }}-actions-storage-config
 {{- end }}

--- a/kubecost/templates/aggregator/_helpers.tpl
+++ b/kubecost/templates/aggregator/_helpers.tpl
@@ -42,9 +42,9 @@ app: aggregator
 {{- end }}
 
 {{- define "kubecost.actions.secretName" -}}
-{{- if ((.Values.kubecostProductConfigs).actions).storageConfigSecret }}
-{{- ((.Values.kubecostProductConfigs).actions).storageConfigSecret }}
-{{- else }}
-{{ .Release.Name }}-actions-storage-config
-{{- end }}
+{{- if ((.Values.kubecostProductConfigs).actions).storageConfigSecret -}}
+  {{- ((.Values.kubecostProductConfigs).actions).storageConfigSecret -}}
+{{- else -}}
+  {{ .Release.Name }}-actions-storage-config
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Release Notes Headline

N/A

## Commentary for Reviewers

Ran into the following error when using the nightly helm chart

```yaml
kubecostProductConfigs:
  actions:
    enabled: true
    config:
      global:
        containerRequestRightSizing:
          enabled: true
    storageConfig: |-
      type: S3
      config:
        bucket: REDACTED
        endpoint: s3.amazonaws.com
        region: us-west-2
```

```console
Error: UPGRADE FAILED: template: kubecost/templates/aggregator/aggregator-statefulset.yaml:219:27: executing "kubecost/templates/aggregator/aggregator-statefulset.yaml" at <include "kubecost.actions.secretName" .>: error calling include: template: kubecost/templates/aggregator/_helpers.tpl:45:16: executing "kubecost.actions.secretName" at <.Values.kubecostProductConfigs>: can't evaluate field secret in type interface {}
```

The Helm chart does not reference the config `((.Values.kubecostProductConfigs).actions).storageConfig.secret` anywhere, so I've updated it to be `((.Values.kubecostProductConfigs).actions).storageConfigSecret` which is referenced in multiple places ([ref1](https://github.com/kubecost/kubecost/blob/aaa3ddb1ae9e036c9904ebbde71593baf653ac02/kubecost/values.yaml#L1336-L1338), [ref2](https://github.com/kubecost/kubecost/blob/aaa3ddb1ae9e036c9904ebbde71593baf653ac02/kubecost/templates/_helpers.tpl#L133), [ref3](https://github.com/kubecost/kubecost/blob/aaa3ddb1ae9e036c9904ebbde71593baf653ac02/kubecost/templates/aggregator/aggregator-statefulset.yaml#L211), [ref4](https://github.com/kubecost/kubecost/blob/aaa3ddb1ae9e036c9904ebbde71593baf653ac02/kubecost/templates/aggregator/actions-store-secret.yaml#L7))

## Links to Issues or Tickets

N/A

## User Impact and Risks

N/A. Bug fix in nightly environment for 3.0 release.

## Testing

Using the above `values.yaml`, after this PRs changes templates correctly:

```sh
$ helm template ./kubecost -f values.yaml --debug > out.yaml
...
        - name: actions-config
          configMap:
            name: actions-config
        - name: actions-storage-config
          secret:
            defaultMode: 420
            secretName: release-name-actions-storage-config
...
```

Without the indentation fixes to the `_helpers.tpl` I ran into the following errors:

```console
install.go:225: 2025-08-22 14:34:27.425782 -0700 PDT m=+0.022662293 [debug] Original chart version: ""
install.go:242: 2025-08-22 14:34:27.42582 -0700 PDT m=+0.022701043 [debug] CHART PATH: /Users/thomasnguyen/code/cost-analyzer-helm-chart/kubecost

Error: YAML parse error on kubecost/templates/aggregator/aggregator-statefulset.yaml: error converting YAML to JSON: yaml: line 76: could not find expected ':'
helm.go:86: 2025-08-22 14:34:27.441556 -0700 PDT m=+0.038436543 [debug] error converting YAML to JSON: yaml: line 76: could not find expected ':'
```

```yaml
# The volumes were incorrectly formatted
        - name: actions-storage-config
          secret:
            defaultMode: 420
            secretName: 
  release-name-actions-storage-config
```

## Documentation Updates

N/A
