### PR TITLE
Move default registry from GCR to ICR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 .manifest
 .kubeconfig
 kubecost/charts/*.tgz
+kubecost/charts/finops-agent-chart
 gke_gcloud_auth_plugin_cache
 temp/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@
 .manifest
 .kubeconfig
 kubecost/charts/*.tgz
-kubecost/charts/finops-agent-chart
 gke_gcloud_auth_plugin_cache
 temp/

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: development
 description: Kubecost Helm chart - monitor your cloud costs!
 name: kubecost
-version: 3.0.0-test.0  # This is a placeholder used on the develop branch. If installing Kubecost, please reference a release branch.
+version: 0.0.0-dev  # This is a placeholder used on the develop branch. If installing Kubecost, please reference a release branch.
 icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
 annotations:
   "artifacthub.io/links": |

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -485,8 +485,10 @@ Kubecost image to be used by all apps which run, can be overridden in each apps 
 {{- define "common.imageRegistry" -}}
   {{- if .Values.global.imageRegistry -}}
     {{- .Values.global.imageRegistry -}}
+  {{- else if eq "development" .Chart.AppVersion -}}
+    gcr.io
   {{- else -}}
-    {{- .Values.kubecost.image.registry -}}
+    icr.io
   {{- end -}}
 {{- end -}}
 

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -479,19 +479,6 @@ Product key secret name with default fallback
 {{- default "product-key" .Values.kubecostProductConfigs.productKey.secretname -}}
 {{- end -}}
 
-{{/*
-Kubecost image to be used by all apps which run, can be overridden in each apps specific configs
-*/}}
-{{- define "common.imageRegistry" -}}
-  {{- if .Values.global.imageRegistry -}}
-    {{- .Values.global.imageRegistry -}}
-  {{- else if eq "development" .Chart.AppVersion -}}
-    {{-/*TODO: How to make this compatible with nightly?*/}}
-    gcr.io
-  {{- else -}}
-    icr.io
-  {{- end -}}
-{{- end -}}
 
 {{/*
 federated storage config helpers

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -486,6 +486,7 @@ Kubecost image to be used by all apps which run, can be overridden in each apps 
   {{- if .Values.global.imageRegistry -}}
     {{- .Values.global.imageRegistry -}}
   {{- else if eq "development" .Chart.AppVersion -}}
+    {{-/*TODO: How to make this compatible with nightly?*/}}
     gcr.io
   {{- else -}}
     icr.io

--- a/kubecost/templates/aggregator/_helpers.tpl
+++ b/kubecost/templates/aggregator/_helpers.tpl
@@ -1,3 +1,11 @@
+{{- define "aggregator.imageRegistry" -}}
+  {{- if .Values.kubecost.image.registry -}}
+    {{- .Values.kubecost.image.registry -}}
+  {{- else -}}
+    {{- .Values.global.imageRegistry -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "kubecost.aggregator.image" }}
   {{- if .Values.aggregator.fullImageName }}
     {{- .Values.aggregator.fullImageName }}
@@ -6,9 +14,9 @@
   {{- else if eq "development" .Chart.AppVersion -}}
     gcr.io/kubecost1/cost-model-nightly:latest
   {{- else if .Values.kubecost.image.tag -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ .Values.kubecost.image.tag }}
