### PR TITLE
Default enable Cluster Controller and Network Costs

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -701,8 +701,10 @@ service:
 
 ## Optional daemonset to more accurately attribute network costs to the correct workload
 ## https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=configuration-network-cost
+##
 networkCosts:
-  enabled: false
+  enabled: true
+
   ## Override the image name and version for the network costs.
   ## If not set, the image will be pulled from the registry and repository specified in the image block.
   ## If set, the fullImageName will be used to pull the image.
@@ -713,13 +715,10 @@ networkCosts:
     repository: kubecost1/kubecost-network-costs
     tag: v0.17.11
   imagePullPolicy: IfNotPresent
+
   updateStrategy:
     type: RollingUpdate
-  # For existing Prometheus Installs, use the serviceMonitor: or prometheusScrape below.
-  # the below setting annotates the networkCost service endpoints for each of the network-costs pods.
-  # The Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.
-  # NOTE: Setting this option to true and leaving the above extraScrapeConfig "job_name: kubecost-networking" configured will cause the
-  # NOTE: pods to be scraped twice.
+
   prometheusScrape: false
   serviceMonitor:
     enabled: false
@@ -823,13 +822,14 @@ networkCosts:
     additionalLabels: {}
   additionalLabels: {}
   nodeSelector: {}
-  # Annotations to be added to network cost daemonset template and pod template annotations
   annotations: {}
   healthCheckProbes: {}
   additionalSecurityContext: {}
 
 ## Kubecost Forecasting forecasts future cost patterns based on historical
 ## patterns observed by Kubecost.
+## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=forecasting
+##
 forecasting:
   enabled: true
   serviceAccountName: ""
@@ -1159,16 +1159,16 @@ cloudCost:
 
   ## Define extra volumemounts for the cloud cost pod
   extraVolumeMounts: []
-# Kubecost Cluster Controller for Right Sizing and Cluster Turndown
+
+## Kubecost Cluster Controller for Automated Right Sizing and Turndown
+## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=configuration-cluster-controller
+##
 clusterController:
-  enabled: false
+  enabled: true
 
-  # enables legacy mode for cluster controller actions (v1)
-  # only used with kubecost versions < 3.0.0
+  # Enables legacy mode for cluster controller actions (v1)
+  # Only used with kubecost versions < 3.0.0
   legacyMode: false
-
-  # log level for cluster controller
-  logLevel: info
 
   ## Override the image name and version for the cluster controller.
   ## If not set, the image will be pulled from the registry and repository specified in the image block.
@@ -1180,6 +1180,7 @@ clusterController:
     repository: kubecost1/cluster-controller
     tag: v0.16.23
   imagePullPolicy: IfNotPresent
+  logLevel: info
   extraEnv: []
   # - name: EXTRA_ENV_VAR
   #   value: "extra_env_var_value"


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
Default enable Cluster Controller and Network Costs

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
As titled

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
N/A

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
The primary risk, would be the additional resource overhead these pods would begin consuming once scheduled. Particularly the network-costs daemonset.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
Templated my changes before and after. The diff correctly shows cluster controller and network costs resources are default templated. [diff.txt](https://github.com/user-attachments/files/22316416/diff.txt)

```sh
$ helm template ./kubecost > after.yaml
$ git checkout develop
$ helm template ./kubecost > before.yaml
$ diff before.yaml after.yaml > diff.txt
```

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A
