### PR TITLE
[KCM-4571]fix: Set default gcp api key

### DIFF
--- a/.github/workflows/test-chart-3.0.yml
+++ b/.github/workflows/test-chart-3.0.yml
@@ -8,9 +8,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
   # Uncomment this if you need to actively test this workflow from a PR draft
-  pull_request:
-    branches:
-      - develop
+  # pull_request:
+  #   branches:
+  #     - develop
 
 # Prevents multiple runs of the same workflow on the same branch from executing 
 # simultaneously. Saves resources.

--- a/examples/agentOnly/helmValues-kubecost-gcp.yaml
+++ b/examples/agentOnly/helmValues-kubecost-gcp.yaml
@@ -13,8 +13,8 @@ global:
   cspPricingApiKey:
     ## When using GCP, an API key to access on-demand pricing is required.
     ## use the apiKey OR the secret.
-    ## A secret is recommended- though the apiKey is can be a read only service account exclusively for downloading public pricing data.
-    apiKey: ""
+    ## A secret is recommended- though the apiKey can be a read only service account exclusively for downloading public pricing data.
+    apiKey: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk"
     existingSecret: ""
 clusterController:
   enabled: true  # optional, automated rightsizing of containers

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -26,12 +26,14 @@ global:
     existingSecret: ""
     # If you want to use a different file name for the federated storage config, you can set the fileName value.
     fileName: federated-store.yaml  # set this value to change what the file name for the yaml config is
-  ## @param cspPricingApiKey.existingSecret The name of an existing secret to use for the GCP API key. If this is set, the secret will be used. Leave empty to create a new secret.
-  ## @param cspPricingApiKey.apiKey The GCP API key value. If this is set, the secret will be created. Leave empty to use an existing secret.
-  ## This is currently only used for GCP.
+  ## @param cspPricingApiKey.existingSecret The name of an existing secret containing a GCP API key. If set, this existing secret will be used instead of creating a new one.
+  ## @param cspPricingApiKey.apiKey The GCP API key value used to access pricing data. Required for GCP clusters to fetch on-demand pricing.
+  ## If set, a new secret will be created with this API key. Leave empty if using an existing secret via cspPricingApiKey.existingSecret.
+  ## WARNING: The default API key provided here is rate-limited and shared across all users.
+  ## For production use, it is strongly recommended to create and use your own GCP API key to avoid quota limits.
   cspPricingApiKey:
     existingSecret: ""
-    apiKey: ""
+    apiKey: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk"
   ## @param global.imageRegistry The image registry used for all images in this chart and subcharts
   imageRegistry: "icr.io"
   ## E.g.


### PR DESCRIPTION
## Release Notes Headline
Set the default gcp api key for finops agent too for getting the on demand pricing.

## Commentary for Reviewers

Using the key already being used by kubecost aggregator. Ref: https://github.com/kubecost/kubecost/blob/13c9c8b95f086039b4a19a4920b789bcdecb0fb8/kubecost/templates/aggregator/aggregator-statefulset.yaml#L472

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-4571
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
This makes a fresh install for gcp users easier and clean

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Helm template.
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