+    {{- include "aggregator.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ .Values.kubecost.image.tag }}
   {{- else -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ $.Chart.AppVersion }}
+    {{- include "aggregator.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/aggregator/_helpers.tpl
+++ b/kubecost/templates/aggregator/_helpers.tpl
@@ -5,8 +5,10 @@
     {{- .Values.kubecost.fullImageName }}
   {{- else if eq "development" .Chart.AppVersion -}}
     gcr.io/kubecost1/cost-model-nightly:latest
-  {{- else -}}
+  {{- else if .Values.kubecost.image.tag -}}
     {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ .Values.kubecost.image.tag }}
+  {{- else -}}
+    {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/cloud-cost/_helpers.tpl
+++ b/kubecost/templates/cloud-cost/_helpers.tpl
@@ -27,6 +27,14 @@ support templating a chart which uses the lookup function.
 {{- end -}}
 {{- end -}}
 
+{{- define "cloudCost.imageRegistry" -}}
+  {{- if .Values.kubecost.image.registry -}}
+    {{- .Values.kubecost.image.registry -}}
+  {{- else -}}
+    {{- .Values.global.imageRegistry -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "kubecost.cloudCost.image" }}
   {{- if .Values.cloudCost.fullImageName }}
     {{- .Values.cloudCost.fullImageName }}
@@ -35,9 +43,9 @@ support templating a chart which uses the lookup function.
   {{- else if eq "development" .Chart.AppVersion -}}
     gcr.io/kubecost1/cost-model-nightly:latest
   {{- else if .Values.kubecost.image.tag -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ .Values.kubecost.image.tag }}
+    {{- include "cloudCost.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ .Values.kubecost.image.tag }}
   {{- else -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ $.Chart.AppVersion }}
+    {{- include "cloudCost.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/cloud-cost/_helpers.tpl
+++ b/kubecost/templates/cloud-cost/_helpers.tpl
@@ -34,8 +34,10 @@ support templating a chart which uses the lookup function.
     {{- .Values.kubecost.fullImageName }}
   {{- else if eq "development" .Chart.AppVersion -}}
     gcr.io/kubecost1/cost-model-nightly:latest
-  {{- else -}}
+  {{- else if .Values.kubecost.image.tag -}}
     {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ .Values.kubecost.image.tag }}
+  {{- else -}}
+    {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/cluster-controller/_helpers.tpl
+++ b/kubecost/templates/cluster-controller/_helpers.tpl
@@ -6,11 +6,19 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "clusterController.imageRegistry" -}}
+  {{- if .Values.clusterController.image.registry -}}
+    {{- .Values.clusterController.image.registry -}}
+  {{- else -}}
+    {{- .Values.global.imageRegistry -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "kubecost.clusterController.image" }}
   {{- if .Values.clusterController.fullImageName }}
     {{- .Values.clusterController.fullImageName }}
   {{- else -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.clusterController.image.repository }}:{{ .Values.clusterController.image.tag }}
+    {{- include "clusterController.imageRegistry" . }}/{{ .Values.clusterController.image.repository }}:{{ .Values.clusterController.image.tag }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/forecasting/_helpers.tpl
+++ b/kubecost/templates/forecasting/_helpers.tpl
@@ -6,11 +6,19 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "forecasting.imageRegistry" -}}
+  {{- if .Values.forecasting.image.registry -}}
+    {{- .Values.forecasting.image.registry -}}
+  {{- else -}}
+    {{- .Values.global.imageRegistry -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "kubecost.forecasting.image" }}
   {{- if .Values.forecasting.fullImageName }}
     {{- .Values.forecasting.fullImageName }}
   {{- else -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.forecasting.image.repository }}:{{ .Values.forecasting.image.tag }}
+    {{- include "forecasting.imageRegistry" . }}/{{ .Values.forecasting.image.repository }}:{{ .Values.forecasting.image.tag }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/frontend/_helpers.tpl
+++ b/kubecost/templates/frontend/_helpers.tpl
@@ -1,12 +1,20 @@
+{{- define "frontend.imageRegistry" -}}
+  {{- if .Values.frontend.image.registry -}}
+    {{- .Values.frontend.image.registry -}}
+  {{- else -}}
+    {{- .Values.global.imageRegistry -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "kubecost.frontend.image" }}
   {{- if .Values.frontend.fullImageName }}
     {{- .Values.frontend.fullImageName }}
   {{- else if eq "development" .Chart.AppVersion -}}
     gcr.io/kubecost1/frontend-nightly:latest
   {{- else if .Values.frontend.image.tag -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}
+    {{- include "frontend.imageRegistry" . }}/{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}
   {{- else -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.frontend.image.repository }}:{{ $.Chart.AppVersion }}
+    {{- include "frontend.imageRegistry" . }}/{{ .Values.frontend.image.repository }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/frontend/_helpers.tpl
+++ b/kubecost/templates/frontend/_helpers.tpl
@@ -3,8 +3,10 @@
     {{- .Values.frontend.fullImageName }}
   {{- else if eq "development" .Chart.AppVersion -}}
     gcr.io/kubecost1/frontend-nightly:latest
-  {{- else -}}
+  {{- else if .Values.frontend.image.tag -}}
     {{- include "common.imageRegistry" . }}/{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}
+  {{- else -}}
+    {{- include "common.imageRegistry" . }}/{{ .Values.frontend.image.repository }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -153,11 +153,9 @@ data:
             try_files $uri $uri/ /index.html;
         }
 {{- end }}
-{{- if .Values.imageVersion }}
-        add_header ETag "{{ $.Values.imageVersion }}";
-{{- else }}
+
         add_header ETag "{{ $.Chart.Version }}";
-{{- end }}
+
 {{- if .Values.frontend.tls }}
 {{- if .Values.frontend.tls.enabled }}
 {{- if .Values.frontend.tls.specifyProtocols }}

--- a/kubecost/templates/local-store/_helpers.tpl
+++ b/kubecost/templates/local-store/_helpers.tpl
@@ -17,8 +17,10 @@
     {{- .Values.kubecost.fullImageName }}
   {{- else if eq "development" .Chart.AppVersion -}}
     gcr.io/kubecost1/cost-model-nightly:latest
-  {{- else -}}
+  {{- else if .Values.kubecost.image.tag -}}
     {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ .Values.kubecost.image.tag }}
+  {{- else -}}
+    {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/local-store/_helpers.tpl
+++ b/kubecost/templates/local-store/_helpers.tpl
@@ -10,6 +10,14 @@
   {{- end -}}
 {{- end -}}
 
+{{- define "kubecost.imageRegistry" -}}
+  {{- if .Values.kubecost.image.registry -}}
+    {{- .Values.kubecost.image.registry -}}
+  {{- else -}}
+    {{- .Values.global.imageRegistry -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "kubecost.localStore.image" }}
   {{- if .Values.localStore.fullImageName }}
     {{- .Values.localStore.fullImageName }}
@@ -18,9 +26,9 @@
   {{- else if eq "development" .Chart.AppVersion -}}
     gcr.io/kubecost1/cost-model-nightly:latest
   {{- else if .Values.kubecost.image.tag -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ .Values.kubecost.image.tag }}
+    {{- include "kubecost.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ .Values.kubecost.image.tag }}
   {{- else -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ $.Chart.AppVersion }}
+    {{- include "kubecost.imageRegistry" . }}/{{ .Values.kubecost.image.repository }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/templates/network-costs/_helpers.tpl
+++ b/kubecost/templates/network-costs/_helpers.tpl
@@ -1,9 +1,16 @@
+{{- define "networkCosts.imageRegistry" -}}
+  {{- if .Values.networkCosts.image.registry -}}
+    {{- .Values.networkCosts.image.registry -}}
+  {{- else -}}
+    {{- .Values.global.imageRegistry -}}
+  {{- end -}}
+{{- end -}}
 
 {{- define "kubecost.networkCosts.image" }}
   {{- if .Values.networkCosts.fullImageName }}
     {{- .Values.networkCosts.fullImageName }}
   {{- else -}}
-    {{- include "common.imageRegistry" . }}/{{ .Values.networkCosts.image.repository }}:{{ .Values.networkCosts.image.tag }}
+    {{- include "networkCosts.imageRegistry" . }}/{{ .Values.networkCosts.image.repository }}:{{ .Values.networkCosts.image.tag }}
   {{- end }}
 {{- end }}
 

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -32,8 +32,8 @@ global:
   cspPricingApiKey:
     existingSecret: ""
     apiKey: ""
-  ## @param global.imageRegistry The image registry to use for the finops agent
-  imageRegistry: ""
+  ## @param global.imageRegistry The image registry used for all images in this chart and the ibm-finops-agent chart
+  imageRegistry: "icr.io"
   ## E.g.
   ## imagePullSecrets:
   ##   - myRegistryKeySecretName
@@ -417,11 +417,6 @@ systemProxy:
 # imagePullSecrets:
 # - name: "image-pull-secret"
 
-# imageVersion uses the base image name (image:) but overrides the version
-# pulled. It should be avoided. If non-default behavior is needed, use
-# fullImageName for the relevant component.
-# imageVersion:
-
 frontend:
   enabled: true
   replicas: 1
@@ -432,12 +427,9 @@ frontend:
   ## fullImageName: gcr.io/kubecost1/frontend:v3.0.0
   fullImageName: ""
   image:
-    repository: kubecost1/frontend
+    repository: kubecost/frontend
     tag: latest
   imagePullPolicy: IfNotPresent
-  # fullImageName overrides the default image construction logic. The exact
-  # image provided (registry, image, tag) will be used for the frontend.
-  # fullImageName:
 
   # extraEnv:
   # - name: NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE
@@ -541,6 +533,7 @@ localStore:
       ## The "helm.sh/resource-policy: keep" annotation is used to prevent the persistent volume from being deleted when uninstalling or moving to a different deployment method.
       # This can be used to allow the agent history to be uploaded to cloud storage when upgrading to Enterprise.
       helm.sh/resource-policy: keep
+
   ## localStore uses the images set in 'kubecost.image', but can be overridden here:
   fullImageName: ""
 
@@ -590,6 +583,11 @@ finops-agent:
 
 
 kubecost:
+  image:
+    registry: icr.io
+    repository: kubecost/cost-model
+    tag: latest
+
   ## Override the image name and version for containers that use the aggregator image.
   ## If not set, the image will be pulled from the registry and repository specified in the image block.
   ## If set, the fullImageName will be used to pull the image.
@@ -597,15 +595,7 @@ kubecost:
   ## fullImageName: gcr.io/kubecost1/cost-model:v3.0.0
   fullImageName: ""
 
-  image:
-    registry: gcr.io
-    repository: kubecost1/cost-model-nightly
-    tag: latest
-
   imagePullPolicy: IfNotPresent
-  # fullImageName overrides the default image construction logic. The exact
-  # image provided (registry, image, tag) will be used for cost-model.
-  # fullImageName:
 
   # Log level for the cost model container. Options are "trace", "debug", "info", "warn", "error", "fatal", "panic"
   logLevel: info
@@ -710,7 +700,7 @@ networkCosts:
   ## fullImageName: gcr.io/kubecost1/kubecost-network-costs:v0.17.11
   fullImageName: ""
   image:
-    repository: kubecost1/kubecost-network-costs
+    repository: kubecost/network-costs
     tag: v0.17.11
   imagePullPolicy: IfNotPresent
   updateStrategy:
@@ -840,7 +830,7 @@ forecasting:
   ## fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.29
   fullImageName: ""
   image:
-    repository: kubecost1/kubecost-modeling
+    repository: kubecost/modeling
     tag: v0.1.29
   imagePullPolicy: IfNotPresent
 
@@ -881,11 +871,10 @@ forecasting:
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=federation-kubecost-aggregator
 ##
 aggregator:
-  # image overrides the values provided in kubecost.image
-  # image:
-  #   registry:
-
   enabled: true
+
+  ## aggregator uses the image set in 'kubecost.image', but can be overridden here:
+  fullImageName: ""
 
   # Replicas sets the number of Aggregator replicas.
   replicas: 1
@@ -1071,6 +1060,10 @@ heartbeat:
 ## can be specified.
 cloudCost:
   enabled: true
+  
+  ## cloudCost uses the images set in 'kubecost.image', but can be overridden here:
+  fullImageName: ""
+
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain
   ## a key with name `cloud-integration.json` and the contents must be in a specific format. It is expected
   ## to exist in the release Namespace. This is mutually exclusive with cloudIntegrationJSON where only one must be defined.
@@ -1131,8 +1124,6 @@ cloudCost:
   ## by default, the cloud cost pod will use the same service account as the aggregator pod.
   ## this can be overridden to use a different service account.
   serviceAccountName: ""
-  ## cloudCost uses the images set in 'kubecost.image', but can be overridden here:
-  fullImageName: ""
 
   readinessProbe:
     enabled: true
@@ -1159,6 +1150,7 @@ cloudCost:
 
   ## Define extra volumemounts for the cloud cost pod
   extraVolumeMounts: []
+
 # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
 clusterController:
   enabled: false
@@ -1177,7 +1169,7 @@ clusterController:
   ## fullImageName: gcr.io/kubecost1/cluster-controller:v0.16.20
   fullImageName: ""
   image:
-    repository: kubecost1/cluster-controller
+    repository: kubecost/cluster-controller
     tag: v0.16.23
   imagePullPolicy: IfNotPresent
   extraEnv: []

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1060,7 +1060,7 @@ heartbeat:
 ## can be specified.
 cloudCost:
   enabled: true
-  
+
   ## cloudCost uses the images set in 'kubecost.image', but can be overridden here:
   fullImageName: ""
 

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -430,7 +430,7 @@ frontend:
   fullImageName: ""
   image:
     repository: kubecost/frontend
-    tag: latest
+    tag: ""
 
   imagePullPolicy: IfNotPresent
 
@@ -589,7 +589,7 @@ kubecost:
   image:
     registry: icr.io
     repository: kubecost/cost-model
-    tag: latest
+    tag: ""
 
   ## Override the image name and version for containers that use the aggregator image.
   ## If not set, the image will be pulled from the registry and repository specified in the image block.

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -32,7 +32,7 @@ global:
   cspPricingApiKey:
     existingSecret: ""
     apiKey: ""
-  ## @param global.imageRegistry The image registry used for all images in this chart and the ibm-finops-agent chart
+  ## @param global.imageRegistry The image registry used for all images in this chart and subcharts
   imageRegistry: ""
   ## E.g.
   ## imagePullSecrets:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -33,7 +33,7 @@ global:
     existingSecret: ""
     apiKey: ""
   ## @param global.imageRegistry The image registry used for all images in this chart and subcharts
-  imageRegistry: ""
+  imageRegistry: "icr.io"
   ## E.g.
   ## imagePullSecrets:
   ##   - myRegistryKeySecretName
@@ -429,9 +429,9 @@ frontend:
   ## fullImageName: gcr.io/kubecost1/frontend:v3.0.0
   fullImageName: ""
   image:
-    registry: icr.io
+    registry: ""  # Default is "icr.io"
     repository: kubecost/frontend
-    tag: ""
+    tag: ""  # Default is to match the Chart.AppVersion
 
   imagePullPolicy: IfNotPresent
 
@@ -588,9 +588,9 @@ finops-agent:
 
 kubecost:
   image:
-    registry: icr.io
+    registry: ""  # Default is "icr.io"
     repository: kubecost/cost-model
-    tag: ""
+    tag: ""  # Default is to match the Chart.AppVersion
 
   ## Override the image name and version for containers that use the aggregator image.
   ## If not set, the image will be pulled from the registry and repository specified in the image block.
@@ -706,7 +706,7 @@ networkCosts:
   ## fullImageName: gcr.io/kubecost1/kubecost-network-costs:v0.17.11
   fullImageName: ""
   image:
-    registry: icr.io
+    registry: ""  # Default is "icr.io"
     repository: kubecost/network-costs
     tag: v0.17.11
   imagePullPolicy: IfNotPresent
@@ -835,7 +835,7 @@ forecasting:
   ## fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.29
   fullImageName: ""
   image:
-    registry: icr.io
+    registry: ""  # Default is "icr.io"
     repository: kubecost/modeling
     tag: v0.1.29
   imagePullPolicy: IfNotPresent
@@ -1174,7 +1174,7 @@ clusterController:
   ## fullImageName: gcr.io/kubecost1/cluster-controller:v0.16.20
   fullImageName: ""
   image:
-    registry: icr.io
+    registry: ""  # Default is "icr.io"
     repository: kubecost/cluster-controller
     tag: v0.16.23
   imagePullPolicy: IfNotPresent

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -414,7 +414,9 @@ systemProxy:
   httpsProxyUrl: ""
   noProxy: ""
 
-# imagePullSecrets:
+## Image pull secrets to apply to all resources
+##
+imagePullSecrets: []
 # - name: "image-pull-secret"
 
 frontend:
@@ -429,6 +431,7 @@ frontend:
   image:
     repository: kubecost/frontend
     tag: latest
+
   imagePullPolicy: IfNotPresent
 
   # extraEnv:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -26,14 +26,14 @@ global:
     existingSecret: ""
     # If you want to use a different file name for the federated storage config, you can set the fileName value.
     fileName: federated-store.yaml  # set this value to change what the file name for the yaml config is
-    ## @param cspPricingApiKey.existingSecret The name of an existing secret to use for the GCP API key. If this is set, the secret will be used. Leave empty to create a new secret.
-    ## @param cspPricingApiKey.apiKey The GCP API key value. If this is set, the secret will be created. Leave empty to use an existing secret.
-    ## This is currently only used for GCP.
+  ## @param cspPricingApiKey.existingSecret The name of an existing secret to use for the GCP API key. If this is set, the secret will be used. Leave empty to create a new secret.
+  ## @param cspPricingApiKey.apiKey The GCP API key value. If this is set, the secret will be created. Leave empty to use an existing secret.
+  ## This is currently only used for GCP.
   cspPricingApiKey:
     existingSecret: ""
     apiKey: ""
   ## @param global.imageRegistry The image registry used for all images in this chart and the ibm-finops-agent chart
-  imageRegistry: "icr.io"
+  imageRegistry: ""
   ## E.g.
   ## imagePullSecrets:
   ##   - myRegistryKeySecretName
@@ -429,6 +429,7 @@ frontend:
   ## fullImageName: gcr.io/kubecost1/frontend:v3.0.0
   fullImageName: ""
   image:
+    registry: icr.io
     repository: kubecost/frontend
     tag: ""
 
@@ -703,6 +704,7 @@ networkCosts:
   ## fullImageName: gcr.io/kubecost1/kubecost-network-costs:v0.17.11
   fullImageName: ""
   image:
+    registry: icr.io
     repository: kubecost/network-costs
     tag: v0.17.11
   imagePullPolicy: IfNotPresent
@@ -833,6 +835,7 @@ forecasting:
   ## fullImageName: gcr.io/kubecost1/kubecost-modeling:v0.1.29
   fullImageName: ""
   image:
+    registry: icr.io
     repository: kubecost/modeling
     tag: v0.1.29
   imagePullPolicy: IfNotPresent
@@ -1172,6 +1175,7 @@ clusterController:
   ## fullImageName: gcr.io/kubecost1/cluster-controller:v0.16.20
   fullImageName: ""
   image:
+    registry: icr.io
     repository: kubecost/cluster-controller
     tag: v0.16.23
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
Default to IBM Cloud Container Registry (ICR) for all Kubecost-related images.

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

- All default-enabled images have a new `registry` config. It is defaulted to `icr.io`.
- Remove `.Values.imageVersion`. This is a legacy config.

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
N/A

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
Users may have compliance or network policies which disallow them from pulling from `icr.io`. If so, they can use the configs in this PR to override the `registry`, `repository`, and `tag` to fall back to images still hosted in `gcr.io`.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

### 1. Release branch

First update the `Chart.yaml` to include the following. This is typically automated during the release process. It can be validated by looking at the [v2.8 branch of this repo](https://github.com/kubecost/kubecost/blob/v2.8/cost-analyzer/Chart.yaml).

```yaml
appVersion: 3.0.0
version: 3.0.0
```

Next test the changes:

```sh
# Pull the subchart
$ helm dependency update ./kubecost

# Template the chart
$ helm template ./kubecost --set clusterController.enabled=true --set networkCosts.enabled=true | grep image:
        image: icr.io/kubecost/network-costs:v0.17.11
          image: icr.io/ibm-finops/agent:v1.0.0-test.0
          image: icr.io/kubecost/cost-model:3.0.0
        image: icr.io/kubecost/cluster-controller:v0.16.23
          image: icr.io/kubecost/modeling:v0.1.29
          image: icr.io/kubecost/frontend:3.0.0
          image: icr.io/kubecost/cost-model:3.0.0
          image: icr.io/kubecost/cost-model:3.0.0
    image: docker.io/alpine/k8s:1.33.4
```

### 2. Nightly "develop" branch

Set the `Chart.yaml` to include the following:

```yaml
appVersion: development
version: 0.0.0-dev
```

Next test the changes:

```sh
$ helm template ./kubecost --set clusterController.enabled=true --set networkCosts.enabled=true | grep image:
        image: icr.io/kubecost/network-costs:v0.17.11
          image: icr.io/ibm-finops/agent:v1.0.0-test.0
          image: gcr.io/kubecost1/cost-model-nightly:latest
        image: icr.io/kubecost/cluster-controller:v0.16.23
          image: icr.io/kubecost/modeling:v0.1.29
          image: gcr.io/kubecost1/frontend-nightly:latest
          image: gcr.io/kubecost1/cost-model-nightly:latest
          image: gcr.io/kubecost1/cost-model-nightly:latest
    image: docker.io/alpine/k8s:1.33.4
```

Notice the `cost-model-nightly` image and `frontend-nightly` image. All other images are pinned to a version tag, including the agent.

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A
