### PR TITLE
Add more detailed failure messages on `.Values.federatedETL`

### DIFF
--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -12,13 +12,13 @@ Kubecost 3.0 preconditions
     {{ fail "`.Values.kubecostModel.federatedStorageConfigSecret` is no longer supported. Please use `.Values.global.federatedStorage.existingSecret` instead." }}
   {{- end -}}
   {{- if (.Values.federatedETL).federatedCluster -}}
-    {{ fail "`.Values.federatedETL.federatedCluster` is no longer supported. Please use `.Values.finops-agent.enabled=true` instead." }}
+    {{ fail "`.Values.federatedETL.federatedCluster` is no longer supported. Please use `.Values.finops-agent.enabled=true` instead if you want to push this cluster's metrics to the federated storage." }}
   {{- end -}}
   {{- if (.Values.federatedETL).agentOnly -}}
     {{ fail "`.Values.federatedETL.agentOnly` is no longer supported. Please use `.Values.aggregator.enabled=false` instead. You may also choose to disable the frontend, cloudcost, and forecasting components." }}
   {{- end -}}
   {{- if (.Values.federatedETL).readOnlyPrimary -}}
-    {{ fail "`.Values.federatedETL.readOnlyPrimary` is no longer supported. Please use `.Values.finops-agent.enabled=false` instead." }}
+    {{ fail "`.Values.federatedETL.readOnlyPrimary` is no longer supported. Please use `.Values.finops-agent.enabled=false` instead if you don't want to push this cluster's metrics to the federated storage." }}
   {{- end -}}
   {{- if .Values.federatedETL -}}
     {{ fail "`.Values.federatedETL` is no longer supported. Please remove this configuration." }}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -11,8 +11,17 @@ Kubecost 3.0 preconditions
   {{- if (.Values.kubecostModel).federatedStorageConfigSecret -}}
     {{ fail "`.Values.kubecostModel.federatedStorageConfigSecret` is no longer supported. Please use `.Values.global.federatedStorage.existingSecret` instead." }}
   {{- end -}}
+  {{- if (.Values.federatedETL).federatedCluster -}}
+    {{ fail "`.Values.federatedETL.federatedCluster` is no longer supported. Please use `.Values.finops-agent.enabled=true` instead." }}
+  {{- end -}}
+  {{- if (.Values.federatedETL).agentOnly -}}
+    {{ fail "`.Values.federatedETL.agentOnly` is no longer supported. Please use `.Values.aggregator.enabled=false` instead. You may also choose to disable the frontend, cloudcost, and forecasting components." }}
+  {{- end -}}
+  {{- if (.Values.federatedETL).readOnlyPrimary -}}
+    {{ fail "`.Values.federatedETL.readOnlyPrimary` is no longer supported. Please use `.Values.finops-agent.enabled=false` instead." }}
+  {{- end -}}
   {{- if .Values.federatedETL -}}
-    {{ fail "`.Values.federatedETL` is no longer supported. Please remove this configuration, and use configurations under `.Values.aggregator` or `.Values.finops-agent` instead." }}
+    {{ fail "`.Values.federatedETL` is no longer supported. Please remove this configuration." }}
   {{- end -}}
 
   {{/* Cloud Integration config migration */}}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -556,6 +556,7 @@ localStore:
 ## Ref: https://github.com/kubecost/finops-agent-chart/
 ##
 finops-agent:
+  enabled: true
   agent:
     collectorDataSource:
       enabled: true


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
N/A

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
- We received feedback that the previous error message on `.Values.federatedETL` was vague.
- This adds specific error messages for each case
- This PR also specifically adds `.Values.finops-agent.enabled=true`. By default, it was already evaluating to true ([ref](https://helm.sh/docs/topics/charts/#tags-and-condition-fields-in-dependencies)).

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
N/A

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
N/A

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
```yaml
# values-test.yaml
federatedETL:
  federatedCluster: true
```

```sh
$ helm template ./kubecost -f values-test.yaml
Error: execution error at (kubecost/templates/NOTES.txt:2:4): `.Values.federatedETL.federatedCluster` is no longer supported. Please use `.Values.finops-agent.enabled=true` instead.
```

```sh
# Ran the following commands. No diff in defaults.
$ helm template ./kubecost --debug > after.yaml
$ git checkout develop
$ helm template ./kubecost --debug > before.yaml
$ diff before.yaml after.yaml > diff.txt
```

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A
