### PR TITLE
[KCM-4516] Add pod list permission in aggregator log collection role

### DIFF
--- a/kubecost/templates/aggregator/aggregator-role.yaml
+++ b/kubecost/templates/aggregator/aggregator-role.yaml
@@ -15,4 +15,10 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - list
 {{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1239,7 +1239,7 @@ clusterController:
     namespaceTurndown: false
 
 reporting:
-  # Kubecost bug report feature: Logs access/collection limited to .Release.Namespace
+  # Kubecost bug report feature: Pods/logs access/collection limited to .Release.Namespace
   # Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=capture-bug-report
   logCollection: true
   # Basic frontend analytics


### PR DESCRIPTION
## Release Notes Headline
N/A

## Commentary for Reviewers
`.values.logCollection` is an optional helm flag that users can set to grant the permissions required to generate a bug report.
Up until this point, the bug report only required permission to access pod logs. 
We have a new product requirement to also include **the list of pods currently in the namespace** in the bug report.

The log collection Role is currently tied (via a RoleBinding) to the aggregator service account. This Role currently has permission to collect logs from pods in the namespace, thus allowing the aggregator pod to access pod logs. This PR adds a new permission on this Role: **list pods**. 

## Links to Issues or Tickets

Related to https://apptio.atlassian.net/browse/KCM-4516

- BE PR with new `GET /pods` API: https://github.com/kubecost/kubecost-cost-model/pull/3682
- FE PR adding new section in bug report: https://github.com/kubecost/kubecost-frontend/pull/2961

## User Impact and Risks

No risks. If users have `.values.logCollection` enabled they should be able to view the following in the bug report:
- list of pods in the namespace
- logs for certain pods, as determined in the bug report definition

## Testing
N/A

## Documentation Updates
N/A
