### PR TITLE
Upgrade cluster controller to v0.16.27

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1142,7 +1142,7 @@ clusterController:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/cluster-controller
-    tag: v0.16.26
+    tag: v0.16.27
   imagePullPolicy: IfNotPresent
   logLevel: info
   extraEnv: []


### PR DESCRIPTION
## Release Notes Headline

N/A

## Commentary for Reviewers

Update cluster controller to latest tag v0.16.27.

## Links to Issues or Tickets

N/A

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A
