### PR TITLE
Bump finops-agent-chart to v1.0.0-rc.1

### DIFF
--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
-  version: 1.0.0-rc.0
-digest: sha256:3328b38c758301dc60806ab5e4171578cf5775fb546de64fbd81eaec171a4a31
-generated: "2025-09-18T13:48:02.82828-07:00"
+  version: 1.0.0-rc.1
+digest: sha256:d22a69292487d811d23c905f05e848d531f35c43ebb9e56aaed4eb1b6d81f271
+generated: "2025-09-21T10:56:52.911498-07:00"

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -10,6 +10,6 @@ annotations:
       url: https://www.kubecost.com
 dependencies:
   - name: finops-agent
-    version: "v1.0.0-rc.0"
+    version: "v1.0.0-rc.1"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finops-agent.enabled


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
N/A

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
As titled. Update `Chart.yaml` and `Chart.lock`.

```
$ helm dependency update ./kubecost
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "ibm-finops" chart repository
...Successfully got an update from the "finops-agent" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading finops-agent from repo https://kubecost.github.io/finops-agent-chart
Deleting outdated charts
```


## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
N/A

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
N/A

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
N/A

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A
