### PR TITLE
[KCM-4572] Forecasting: use /model/forecast instead of /forecasting, update path

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -475,10 +475,10 @@ data:
         }
 
         {{- if .Values.forecasting.enabled }}
-        location /forecasting {
+        location /model/forecast/ {
             default_type 'application/json';
             proxy_read_timeout          300;
-            proxy_pass http://forecasting/;
+            proxy_pass http://forecasting/forecast/;
             proxy_redirect off;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;


### PR DESCRIPTION
## Release Notes Headline

N/A

## Commentary for Reviewers

Bug fix 

## Links to Issues or Tickets

https://apptio.atlassian.net/browse/KCM-4572

## User Impact and Risks

N/A

## Testing

- installed chart in local kind cluster, port forwarded 9090 and validated that the /model/forecast paths were available

## Documentation Updates

N/A
