### PR TITLE
Aligon/custom branding

### DIFF
--- a/kubecost/templates/frontend/_helpers.tpl
+++ b/kubecost/templates/frontend/_helpers.tpl
@@ -49,3 +49,14 @@ Create the nginx config map name with fallback logic.
   {{- printf "nginx-conf-%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the branding config map name with fallback logic.
+*/}}
+{{- define "kubecost.frontend.logoConfigMapName" -}}
+{{- if ((.Values.kubecostProductConfigs).branding).configmap -}}
+  {{- ((.Values.kubecostProductConfigs).branding).configmap  -}}
+{{- else -}}
+  {{ printf "frontend-logo-%s" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}

--- a/kubecost/templates/frontend/frontend-branding.yaml
+++ b/kubecost/templates/frontend/frontend-branding.yaml
@@ -5,9 +5,13 @@ metadata:
   name: frontend-logo-{{.Release.Name}}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
-data:
+binaryData:
+{{- if ((.Values.kubecostProductConfigs).branding).fullLogoBase64 }}
   fullLogo: |-
-{{- toYaml ((.Values.kubecostProductConfigs).branding).fullLogoDataURI | nindent 4 }}
+{{- ((.Values.kubecostProductConfigs).branding).fullLogoBase64 | nindent 4 }}
+{{- end }}
+{{- if ((.Values.kubecostProductConfigs).branding).squareLogoBase64 }}
   squareLogo: |-
-{{- toYaml ((.Values.kubecostProductConfigs).branding).squareLogoDataURI | nindent 4 }}
-{{- end -}}
+{{- ((.Values.kubecostProductConfigs).branding).squareLogoBase64 | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/kubecost/templates/frontend/frontend-branding.yaml
+++ b/kubecost/templates/frontend/frontend-branding.yaml
@@ -1,0 +1,13 @@
+{{- if ((.Values.kubecostProductConfigs).branding) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-logo-{{.Release.Name}}
+  labels:
+    {{- include "kubecost.commonLabels" . | nindent 4 }}
+data:
+  fullLogo: |-
+{{- toYaml ((.Values.kubecostProductConfigs).branding).fullLogoDataURI | nindent 4 }}
+  squareLogo: |-
+{{- toYaml ((.Values.kubecostProductConfigs).branding).squareLogoDataURI | nindent 4 }}
+{{- end -}}

--- a/kubecost/templates/frontend/frontend-branding.yaml
+++ b/kubecost/templates/frontend/frontend-branding.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: frontend-logo-{{.Release.Name}}
+  name: {{ template "kubecost.frontend.logoConfigMapName" . }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 binaryData:

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -582,7 +582,7 @@ data:
         {{- $squareLogoExt := default "not-found" (((.Values.kubecostProductConfigs).branding).squareLogoExt)}}
         location /custom-branding/square-logo {
             {{- if  ne $squareLogoExt "not-found"}}
-                try_files /static/templated-full-logo.{{$squareLogoExt}} =404;
+                try_files /static/templated-square-logo.{{$squareLogoExt}} =404;
             {{- else }}
                 return 404;
             {{- end }}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -559,8 +559,10 @@ data:
             {{- if $branding}}
             default_type 'application/json';
             return 200 '{
-                fullLogoAltText: "{{ $branding.fullLogoAltText}}",
-                squareLogoAltText: "{{ $branding.squareLogoAltText}}"
+                productName: "{{ $branding.productName }}"
+                primaryAccentColor: "{{ $branding.primaryAccentColor }}"
+                fullLogoAltText: "{{ $branding.fullLogoAltText }}",
+                squareLogoAltText: "{{ $branding.squareLogoAltText }}"
             }';
             {{- else }}            
             return 404;

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -559,8 +559,9 @@ data:
             {{- if $branding}}
             default_type 'application/json';
             return 200 '{
-                productName: "{{ $branding.productName }}"
-                primaryAccentColor: "{{ $branding.primaryAccentColor }}"
+                productName: "{{ $branding.productName }}",
+                footerHTML: "{{ $branding.footerHTML }}",
+                primaryAccentColor: "{{ $branding.primaryAccentColor }}",
                 fullLogoAltText: "{{ $branding.fullLogoAltText }}",
                 squareLogoAltText: "{{ $branding.squareLogoAltText }}"
             }';

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -559,11 +559,11 @@ data:
             {{- if $branding}}
             default_type 'application/json';
             return 200 '{
-                productName: "{{ $branding.productName }}",
-                footerHTML: "{{ $branding.footerHTML }}",
-                primaryAccentColor: "{{ $branding.primaryAccentColor }}",
-                fullLogoAltText: "{{ $branding.fullLogoAltText }}",
-                squareLogoAltText: "{{ $branding.squareLogoAltText }}"
+               "productName": "{{ $branding.productName }}",
+                "footerHTML": "{{ $branding.footerHTML }}",
+                "primaryAccentColor": "{{ $branding.primaryAccentColor }}",
+                "fullLogoAltText": "{{ $branding.fullLogoAltText }}",
+                "squareLogoAltText": "{{ $branding.squareLogoAltText }}"
             }';
             {{- else }}            
             return 404;

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -567,17 +567,19 @@ data:
             {{- end}}
         }
 
+        {{- $fullLogoExt := default "not-found" (((.Values.kubecostProductConfigs).branding).fullLogoExt)}}
         location /custom-branding/full-logo {
-            {{- if .Values.kubecostProductConfigs.branding.fullLogoExt }}
-                try_files /static/templated-full-logo.{{.Values.kubecostProductConfigs.branding.fullLogoExt}} =404;
+            {{- if ne $fullLogoExt "not-found" }}
+                try_files /static/templated-full-logo.{{$fullLogoExt}} =404;
             {{- else }}
                 return 404;
             {{- end }}
         }
 
+        {{- $squareLogoExt := default "not-found" (((.Values.kubecostProductConfigs).branding).squareLogoExt)}}
         location /custom-branding/square-logo {
-            {{- if .Values.kubecostProductConfigs.branding.squareLogoExt }}
-                try_files /static/templated-full-logo.{{.Values.kubecostProductConfigs.branding.squareLogoExt}} =404;
+            {{- if  ne $squareLogoExt "not-found"}}
+                try_files /static/templated-full-logo.{{$squareLogoExt}} =404;
             {{- else }}
                 return 404;
             {{- end }}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -566,28 +566,6 @@ data:
             return 404;
             {{- end}}
         }
-
-        location /custom-branding/full-logo {
-            {{- if $branding.fullLogoSrc }}
-            proxy_pass {{ $branding.fullLogoSrc }};
-            {{- else if $branding.fullLogoDataURI }}
-            default_type {{$branding.fullLogoContentType }};
-            return 200 "{{$branding.fullLogoDataURI}}";
-            {{- else }}
-            return 404;
-            {{- end }}
-        }
-
-        location /custom-branding/square-logo {
-            {{- if $branding.squareLogoSrc }}
-            proxy_pass {{ $branding.squareLogoSrc }};
-            {{- else if $branding.squareLogoDataURI }}
-            default_type {{$branding.squareLogoContentType }};
-            return 200 "{{$branding.squareLogoDataURI}}";
-            {{- else }}
-            return 404;
-            {{- end }}
-        }
     }
 {{- end }}
 {{- end }}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -552,6 +552,42 @@ data:
                 }
             }';
         }
