### PR TITLE
Network Costs v0.18.0

### DIFF
--- a/kubecost/templates/network-costs/network-costs-cluster-role.yaml
+++ b/kubecost/templates/network-costs/network-costs-cluster-role.yaml
@@ -17,4 +17,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - patch
 {{- end }}

--- a/kubecost/templates/network-costs/network-costs-cluster-role.yaml
+++ b/kubecost/templates/network-costs/network-costs-cluster-role.yaml
@@ -17,6 +17,7 @@ rules:
       - get
       - list
       - watch
+  {{- if .Values.networkCosts.leaderKubernetesWatcher }}
   - apiGroups:
       - coordination.k8s.io
     resources:
@@ -25,4 +26,5 @@ rules:
       - create
       - get
       - patch
+  {{- end }}
 {{- end }}

--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -90,10 +90,8 @@ spec:
         {{- if .Values.networkCosts.healthCheckProbes }}
         {{- toYaml .Values.networkCosts.healthCheckProbes | nindent 8 }}
         {{- end }}
-        {{- if .Values.networkCosts.leaderKubernetesWatcher }}
         - name: USE_LEADER_KUBERNETES_WATCHERS
-          value: {{ (quote .Values.networkCosts.leaderKubernetesWatcher) | default (quote true) }}
-        {{- end }}
+          value: {{ (quote .Values.networkCosts.leaderKubernetesWatcher) | default (quote false) }}
         volumeMounts:
         {{- if .Values.networkCosts.hostProc }}
         - mountPath: {{ .Values.networkCosts.hostProc.mountPath }}

--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -89,6 +89,8 @@ spec:
           value: {{ .Values.networkCosts.logLevel }}
         - name: USE_LEADER_KUBERNETES_WATCHERS
           value: {{ (quote .Values.networkCosts.leaderKubernetesWatcher) | default (quote false) }}
+        - name: USE_HOST_NODE_NETWORK_MAP
+          value: {{ (quote .Values.networkCosts.hostNodeNetworkMap) | default (quote false) }}
         {{- if .Values.networkCosts.healthCheckProbes }}
         {{- toYaml .Values.networkCosts.healthCheckProbes | nindent 8 }}
         {{- end }}

--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -76,30 +76,23 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: HOST_PORT
           value: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
         - name: TRAFFIC_LOGGING_ENABLED
           value: {{ (quote .Values.networkCosts.trafficLogging) | default (quote true) }}
         - name: LOG_LEVEL
           value: {{ .Values.networkCosts.logLevel }}
