### PR TITLE
[KCM-4506] Cluster controller: Use federated store as default

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -229,7 +229,7 @@ spec:
         - name: actions-storage-config
           secret:
             defaultMode: 420
-            secretName: {{ ((.Values.kubecostProductConfigs).actions).storageConfigSecret | default "actions-store" }}
+            secretName: {{ include "kubecost.actions.secretName" . }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/kubecost/templates/cluster-controller/cluster-controller-actions-bucket.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-actions-bucket.yaml
@@ -1,5 +1,5 @@
 {{- if (.Values.clusterController).enabled }}
-{{- if not (.Values.clusterController).storageConfigSecret }}
+{{- if (.Values.clusterController).storageConfig }}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
@@ -78,6 +78,18 @@ spec:
         volumeMounts:
         - name: cluster-controller-keys
           mountPath: /var/keys
+        {{- if (not (.Values.clusterController).legacyMode) }}
+        {{- if and (not (.Values.clusterController).storageConfigSecret) (not (.Values.clusterController).storageConfig) }}
+        - name: federated-storage-config
+          mountPath: /var/configs/actions-store.yaml
+          subPath: {{ include "kubecost.federatedStorage.fileName" . }}
+          readOnly: true
+        {{- else }}
+        - name: actions-bucket-config
+          mountPath: /var/configs
+          readOnly: true
+        {{- end }}
+        {{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -136,12 +148,6 @@ spec:
         ports:
         - name: http-server
           containerPort: 9731
-        {{- if (not (.Values.clusterController).legacyMode) }}
-        volumeMounts:
-        - name: actions-bucket-config
-          mountPath: /var/configs
-          readOnly: true
-        {{- end }}
         resources:
           {{- toYaml .Values.clusterController.resources | nindent 12 }}
       {{- if .Values.imagePullSecrets }}
@@ -174,8 +180,15 @@ spec:
           # and their validity.
           optional: true
       {{- if not (.Values.clusterController).legacyMode }}
+      {{- if and (not (.Values.clusterController).storageConfigSecret) (not (.Values.clusterController).storageConfig) }}
+      - name: federated-storage-config
+        secret:
+          defaultMode: 420
+          secretName: {{ include "kubecost.federatedStorage.secretName" . }}
+      {{- else }}
       - name: actions-bucket-config
         secret:
           secretName: {{ include "kubecost.clusterController.actionsBucketConfigSecretName" . }}
+      {{- end }}
       {{- end }}
 {{- end }}

--- a/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
@@ -80,6 +80,8 @@ spec:
           mountPath: /var/keys
         {{- if (not (.Values.clusterController).legacyMode) }}
         {{- if and (not (.Values.clusterController).storageConfigSecret) (not (.Values.clusterController).storageConfig) }}
+        - name: config-storage
+          mountPath: /var/configs
         - name: federated-storage-config
           mountPath: /var/configs/actions-store.yaml
           subPath: {{ include "kubecost.federatedStorage.fileName" . }}
@@ -181,6 +183,8 @@ spec:
           optional: true
       {{- if not (.Values.clusterController).legacyMode }}
       {{- if and (not (.Values.clusterController).storageConfigSecret) (not (.Values.clusterController).storageConfig) }}
+      - name: config-storage
+        emptyDir: { }
       - name: federated-storage-config
         secret:
           defaultMode: 420

--- a/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
@@ -78,17 +78,17 @@ spec:
         volumeMounts:
         - name: cluster-controller-keys
           mountPath: /var/keys
-        {{- if (not (.Values.clusterController).legacyMode) }}
+        {{- if not (.Values.clusterController).legacyMode }}
         {{- if and (not (.Values.clusterController).storageConfigSecret) (not (.Values.clusterController).storageConfig) }}
-        - name: config-storage
-          mountPath: /var/configs
+        - name: actions-storage
+          mountPath: /var/configs/actions/storage
         - name: federated-storage-config
-          mountPath: /var/configs/actions-store.yaml
+          mountPath: /var/configs/actions/storage/actions-store.yaml
           subPath: {{ include "kubecost.federatedStorage.fileName" . }}
           readOnly: true
         {{- else }}
         - name: actions-bucket-config
-          mountPath: /var/configs
+          mountPath: /var/configs/actions/storage
           readOnly: true
         {{- end }}
         {{- end }}
@@ -119,7 +119,7 @@ spec:
         - name: LOG_LEVEL
           value: {{ .Values.clusterController.logLevel | default "info" }}
         - name: ACTIONS_BUCKET_CONFIG
-          value: /var/configs/actions-store.yaml
+          value: /var/configs/actions/storage/actions-store.yaml
         {{- end }}
         - name: CC_KUBESCALER_COST_MODEL_PATH
           {{- if .Values.clusterController.primaryKubecostURL }}
@@ -183,7 +183,7 @@ spec:
           optional: true
       {{- if not (.Values.clusterController).legacyMode }}
       {{- if and (not (.Values.clusterController).storageConfigSecret) (not (.Values.clusterController).storageConfig) }}
-      - name: config-storage
+      - name: actions-storage
         emptyDir: { }
       - name: federated-storage-config
         secret:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1227,18 +1227,6 @@ clusterController:
   #         "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
   #         "client_x509_cert_url": ""
   #       }
-  # # Actions can reference configuration at a global or cluster-specific level
-  # config:
-  #   global: # Define global action configuration
-  #     rightsizing:
-  #       enabled: true
-  #   clusters: # Define cluster-specific action configuration, where top-level keys are cluster names
-  #     cluster-1:
-  #       rightsizing:
-  #         enabled: false
-  #     cluster-2:
-  #       rightsizing:
-  #         enabled: false
 #  fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
 
   rbac:


### PR DESCRIPTION
## Release Notes Headline

Use federated store secret as default if no storage configs defined for cluster controller v2.

## Commentary for Reviewers

Mount the federated storage secret as a volume and use it if no storage configs are defined for cluster controller v2, otherwise use the storage config secret.

## Links to Issues or Tickets
Closes https://apptio.atlassian.net/browse/KCM-4506

## User Impact and Risks

N/A

## Testing

- helm template

## Documentation Updates

N/A
