### PR TITLE
[KCM-4382] Rename log collection Role/RoleBinding

### DIFF
--- a/kubecost/templates/aggregator/aggregator-role-binding.yaml
+++ b/kubecost/templates/aggregator/aggregator-role-binding.yaml
@@ -2,14 +2,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "kubecost.aggregator.serviceAccountName" . }}-log-collection
+  name: {{ template "kubecost.aggregator.serviceAccountName" . }}-aggregator-log-collection
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "kubecost.aggregator.serviceAccountName" . }}-log-collection
+  name: {{ template "kubecost.aggregator.serviceAccountName" . }}-aggregator-log-collection
 subjects:
   - kind: ServiceAccount
     name: {{ template "kubecost.aggregator.serviceAccountName" . }}

--- a/kubecost/templates/aggregator/aggregator-role.yaml
+++ b/kubecost/templates/aggregator/aggregator-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ template "kubecost.aggregator.serviceAccountName" . }}-log-collection
+  name: {{ template "kubecost.aggregator.serviceAccountName" . }}-aggregator-log-collection
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 rules:

--- a/kubecost/templates/kubecost-role-binding-template.yaml
+++ b/kubecost/templates/kubecost-role-binding-template.yaml
@@ -11,5 +11,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kubecost.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }} 
----
+    namespace: {{ .Release.Namespace }}
+


### PR DESCRIPTION
## Release Notes Headline

Rename log collection Role/RoleBinding

## Commentary for Reviewers

Rename log collection Role/RoleBinding. There is an existing `-log-collection` RoleBinding with an invalid roleRef; however, as roleRefs are immutable, we cannot change them without deleting and re-creating the RoleBinding. This was spotted in a nightly workflow run where `helm upgrade` failed:
```
Error: UPGRADE FAILED: cannot patch "bigquery-reader-log-collection" with kind RoleBinding: RoleBinding.rbac.authorization.k8s.io "bigquery-reader-log-collection" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io", Kind:"Role", Name:"bigquery-reader-log-collection"}: cannot change roleRef
```

This change gives an entirely new name to the RoleBinding to avoid such a conflict on a helm upgrade. Ideally we should also look into deleting the redundant RoleBinding ending in `-log-collection` if it exists.  

## Links to Issues or Tickets

Related to https://apptio.atlassian.net/browse/KCM-4382

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A
