### PR TITLE
[KCM-3969] Cluster controller: Use port 9732 for non-legacy mode

### DIFF
--- a/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
@@ -150,7 +150,11 @@ spec:
         {{- end }}
         ports:
         - name: http-server
+        {{- if not (.Values.clusterController).legacyMode }}
+          containerPort: 9732
+        {{- else }}
           containerPort: 9731
+        {{- end }}
         resources:
           {{- toYaml .Values.clusterController.resources | nindent 12 }}
       {{- if .Values.imagePullSecrets }}

--- a/kubecost/templates/cluster-controller/cluster-controller-service.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-service.yaml
@@ -11,8 +11,13 @@ spec:
   ports:
     - name: http
       protocol: TCP
+      {{- if not (.Values.clusterController).legacyMode }}
+      port: 9732
+      targetPort: 9732
+      {{- else }}
       port: 9731
       targetPort: 9731
+      {{- end }}
   selector:
     app: {{ template "kubecost.clusterController.name" . }}
 {{- end }}


### PR DESCRIPTION
## Release Notes Headline
N/A

## Commentary for Reviewers
Update the cluster controller Service to surface port 9732 if not in legacy mode. 

## Links to Issues or Tickets

https://apptio.atlassian.net/browse/KCM-3969

## User Impact and Risks

N/A

## Testing

- helm template

## Documentation Updates

N/A
