### PR TITLE
[cherry-pick] Move relevant root-level configs under `.Values.frontend`

### DIFF
--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -15,9 +15,9 @@ Kubecost 3.x is a major upgrade from previous versions and includes major new fe
 
 When pods are Ready, you can enable port-forwarding with the following command:
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "kubecost.frontend.serviceName" . }} {{ .Values.service.targetPort }}
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "kubecost.frontend.serviceName" . }} {{ .Values.frontend.service.targetPort }}
 
-Then, navigate to http://localhost:{{ .Values.service.targetPort }} in a web browser.
+Then, navigate to http://localhost:{{ .Values.frontend.service.targetPort }} in a web browser.
 
 Please allow 25 minutes for Kubecost to gather metrics. A progress indicator will appear at the top of the UI.
 

--- a/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
@@ -126,13 +126,13 @@ spec:
           {{- if .Values.clusterController.primaryKubecostURL }}
           value: {{ .Values.clusterController.primaryKubecostURL }}/model
           {{- else }}
-          value: http://{{ include "kubecost.frontend.serviceName" . }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort | default 9090 }}/model
+          value: http://{{ include "kubecost.frontend.serviceName" . }}.{{ .Release.Namespace }}:{{ .Values.frontend.service.targetPort | default 9090 }}/model
           {{- end }}
         - name: CC_CCL_COST_MODEL_PATH
           {{- if .Values.clusterController.primaryKubecostURL }}
           value: {{ .Values.clusterController.primaryKubecostURL }}/model
           {{- else }}
-          value: http://{{ include "kubecost.frontend.serviceName" . }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort | default 9090 }}/model
+          value: http://{{ include "kubecost.frontend.serviceName" . }}.{{ .Release.Namespace }}:{{ .Values.frontend.service.targetPort | default 9090 }}/model
           {{- end }}
         {{- if .Values.clusterController.kubecostAPIKey }}
         - name: KUBECOST_API_KEY

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -163,20 +163,20 @@ data:
 {{- end }}
         ssl_certificate     /etc/ssl/certs/kc.crt;
         ssl_certificate_key /etc/ssl/certs/kc.key;
-        listen {{ .Values.service.targetPort }} ssl;
+        listen {{ .Values.frontend.service.targetPort }} ssl;
 {{- if .Values.frontend.ipv6.enabled }}
-        listen [::]:{{ .Values.service.targetPort }} ssl;
+        listen [::]:{{ .Values.frontend.service.targetPort }} ssl;
 {{- end }}
 {{- else }}
-        listen {{ .Values.service.targetPort }};
+        listen {{ .Values.frontend.service.targetPort }};
 {{- if .Values.frontend.ipv6.enabled }}
-        listen [::]:{{ .Values.service.targetPort }};
+        listen [::]:{{ .Values.frontend.service.targetPort }};
 {{- end }}
 {{- end }}
 {{- else }}
-        listen {{ .Values.service.targetPort }};
+        listen {{ .Values.frontend.service.targetPort }};
 {{- if .Values.frontend.ipv6.enabled }}
-        listen [::]:{{ .Values.service.targetPort }};
+        listen [::]:{{ .Values.frontend.service.targetPort }};
 {{- end }}
 {{- end }}
         

--- a/kubecost/templates/frontend/frontend-deployment.yaml
+++ b/kubecost/templates/frontend/frontend-deployment.yaml
@@ -177,28 +177,28 @@ spec:
         - name: {{ .name }}
       {{- end }}
     {{- end }}
-      {{- if .Values.priority }}
-      {{- if .Values.priority.enabled }}
-      {{- if gt (len .Values.priority.name) 0 }}
-      priorityClassName: {{ .Values.priority.name }}
+      {{- if .Values.frontend.priority }}
+      {{- if .Values.frontend.priority.enabled }}
+      {{- if gt (len .Values.frontend.priority.name) 0 }}
+      priorityClassName: {{ .Values.frontend.priority.name }}
       {{- else }}
       priorityClassName: {{ include "kubecost.fullname" . }}-priority
       {{- end }}
       {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.frontend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.frontend.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.frontend.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
+      {{- with .Values.frontend.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/kubecost/templates/frontend/frontend-priority-class.yaml
+++ b/kubecost/templates/frontend/frontend-priority-class.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.priority }}
-{{- if .Values.priority.enabled }}
-{{- if eq (len .Values.priority.name) 0 }}
+{{- if .Values.frontend.priority }}
+{{- if .Values.frontend.priority.enabled }}
+{{- if eq (len .Values.frontend.priority.name) 0 }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ template "kubecost.fullname" . }}-priority
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
-value: {{ .Values.priority.value | default "1000000" }}
+value: {{ .Values.frontend.priority.value | default "1000000" }}
 globalDefault: false
 description: "Priority class for scheduling the frontend pod"
 {{- end }}