+
+        # Branding Routes
+        {{- $branding := .Values.kubecostProductConfigs.branding}}
+        location /custom-branding/info {
+            {{- if $branding}}
+            default_type 'application/json';
+            return 200 '{
+                fullLogoAltText: "{{ $branding.fullLogoAltText}}",
+                squareLogoAltText: "{{ $branding.squareLogoAltText}}"
+            }';
+            {{- else }}            
+            return 404;
+            {{- end}}
+        }
+
+        location /custom-branding/full-logo {
+            {{- if $branding.fullLogoSrc }}
+            proxy_pass {{ $branding.fullLogoSrc }};
+            {{- else if $branding.fullLogoDataURI }}
+            default_type {{$branding.fullLogoContentType }};
+            return 200 "{{$branding.fullLogoDataURI}}";
+            {{- else }}
+            return 404;
+            {{- end }}
+        }
+
+        location /custom-branding/square-logo {
+            {{- if $branding.squareLogoSrc }}
+            proxy_pass {{ $branding.squareLogoSrc }};
+            {{- else if $branding.squareLogoDataURI }}
+            default_type {{$branding.squareLogoContentType }};
+            return 200 "{{$branding.squareLogoDataURI}}";
+            {{- else }}
+            return 404;
+            {{- end }}
+        }
     }
 {{- end }}
 {{- end }}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -566,6 +566,22 @@ data:
             return 404;
             {{- end}}
         }