-        {{- if .Values.networkCosts.softMemoryLimit }}
-        - name: GOMEMLIMIT
-          value: {{ .Values.networkCosts.softMemoryLimit }}
-        {{- end }}
-        {{- if .Values.networkCosts.heapMonitor }}
-        {{- if .Values.networkCosts.heapMonitor.enabled }}
-        - name: HEAP_MONITOR_ENABLED
-          value: "true"
-        - name: HEAP_MONITOR_THRESHOLD
-          value: {{ .Values.networkCosts.heapMonitor.threshold }}
-        {{- if .Values.networkCosts.heapMonitor.outFile }}
-        - name: HEAP_MONITOR_OUTPUT
-          value: {{ .Values.networkCosts.heapMonitor.outFile }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
         {{- if .Values.networkCosts.healthCheckProbes }}
         {{- toYaml .Values.networkCosts.healthCheckProbes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.networkCosts.leaderKubernetesWatcher }}
+        - name: USE_LEADER_KUBERNETES_WATCHERS
+          value: {{ (quote .Values.networkCosts.leaderKubernetesWatcher) | default (quote true) }}
         {{- end }}
         volumeMounts:
         {{- if .Values.networkCosts.hostProc }}

--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -87,11 +87,11 @@ spec:
           value: {{ (quote .Values.networkCosts.trafficLogging) | default (quote true) }}
         - name: LOG_LEVEL
           value: {{ .Values.networkCosts.logLevel }}
+        - name: USE_LEADER_KUBERNETES_WATCHERS
+          value: {{ (quote .Values.networkCosts.leaderKubernetesWatcher) | default (quote false) }}
         {{- if .Values.networkCosts.healthCheckProbes }}
         {{- toYaml .Values.networkCosts.healthCheckProbes | nindent 8 }}
         {{- end }}
-        - name: USE_LEADER_KUBERNETES_WATCHERS
-          value: {{ (quote .Values.networkCosts.leaderKubernetesWatcher) | default (quote false) }}
         volumeMounts:
         {{- if .Values.networkCosts.hostProc }}
         - mountPath: {{ .Values.networkCosts.hostProc.mountPath }}

--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -77,10 +77,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: ELECTION_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
+          value: {{ .Release.Namespace }}
         - name: HOST_PORT
           value: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
         - name: TRAFFIC_LOGGING_ENABLED

--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -85,9 +85,9 @@ spec:
         - name: LOG_LEVEL
           value: {{ .Values.networkCosts.logLevel }}
         - name: USE_LEADER_KUBERNETES_WATCHERS
-          value: {{ (quote .Values.networkCosts.leaderKubernetesWatcher) | default (quote false) }}
+          value: {{ (quote .Values.networkCosts.leaderKubernetesWatcher) }}
         - name: USE_HOST_NODE_NETWORK_MAP
-          value: {{ (quote .Values.networkCosts.hostNodeNetworkMap) | default (quote false) }}
+          value: {{ (quote .Values.networkCosts.hostNodeNetworkMap) }}
         {{- if .Values.networkCosts.healthCheckProbes }}
         {{- toYaml .Values.networkCosts.healthCheckProbes | nindent 8 }}
         {{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -695,15 +695,15 @@ networkCosts:
   # Log level for the network cost containers. Options are "trace", "debug", "info", "warn", "error", "fatal", "panic"
   logLevel: info
 
-  # Leader/Follower Kubernetes Watchers: Instead of every network-costs pod running watchers for kubernetes resources, a 
+  # Leader/Follower Kubernetes Watchers: Instead of every network-costs pod running watchers for kubernetes resources, a
   # leader is selected as the designated watcher, and delta updates are sent to every follower pod over http. This option is
   # recommended for large kubernetes clusters to avoid overwhelming the kubernetes API.
-  leaderKubernetesWatcher: false 
+  leaderKubernetesWatcher: false
 
-  # Enabling this option will restrict the pod watchers to only pods that are hosted on the node network-costs in running on. 
-  # This reduces the memory footprint of the pod mapping inside network costs slightly at the cost of classification accuracy 
+  # Enabling this option will restrict the pod watchers to only pods that are hosted on the node network-costs in running on.
+  # This reduces the memory footprint of the pod mapping inside network costs slightly at the cost of classification accuracy
   # on ingress. Note that this option is only applicable when leaderKubernetesWatcher is false
-  hostNodeNetworkMap: false 
+  hostNodeNetworkMap: false
 
   # Port will set both the containerPort and hostPort to this value.
   # These must be identical due to network-costs being run on hostNetwork

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -668,12 +668,12 @@ networkCosts:
   ## If not set, the image will be pulled from the registry and repository specified in the image block.
   ## If set, the fullImageName will be used to pull the image.
   ## Example:
-  ## fullImageName: gcr.io/kubecost1/kubecost-network-costs:v0.17.11
+  ## fullImageName: gcr.io/kubecost1/kubecost-network-costs:v0.18.0
   fullImageName: ""
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/network-costs
-    tag: v0.17.11
+    tag: v0.18.0
   imagePullPolicy: IfNotPresent
 
   updateStrategy:
@@ -694,6 +694,11 @@ networkCosts:
 
   # Log level for the network cost containers. Options are "trace", "debug", "info", "warn", "error", "fatal", "panic"
   logLevel: info
+
+  # Leader/Follower Kubernetes Watchers: Instead of every network-costs pod running watchers for kubernetes resources, a 
+  # leader is selected as the designated watcher, and delta updates are sent to every follower pod over http. This option is
+  # recommended for large kubernetes clusters to avoid overwhelming the kubernetes API.
+  leaderKubernetesWatcher: false 
 
   # Port will set both the containerPort and hostPort to this value.
   # These must be identical due to network-costs being run on hostNetwork

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -702,7 +702,7 @@ networkCosts:
 
   # Enabling this option will restrict the pod watchers to only pods that are hosted on the node network-costs in running on. 
   # This reduces the memory footprint of the pod mapping inside network costs slightly at the cost of classification accuracy 
-  # on ingress. 
+  # on ingress. Note that this option is only applicable when leaderKubernetesWatcher is false
   hostNodeNetworkMap: false 
 
   # Port will set both the containerPort and hostPort to this value.

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -700,6 +700,11 @@ networkCosts:
   # recommended for large kubernetes clusters to avoid overwhelming the kubernetes API.
   leaderKubernetesWatcher: false 
 
+  # Enabling this option will restrict the pod watchers to only pods that are hosted on the node network-costs in running on. 
+  # This reduces the memory footprint of the pod mapping inside network costs slightly at the cost of classification accuracy 
+  # on ingress. 
+  hostNodeNetworkMap: false 
+
   # Port will set both the containerPort and hostPort to this value.
   # These must be identical due to network-costs being run on hostNetwork
   port: 3001


### PR DESCRIPTION
* Add clusterrole permissions for leader/follower lease 
* Add leader/follower flag and doc comment 
* Cleanup old go env vars

## Testing

```sh
$ helm template ./kubecost --debug > out.txt

# Success
```

```sh
$ helm template ./kubecost --debug --set networkCosts.leaderKubernetesWatcher=true

# Success
# ClusterRole now includes "leases" resource
```

```sh
$ helm template ./kubecost --debug --set networkCosts.hostNodeNetworkMap=true

# Success
```
