### PR TITLE
[KCM-4382] Log collection: Set up Role/RoleBinding for aggregator SA

### DIFF
--- a/kubecost/templates/aggregator/aggregator-role-binding.yaml
+++ b/kubecost/templates/aggregator/aggregator-role-binding.yaml
@@ -14,5 +14,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kubecost.aggregator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
----
 {{- end }}

--- a/kubecost/templates/aggregator/aggregator-role-binding.yaml
+++ b/kubecost/templates/aggregator/aggregator-role-binding.yaml
@@ -1,0 +1,18 @@
+{{- if (.Values.reporting).logCollection }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "kubecost.aggregator.serviceAccountName" . }}-log-collection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubecost.commonLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubecost.aggregator.serviceAccountName" . }}-log-collection
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubecost.aggregator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+{{- end }}

--- a/kubecost/templates/aggregator/aggregator-role.yaml
+++ b/kubecost/templates/aggregator/aggregator-role.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.reporting).logCollection -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "kubecost.aggregator.serviceAccountName" . }}-log-collection
+  labels:
+    {{- include "kubecost.commonLabels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - "pods/log"
+    verbs:
+      - get
+      - list
+      - watch
+---
+{{- end }}

--- a/kubecost/templates/aggregator/aggregator-role.yaml
+++ b/kubecost/templates/aggregator/aggregator-role.yaml
@@ -15,5 +15,4 @@ rules:
       - get
       - list
       - watch
----
 {{- end }}

--- a/kubecost/templates/kubecost-role-binding-template.yaml
+++ b/kubecost/templates/kubecost-role-binding-template.yaml
@@ -1,21 +1,3 @@
-{{- if (.Values.reporting).logCollection }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ template "kubecost.serviceAccountName" . }}-log-collection
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kubecost.commonLabels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ template "kubecost.serviceAccountName" . }}-log-collection
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "kubecost.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
----
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/kubecost/templates/kubecost-role-template.yaml
+++ b/kubecost/templates/kubecost-role-template.yaml
@@ -1,31 +1,3 @@
-{{- if (.Values.reporting).logCollection -}}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  namespace: {{ .Release.Namespace }}
-  name: {{ template "kubecost.serviceAccountName" . }}-log-collection
-  labels:
-    {{- include "kubecost.commonLabels" . | nindent 4 }}
-rules:
-- apiGroups: 
-    - ''
-  resources:
-    - "pods/log"
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-    - ''
-  resources:
-    - configmaps
-  verbs:
-    - get
-    - list
-    - watch
-    - update
----
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
## Release Notes Headline

N/A

## Commentary for Reviewers

We need the service account linked with the `aggregator` to be able to read pod logs for bug report capture. This PR:
- sets up "log collection" Role with `pods/log` read rule 
- sets up RoleBinding to associate log collection Role with the kubecost aggregator service account

## Links to Issues or Tickets

Part of https://apptio.atlassian.net/browse/KCM-4382

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A
