### PR TITLE
Mount bucket storage to cluster storage

### DIFF
--- a/kubecost/templates/local-store/_helpers.tpl
+++ b/kubecost/templates/local-store/_helpers.tpl
@@ -1,12 +1,8 @@
 {{- define "kubecost.localStore.enabled" -}}
-  {{- if .Values.global.federatedStorage.config -}}
-    {{- "disabled" -}}
-  {{- else if .Values.global.federatedStorage.existingSecret -}}
-    {{- "disabled" -}}
-  {{- else if not .Values.localStore.enabled -}}
-    {{- "disabled" -}}
-  {{- else -}}
+  {{- if .Values.localStore.enabled -}}
     {{- "enabled" -}}
+  {{- else -}}
+    {{- "disabled" -}}
   {{- end -}}
 {{- end -}}
 

--- a/kubecost/templates/local-store/cluster-storage-deployment.yaml
+++ b/kubecost/templates/local-store/cluster-storage-deployment.yaml
@@ -57,6 +57,10 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        - name: federated-storage-config
+          secret:
+            defaultMode: 420
+            secretName: {{ include "kubecost.federatedStorage.secretName" . }}
       containers:
         - name: local-object-store
           image: {{ include "kubecost.localStore.image" . }}
@@ -90,6 +94,10 @@ spec:
           volumeMounts:
             - name: file-storage
               mountPath: /var/configs
+            - name: federated-storage-config
+              mountPath: /var/configs/federated-store.yaml
+              subPath: {{ include "kubecost.federatedStorage.fileName" . }}
+              readOnly: true
           {{- if (.Values.localStore).extraVolumeMounts }}
             {{- toYaml (.Values.localStore).extraVolumeMounts | nindent 4 }}
           {{- end }}


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
This PR mounts the bucket storage to the local-store which allows it to migrate its data to a new bucket configuration. After a being deployed with a bucket store once and completing a migration. It will be safe to disable local-store using `.Values.localStore.enabled=false`

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Tested by deploying to a cluster which has been running local-store and ensuring that old files were migrated to the configured bucket

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
