### PR TITLE
Re-add cluster config for multicluster turndown

### DIFF
--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -437,6 +437,7 @@ kubecost.costEventsAudit.enabled flag for nginx configmap
   "aggregator/kubecost-alerts-configmap.yaml"
   "aggregator/kubecost-asset-reports-configmap.yaml"
   "aggregator/kubecost-cloud-cost-reports-configmap.yaml"
+  "aggregator/kubecost-clusters-configmap.yaml"
   "aggregator/kubecost-saved-reports-configmap.yaml"
   "aggregator/kubecost-smtp-configmap.yaml"
   "aggregator/saml-configmap.yaml"

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -229,6 +229,11 @@ spec:
             secretName: {{ ((.Values.kubecostProductConfigs).actions).storageConfigSecret | default "actions-store" }}
           {{- end }}
         {{- end }}
+        {{- if  ((.Values.kubecostProductConfigs).actions).turndownClusters }}
+        - name: kubecost-clusters
+          configMap:
+            name: kubecost-clusters
+        {{- end }}
       {{- end }}
         {{- if .Values.aggregator.extraVolumes }}
         {{- toYaml .Values.aggregator.extraVolumes | nindent 8 }}
@@ -395,6 +400,10 @@ spec:
               mountPath: /var/configs/actions/storage/actions-store.yaml
               subPath: {{ include "kubecost.federatedStorage.fileName" . }}
               readOnly: true
+            {{- end }}
+            {{- if  ((.Values.kubecostProductConfigs).actions).turndownClusters }}
+            - name: kubecost-clusters
+              mountPath: /var/configs/clusters
             {{- end }}
             {{- if ((.Values.kubecostProductConfigs).actions).storageConfig }}
             - name: actions-storage-config

--- a/kubecost/templates/aggregator/kubecost-clusters-configmap.yaml
+++ b/kubecost/templates/aggregator/kubecost-clusters-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubecostProductConfigs.actions.enabled }}
+{{- if .Values.kubecostProductConfigs.actions.turndownClusters }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubecost-clusters
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubecost.commonLabels" . | nindent 4 }}
+data:
+  clusters.json: |
+{{- toJson .Values.kubecostProductConfigs.actions.turndownClusters | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1307,6 +1307,13 @@ kubecostProductConfigs:
     # # The name of the Secret containing the bucket config. The contents should be stored under a key named actions-store.yaml
     # storageConfigSecret: actions-store
 
+    # # An optional list of cluster definitions that can be added for multicluster turndown
+    # # actions.
+    # turndownClusters:
+    #   - name: "Cluster A"
+    #     address: http://cluster-a.kubecost.com:9090
+    #   - name: "Cluster B"
+    #     address: http://cluster-b.kubecost.com:9090
     # # (If not using Secret) Define storage config directly in yaml, as below:
     # storageConfig: |-
     # # AWS EXAMPLE


### PR DESCRIPTION
## Release Notes Headline

N/A

## Commentary for Reviewers
Re-adds ability to specify clusters for multicluster turndown, previously under `.Values.kubecostProductConfigs.clusters`. Cluster address values are required for the turndown FE functionality.

## Links to Issues or Tickets

https://apptio.atlassian.net/browse/KCM-4418

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Templated helm chart and verified valid manifests.
Deployed using local helm chart to a cluster and observed complete functionality.

## Documentation Updates

