### PR TITLE
Remove "GCP Cherry-Pick Bot". It is deprecated.

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,2 +1,0 @@
-enabled: true
-preservePullRequestTitle: true


### PR DESCRIPTION
## Release Notes Headline

N/A

## Commentary for Reviewers

https://github.com/apps/gcp-cherry-pick-bot

<img width="1240" height="627" alt="gcp-cherry-pick-bot-deprecation" src="https://github.com/user-attachments/assets/008c7277-a718-490a-890d-2ae65724ca65" />

## Links to Issues or Tickets

N/A

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A
