### PR TITLE
Rev KC Modeling Image to v0.1.30

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -841,7 +841,7 @@ forecasting:
   fullImageName: ""
   image:
     repository: kubecost1/kubecost-modeling
-    tag: v0.1.29
+    tag: v0.1.30
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.


### PR DESCRIPTION
## Release Notes Headline

Rev to push KC modeling image to latest: https://github.com/kubecost/kubecost-modeling/releases/tag/v0.1.30

## Commentary for Reviewers

<none>

## Links to Issues or Tickets

N/A

## User Impact and Risks

N/A

## Testing



## Documentation Updates

N/A