+
+        location /custom-branding/full-logo {
+            {{- if .Values.kubecostProductConfigs.branding.fullLogoExt }}
+                try_files /static/templated-full-logo.{{.Values.kubecostProductConfigs.branding.fullLogoExt}} =404;
+            {{- else }}
+                return 404;
+            {{- end }}
+        }
+
+        location /custom-branding/square-logo {
+            {{- if .Values.kubecostProductConfigs.branding.squareLogoExt }}
+                try_files /static/templated-full-logo.{{.Values.kubecostProductConfigs.branding.squareLogoExt}} =404;
+            {{- else }}
+                return 404;
+            {{- end }}
+        }
     }
 {{- end }}
 {{- end }}

--- a/kubecost/templates/frontend/frontend-deployment.yaml
+++ b/kubecost/templates/frontend/frontend-deployment.yaml
@@ -99,7 +99,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- if .Values.kubecostProductConfigs.branding }}
+        {{- if (.Values.kubecostProductConfigs).branding }}
         - name: custom-branding
           configMap:
             name: frontend-logo-{{.Release.Name}}
@@ -147,12 +147,12 @@ spec:
               mountPath: /etc/ssl/certs
             {{- end }}
             {{- end }}
-            {{- if .Values.kubecostProductConfigs.branding.fullLogoExt }}
+            {{- if ((.Values.kubecostProductConfigs).branding).fullLogoExt }}
             - name: custom-branding
               mountPath: /var/www/static/templated-full-logo.{{.Values.kubecostProductConfigs.branding.fullLogoExt}}
               subPath: fullLogo
             {{- end }}
-            {{- if .Values.kubecostProductConfigs.branding.squareLogoExt }}
+            {{- if ((.Values.kubecostProductConfigs).branding).squareLogoExt }}
             - name: custom-branding
               mountPath: /var/www/static/templated-square-logo.{{.Values.kubecostProductConfigs.branding.squareLogoExt}}
               subPath: squareLogo

--- a/kubecost/templates/frontend/frontend-deployment.yaml
+++ b/kubecost/templates/frontend/frontend-deployment.yaml
@@ -99,7 +99,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{ - if .Values.kubecostProductConfigs.branding }}
+        {{- if .Values.kubecostProductConfigs.branding }}
         - name: custom-branding
           configMap:
             name: frontend-logo-{{.Release.Name}}
@@ -147,12 +147,14 @@ spec:
               mountPath: /etc/ssl/certs
             {{- end }}
             {{- end }}
-            {{- if .Values.kubecostProductConfigs.branding }}
+            {{- if .Values.kubecostProductConfigs.branding.fullLogoExt }}
             - name: custom-branding
-              mountPath: /var/www/static/templated-full-logo
+              mountPath: /var/www/static/templated-full-logo.{{.Values.kubecostProductConfigs.branding.fullLogoExt}}
               subPath: fullLogo
+            {{- end }}
+            {{- if .Values.kubecostProductConfigs.branding.squareLogoExt }}
             - name: custom-branding
-              mountPath: /var/www/static/templated-square-logo
+              mountPath: /var/www/static/templated-square-logo.{{.Values.kubecostProductConfigs.branding.squareLogoExt}}
               subPath: squareLogo
             {{- end }}
           resources:

--- a/kubecost/templates/frontend/frontend-deployment.yaml
+++ b/kubecost/templates/frontend/frontend-deployment.yaml
@@ -99,6 +99,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{ - if .Values.kubecostProductConfigs.branding }}
+        - name: custom-branding
+          configMap:
+            name: frontend-logo-{{.Release.Name}}
+        {{- end }}
       containers:
         - name: frontend
           image: {{ include "kubecost.frontend.image" . }}
@@ -141,6 +146,14 @@ spec:
             - name: tls
               mountPath: /etc/ssl/certs
             {{- end }}
+            {{- end }}
+            {{- if .Values.kubecostProductConfigs.branding }}
+            - name: custom-branding
+              mountPath: /var/www/static/templated-full-logo
+              subPath: fullLogo
+            - name: custom-branding
+              mountPath: /var/www/static/templated-square-logo
+              subPath: squareLogo
             {{- end }}
           resources:
           {{- toYaml .Values.frontend.resources | nindent 12 }}

--- a/kubecost/templates/frontend/frontend-deployment.yaml
+++ b/kubecost/templates/frontend/frontend-deployment.yaml
@@ -102,7 +102,7 @@ spec:
         {{- if (.Values.kubecostProductConfigs).branding }}
         - name: custom-branding
           configMap:
