### PR TITLE
Update finops-agent chart to v1.0.0

### DIFF
--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
-  version: 1.0.0-rc.1
-digest: sha256:d22a69292487d811d23c905f05e848d531f35c43ebb9e56aaed4eb1b6d81f271
-generated: "2025-09-21T10:56:52.911498-07:00"
+  version: 1.0.0
+digest: sha256:44499188b042585b88689103c62868d8d74a1a78fd394512fb8569b9aea9b0eb
+generated: "2025-09-26T23:13:15.990971+05:30"

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -10,6 +10,6 @@ annotations:
       url: https://www.kubecost.com
 dependencies:
   - name: finops-agent
-    version: "v1.0.0-rc.1"
+    version: "v1.0.0"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finops-agent.enabled


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers

```sh
helm dependency update ./kubecost
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://kubecost.github.io/finops-agent-chart" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "ingress-nginx" chart repository
...Successfully got an update from the "fluent" chart repository
...Successfully got an update from the "kc30" chart repository
...Successfully got an update from the "opencost-charts" chart repository
...Successfully got an update from the "argo" chart repository
...Successfully got an update from the "grafana" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading finops-agent from repo https://kubecost.github.io/finops-agent-chart
Deleting outdated charts
```

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
