### PR TITLE
v2.8 fix check for nulls on /getConfigs

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1654,14 +1654,14 @@ data:
                 "code": 200,
                 "status": "success",
                 "data": {
-                    "defaultIdle": "{{ .Values.kubecostProductConfigs.defaultIdle }}",
-                    "currencyCode": "{{ .Values.kubecostProductConfigs.currencyCode }}",
-                    "negotiatedDiscount": "{{ .Values.kubecostProductConfigs.negotiatedDiscount }}",
-                    "sharedOverhead": "{{ .Values.kubecostProductConfigs.sharedOverhead }}",
-                    "sharedNamespaces": "{{ .Values.kubecostProductConfigs.sharedNamespaces }}",
-                    "sharedLabelNames": "{{ .Values.kubecostProductConfigs.sharedLabelNames }}",
-                    "sharedLabelValues": "{{ .Values.kubecostProductConfigs.sharedLabelValues }}",
-                    "shareTenancyCosts": "{{ .Values.kubecostProductConfigs.shareTenancyCosts }}"
+                    "defaultIdle": "{{ (.Values.kubecostProductConfigs).defaultIdle }}",
+                    "currencyCode": "{{ (.Values.kubecostProductConfigs).currencyCode }}",
+                    "negotiatedDiscount": "{{ (.Values.kubecostProductConfigs).negotiatedDiscount }}",
+                    "sharedOverhead": "{{ (.Values.kubecostProductConfigs).sharedOverhead }}",
+                    "sharedNamespaces": "{{ (.Values.kubecostProductConfigs).sharedNamespaces }}",
+                    "sharedLabelNames": "{{ (.Values.kubecostProductConfigs).sharedLabelNames }}",
+                    "sharedLabelValues": "{{ (.Values.kubecostProductConfigs).sharedLabelValues }}",
+                    "shareTenancyCosts": "{{ (.Values.kubecostProductConfigs).shareTenancyCosts }}"
                 }
             }';
         }


### PR DESCRIPTION
Kubecost 3.0 no longer has nulls on
```yaml
kubecostProductConfigs:
```

but 2.8 does.