--- a/kubecost/templates/frontend/frontend-service.yaml
+++ b/kubecost/templates/frontend/frontend-service.yaml
@@ -6,46 +6,46 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
-{{- if .Values.service.labels }}
-{{ toYaml .Values.service.labels | indent 4 }}
+{{- if .Values.frontend.service.labels }}
+{{ toYaml .Values.frontend.service.labels | indent 4 }}
 {{- end }}
-{{- if .Values.service.annotations }}
+{{- if .Values.frontend.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{ toYaml .Values.frontend.service.annotations | indent 4 }}
 {{- end }}
 spec:
   selector:
     {{- include "kubecost.frontend.selectorLabels" . | nindent 4 }}
 {{- if .Values.service -}}
-{{- if .Values.service.type }}
-  type: "{{ .Values.service.type }}"
+{{- if .Values.frontend.service.type }}
+  type: "{{ .Values.frontend.service.type }}"
 {{- else }}
   type: ClusterIP
 {{- end }}
 {{- else }}
   type: ClusterIP
 {{- end }}
-{{- if (eq .Values.service.type "LoadBalancer") }}
-  {{- if .Values.service.loadBalancerSourceRanges }}
+{{- if (eq .Values.frontend.service.type "LoadBalancer") }}
+  {{- if .Values.frontend.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 -}}
+    {{- toYaml .Values.frontend.service.loadBalancerSourceRanges | nindent 4 -}}
   {{- end -}}
 {{- end }}
   ports:
     - name: tcp-frontend
-      {{- if (eq .Values.service.type "NodePort") }}
-      {{- if .Values.service.nodePort }}
-      nodePort: {{ .Values.service.nodePort }}
+      {{- if (eq .Values.frontend.service.type "NodePort") }}
+      {{- if .Values.frontend.service.nodePort }}
+      nodePort: {{ .Values.frontend.service.nodePort }}
       {{- end }}
       {{- end }}
-      port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
-{{- if .Values.service.sessionAffinity.enabled }}
+      port: {{ .Values.frontend.service.port }}
+      targetPort: {{ .Values.frontend.service.targetPort }}
+{{- if .Values.frontend.service.sessionAffinity.enabled }}
   sessionAffinity: ClientIP
-  {{- if .Values.service.sessionAffinity.timeoutSeconds }}
+  {{- if .Values.frontend.service.sessionAffinity.timeoutSeconds }}
   sessionAffinityConfig:
     clientIP:
-      timeoutSeconds: {{ .Values.service.sessionAffinity.timeoutSeconds }}
+      timeoutSeconds: {{ .Values.frontend.service.sessionAffinity.timeoutSeconds }}
   {{- end }}
 {{- else }}
   sessionAffinity: None

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -444,7 +444,25 @@ frontend:
     requests:
       cpu: "10m"
       memory: "55Mi"
+  service:
+    type: ClusterIP
+    port: 9090
+    targetPort: 9090
+    nodePort: {}
+    labels: {}
+    annotations: {}
+    loadBalancerSourceRanges: []
+    sessionAffinity:
+      enabled: false  # Makes sure that connections from a client are passed to the same Pod each time, when set to `true`. You should set it when you enabled authentication through OIDC or SAML integration.
+      timeoutSeconds: 10800
   deploymentStrategy: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  priority:
+    enabled: false
+    name: ""
   readinessProbe:
     enabled: true
     initialDelaySeconds: 1
@@ -670,28 +688,6 @@ ingress:
   #  - secretName: kubecost-tls
   #    hosts:
   #      - kubecost.local
-
-nodeSelector: {}
-tolerations: []
-affinity: {}
-topologySpreadConstraints: []
-priority:
-  enabled: false
-  name: ""
-extraVolumes: []
-extraVolumeMounts: []
-
-service:
-  type: ClusterIP
-  port: 9090
-  targetPort: 9090
-  nodePort: {}
-  labels: {}
-  annotations: {}
-  # loadBalancerSourceRanges: []
-  sessionAffinity:
-    enabled: false  # Makes sure that connections from a client are passed to the same Pod each time, when set to `true`. You should set it when you enabled authentication through OIDC or SAML integration.
-    timeoutSeconds: 10800
 
 ## Optional daemonset to more accurately attribute network costs to the correct workload
 ## https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=configuration-network-cost


### PR DESCRIPTION
Cherry-pick of https://github.com/kubecost/kubecost/pull/4259 into v3.0 branch