### PR TITLE
Fix System Proxy in Manifests

### DIFF
--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -382,19 +382,19 @@ enabled only version to the output .r
 
 {{- define "common.systemProxy" -}}
 {{- if .Values.systemProxy.enabled }}
-    - name: HTTP_PROXY
-      value: {{ .Values.systemProxy.httpProxyUrl }}
-    - name: http_proxy
-      value: {{ .Values.systemProxy.httpProxyUrl }}
-    - name: HTTPS_PROXY
-      value: {{ .Values.systemProxy.httpsProxyUrl }}
-    - name: https_proxy
-      value: {{ .Values.systemProxy.httpsProxyUrl }}
-    - name: NO_PROXY
-      value: {{ .Values.systemProxy.noProxy }}
-    - name: no_proxy
-      value: {{ .Values.systemProxy.noProxy }}
-    {{- end }}
+- name: HTTP_PROXY
+  value: {{ .Values.systemProxy.httpProxyUrl }}
+- name: http_proxy
+  value: {{ .Values.systemProxy.httpProxyUrl }}
+- name: HTTPS_PROXY
+  value: {{ .Values.systemProxy.httpsProxyUrl }}
+- name: https_proxy
+  value: {{ .Values.systemProxy.httpsProxyUrl }}
+- name: NO_PROXY
+  value: {{ .Values.systemProxy.noProxy }}
+- name: no_proxy
+  value: {{ .Values.systemProxy.noProxy }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -484,7 +484,7 @@ spec:
             {{- end }}
             - name: READ_ONLY
               value: {{ (quote .Values.readonly) | default (quote false) }}
-            {{- include "common.systemProxy" . }}
+            {{- include "common.systemProxy" . | nindent 12 }}
             {{- if ((.Values.kubecostProductConfigs).carbonEstimates) }}
             - name: CARBON_ESTIMATES_ENABLED
               value: "true"

--- a/kubecost/templates/local-store/cluster-storage-deployment.yaml
+++ b/kubecost/templates/local-store/cluster-storage-deployment.yaml
@@ -114,7 +114,7 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- include "common.systemProxy" . }}
+            {{- include "common.systemProxy" . | indent 12 }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- range $.Values.imagePullSecrets }}


### PR DESCRIPTION
## Release Notes Headline

When `.Values.systemProxy.enabled=true`, the cloud-costs, local-store, and aggregator k8s manifests do not render because the Go template `common.systemProxy` adds extra indentation, and the manifests do not appropriately handle the indentation.

## Commentary for Reviewers

See incorrect manifests below

Aggregator Statefulset
```
[...]
            - name: READ_ONLY
              value: "false"
    - name: HTTP_PROXY
      value: "http://hunter.test:8080"
    - name: http_proxy
      value: "http://hunter.test:8080"
    - name: HTTPS_PROXY
      value: "http://hunter.test:8080"
    - name: https_proxy
      value: "http://hunter.test:8080"
    - name: NO_PROXY
      value: "local,cluster,svc,kube-system,monitoring,10.0.0.0/7,100.53.0.0/14,172.0.1.0/16,amazoncognito.com"
    - name: no_proxy
      value: "local,cluster,svc,kube-system,monitoring,10.0.0.0/7,100.53.0.0/14,172.0.1.0/16,amazoncognito.com"
            - name: CUSTOM_COST_ENABLED
              value: "false"
[...]
```

Cloud Costs
```
[...]
            - name: CUSTOM_COST_ENABLED
              value: "false"

                - name: HTTP_PROXY
                  value: "http://hunter.test:8080"
                - name: http_proxy
                  value: "http://hunter.test:8080"
                - name: HTTPS_PROXY
                  value: "http://hunter.test:8080"
                - name: https_proxy
                  value: "http://hunter.test:8080"
                - name: NO_PROXY
                  value: "local,cluster,svc,kube-system,monitoring,10.0.0.0/7,100.53.0.0/14,172.0.1.0/16,amazoncognito.com"
                - name: no_proxy
                  value: "local,cluster,svc,kube-system,monitoring,10.0.0.0/7,100.53.0.0/14,172.0.1.0/16,amazoncognito.com"
```


## Links to Issues or Tickets

Addresses a few issues oberserved in the field

## User Impact and Risks

Unable to install Kubecost 3.0 with `.Values.systemProxy.enabled=true`
## Testing

values.yaml: systemProxy settings
```
systemProxy:
   enabled: true
   httpProxyUrl: "http://hunter.test:8080"
   httpsProxyUrl: "http://hunter.test:8080"
   noProxy: "local,cluster,svc,kube-system,monitoring,10.0.0.0/7,100.53.0.0/14,172.0.1.0/16,amazoncognito.com"
```

Successful Helm template validation (must have federated-store secret in a k8s namespace called Kubecost)
```
helm template . --namespace kubecost --values values.yaml --validate --dryrun=server 
```
`--validate` instructs Helm to compare these rendered manifests against the Kubernetes OpenAPI schema. This schema defines the structure and valid fields for all Kubernetes resource types (e.g., Deployments, Services, Pods). If it passes validation, the manifest will deploy.

[manifest.yaml](https://github.com/user-attachments/files/23099177/manifest.yaml)
