### PR TITLE
bump aggregator.persistentConfigStorage.storageRequest to 10Gi from 1Gi

### DIFF
--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -8,6 +8,7 @@
 {{- include "kubecost.caCertsSecretConfig.check" . -}}
 {{- include "kubecost.actionsStorageSourceCheck" . -}}
 {{- include "kubecost.localStoreClusterIdCheck" . -}}
+{{- include "kubecost.aggregatorConfigStorageWarning" . -}}
 ================================================================================
 KUBECOST INSTALLATION SUCCESSFUL
 ================================================================================

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -594,3 +594,12 @@ NOTE: added kubecostModel for backward compatibility
 {{ printf "\n\nWARNING: The clusterId is set to the default value of 'cluster-one'. This is not recommended if you intend to use multi-cluster federation in the future. Please set a globally unique .Values.global.clusterId\n\n" }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+NOTE: Added storage request warning for aggregator config storage
+*/}}
+{{- define "kubecost.aggregatorConfigStorageWarning" -}}
+{{- if and .Values.aggregator.enabled (lt (.Values.aggregator.aggregatorDbStorage.storageRequest | regexFind "[0-9]+" | int) 50) -}}
+{{ printf "\n\nWARNING: Using storage request of %s for aggregator config may be insufficient and can cause the aggregator pod to fail to start depending on your storage class and cluster size. Consider using at least 50Gi by adjusting .Values.aggregator.aggregatorDbStorage.storageRequest based on your requirements.\n\n" .Values.aggregator.aggregatorDbStorage.storageRequest }}
+{{- end -}}
+{{- end -}}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -953,15 +953,15 @@ aggregator:
   ## use fast IOPS storage for the aggregator db and persistent configs.
   persistentConfigsStorage:
     storageClass: ""  # default storage class. Using the same storage class as the aggregator db storage is recommended for node placement concerns.
-    storageRequest: 10Gi # may need to be increased if the storage class requires a certain size per IOPS
+    storageRequest: 10Gi  # may need to be increased if the storage class requires a certain size per IOPS
   aggregatorDbStorage:
     storageClass: ""  # default storage class. NFS is not supported.
     storageRequest: 128Gi
   resources:
     ## Consider setting a limit after a baseline has been established
     limits: {}
-        # memory: ""
-        # cpu: ""
+      # memory: ""
+      # cpu: ""
     requests:
       memory: 3Gi
       cpu: 100m

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -933,7 +933,7 @@ aggregator:
 
   persistentConfigsStorage:
     storageClass: ""  # default storage class
-    storageRequest: 50Gi
+    storageRequest: 15Gi
   aggregatorDbStorage:
     storageClass: ""  # default storage class
     storageRequest: 128Gi

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -949,8 +949,8 @@ aggregator:
     storageRequest: 128Gi
   resources:
     limits: {}
-      # memory: ""
-      # cpu: ""
+        # memory: ""
+        # cpu: ""
     requests:
       memory: 3Gi
       cpu: 100m

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -933,7 +933,7 @@ aggregator:
 
   persistentConfigsStorage:
     storageClass: ""  # default storage class
-    storageRequest: 1Gi
+    storageRequest: 50Gi
   aggregatorDbStorage:
     storageClass: ""  # default storage class
     storageRequest: 128Gi

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -933,7 +933,7 @@ aggregator:
 
   persistentConfigsStorage:
     storageClass: ""  # default storage class
-    storageRequest: 15Gi
+    storageRequest: 10Gi
   aggregatorDbStorage:
     storageClass: ""  # default storage class
     storageRequest: 128Gi


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. --> When deploying the Kubecost Helm chart to a cluster using a non-standard storage class, the aggrator fails to come up because we're allocating 1Gi of storage for the AggregatorConfig PVC, but most non-default storage classes have a higher minimum. This results in the aggregator failing to come up, per the logs in this bug ticket: https://apptio.atlassian.net/browse/KCM-4659

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. --> Bumps default Helm values for `.Values.aggregator.persistentConfigStorage.storageRequest` from 1Gi to 10Gi. Note: we use 50Gi in the `kc30rc` namespace. 

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". --> N/A
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? --> Limited - this change should help customers running non-standard default storage classs from experiencing deployment issues. 

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. --> N/A
