### PR TITLE
[KCM-4516] Add app.kubernetes.io/name label to cluster controller pod

### DIFF
--- a/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
@@ -32,6 +32,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: cluster-controller
         app: {{ include "kubecost.clusterController.name" . }}
         {{- if .Values.global.additionalLabels }}
         {{- toYaml .Values.global.additionalLabels | nindent 8 }}


### PR DESCRIPTION
## Release Notes Headline
N/A

## Commentary for Reviewers
For bug reporting purposes, we need an identifiable, common label to track pod logs for cluster controller pods. This PR adds the `app.kubernetes.io/name: cluster-controller` label on the cluster controller Pod. 

## Links to Issues or Tickets
Related to https://apptio.atlassian.net/browse/KCM-4516

## User Impact and Risks

No risks, addition to metadata

## Testing

N/A

## Documentation Updates

N/A