-            name: frontend-logo-{{.Release.Name}}
+            name: {{ template "kubecost.frontend.logoConfigMapName" . }}
         {{- end }}
       containers:
         - name: frontend

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1404,17 +1404,17 @@ kubecostProductConfigs:
 #     GCP: []
 #     Azure: []
 
-  # Customize the branding, the UI will only honor these values for enterprise licenses
+  # Customize the branding, the UI will only honor these values for custom enterprise licenses
   # branding:
   #   productName: "" # Name to use to refer to the product in messaging
   #   footerHTML: "" # HTML to use on the footer
   #   primaryAccentColor: "" # Needs to be legible on #ffffff and #343434 backgrounds
-  #   fullLogoAltText: ""
-  #   fullLogoExt: ""
-  #   fullLogoBase64: ""
-  #   squareLogoAltText: ""
-  #   squareLogoExt: ""
-  #   squareLogoBase64: ""
+  #   fullLogoBase64: "" # base64 encoded binary asset to use as the full logo, used in the nav bar when the nav is expanded
+  #   fullLogoExt: "" # the extension of the full logo
+  #   fullLogoAltText: "" # alt text to apply to the img tags for the full logo
+  #   squareLogoBase64: "" # base64 encoded binary asset to use for the square logo, used in the collapsed nav as well as empty and loading states
+  #   squareLogoExt: "" # the extension of the square logo
+  #   squareLogoAltText: "" # alt text to apply to the img tags for the square logo
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1404,6 +1404,16 @@ kubecostProductConfigs:
 #     GCP: []
 #     Azure: []
 
+  # branding:
+    # fullLogoAltText: ""
+    # fullLogoSrc: ""
+    # fullLogoDataURI: ""
+    # fullLogoContentType: ""
+    # squareLogoAltText: ""
+    # squareLogoSrc: ""
+    # squareLogoDataURI: ""
+    # squareLogoContentType: ""
+
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates
 extraObjects: []

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1405,6 +1405,8 @@ kubecostProductConfigs:
 #     Azure: []
 
   # branding:
+  #   productName: "" # Name to use to refer to the product in messaging
+  #   primaryAccentColor: "" # Needs to be legible on #ffffff and #343434 backgrounds
   #   fullLogoAltText: ""
   #   fullLogoExt: ""
   #   fullLogoBase64: ""

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1404,6 +1404,7 @@ kubecostProductConfigs:
 #     GCP: []
 #     Azure: []
 
+  # Customize the branding, the UI will only honor these values for enterprise licenses
   # branding:
   #   productName: "" # Name to use to refer to the product in messaging
   #   primaryAccentColor: "" # Needs to be legible on #ffffff and #343434 backgrounds

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1405,14 +1405,12 @@ kubecostProductConfigs:
 #     Azure: []
 
   # branding:
-    # fullLogoAltText: ""
-    # fullLogoSrc: ""
-    # fullLogoDataURI: ""
-    # fullLogoContentType: ""
-    # squareLogoAltText: ""
-    # squareLogoSrc: ""
-    # squareLogoDataURI: ""
-    # squareLogoContentType: ""
+  #   fullLogoAltText: ""
+  #   fullLogoExt: ""
+  #   fullLogoBase64: ""
+  #   squareLogoAltText: ""
+  #   squareLogoExt: ""
+  #   squareLogoBase64: ""
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1407,6 +1407,7 @@ kubecostProductConfigs:
   # Customize the branding, the UI will only honor these values for enterprise licenses
   # branding:
   #   productName: "" # Name to use to refer to the product in messaging
+  #   footerHTML: "" # HTML to use on the footer
   #   primaryAccentColor: "" # Needs to be legible on #ffffff and #343434 backgrounds
   #   fullLogoAltText: ""
   #   fullLogoExt: ""


### PR DESCRIPTION
## Release Notes Headline

Add the ability for enterprise customers to add custom branding assets

## Commentary for Reviewers

This exposes the ability to any customer to add the assets, but the FE piece of this is only looking for custom branding if there is an enterprise license.

## Links to Issues or Tickets

- [CLDYCON-6248
](https://apptio.atlassian.net/browse/CLDYCON-6248)

## User Impact and Risks

Including the custom assets as base64 strings in the config map, potentially could reach size limits

## Testing

Manually installed the helm chart with various custom values to ensure all the states work as expected

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
