### PR TITLE
Update basicHealth image to remove critical CVEs present in alpine/k8s

### DIFF
--- a/.github/workflows/test-chart-3.0.yml
+++ b/.github/workflows/test-chart-3.0.yml
@@ -8,9 +8,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
   # Uncomment this if you need to actively test this workflow from a PR draft
-  pull_request:
-    branches:
-      - develop
+  # pull_request:
+  #   branches:
+  #     - develop
 
 # Prevents multiple runs of the same workflow on the same branch from executing 
 # simultaneously. Saves resources.

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1430,5 +1430,5 @@ extraObjects: []
 # -- Optional override for the image used for the basic health test container
 basicHealth:
   registry: docker.io
-  repository: alpine/k8s
-  tag: 1.34.1
+  repository: alpine/curl
+  tag: 8.14.1


### PR DESCRIPTION
## Release Notes Headline
Update basicHealth image to remove critical CVEs present in alpine/k8s

## Commentary for Reviewers
* alpine/k8s had almost 5 critical CVEs present.
* Basic healht pod only needed curl command
* alpine/curl 8.14.1 has 0 vuln

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Trivy scan gives us
```sh
┌────────────────────────────────────┬────────┬─────────────────┬─────────┐
│               Target               │  Type  │ Vulnerabilities │ Secrets │
├────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ alpine/curl:8.14.1 (alpine 3.22.2) │ alpine │        0        │    -    │
└────────────────────────────────────┴────────┴─────────────────┴─────────┘
```

using `alpine/curl` image the basic-health test works fine:
<img width="630" height="38" alt="Screenshot 2025-10-13 at 3 12 49 AM" src="https://github.com/user-attachments/assets/c12c484c-8378-44fb-afcf-a0724b65f55b" />
with valid logs
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
