### PR TITLE
[KCM-4760] Cluster Controller: Add ResourceQuotas in ClusterRole

### DIFF
--- a/kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
@@ -64,4 +64,9 @@ rules:
     resources: ['*']
     verbs: ['list', 'get', 'delete']
   {{- end }}
+  {{- if .Values.clusterController.rbac.resourceQuotaRightSizing }}
+  - apiGroups: [ '' ]
+    resources: [ 'resourcequotas' ]
+    verbs: [ 'get', 'create', 'patch' ]
+  {{- end }}
 {{- end }}

--- a/kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
@@ -67,6 +67,6 @@ rules:
   {{- if .Values.clusterController.rbac.resourceQuotaRightSizing }}
   - apiGroups: [ '' ]
     resources: [ 'resourcequotas' ]
-    verbs: [ 'get', 'create', 'patch' ]
+    verbs: [ 'get', 'list', 'create', 'patch' ]
   {{- end }}
 {{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1224,8 +1224,9 @@ clusterController:
   #       }
 
   rbac:
-    # In 3.x, only containerRequestRightSizing is supported, all other features are in progress.
+    # In 3.x, only containerRequestRightSizing and resourceQuotaRightSizing are supported, all other features are in progress.
     containerRequestRightSizing: true
+    resourceQuotaRightSizing: true
     clusterRightSizing: false
     clusterTurndown: false
     namespaceTurndown: false


### PR DESCRIPTION
## Release Notes Headline
Allow cluster controller to operate on ResourceQuotas.

## Commentary for Reviewers
Add new flag `.Values.clusterController.rbac.resourceQuotaRightSizing`, use in enabling get/create/patch ops on ResourceQuotas in the ClusterRole bound to the cluster controller.

## Links to Issues or Tickets

Closes https://apptio.atlassian.net/browse/KCM-4760

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A
