### PR TITLE
fix healthz logs

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -124,7 +124,11 @@ data:
         location = /custom_504.html {
             internal;
         }
-
+        location /healthz {
+            add_header 'Content-Type' 'text/plain';
+            return 200 "healthy\n";
+            access_log off;
+        }
 {{- if or .Values.saml.enabled .Values.oidc.enabled }}
 
         add_header Cache-Control "max-age=0";
@@ -139,12 +143,6 @@ data:
             try_files $uri $uri/ /index.html;
         }
         
-        # need to be served outside of the auth middleware
-        location /healthz {
-            add_header 'Content-Type' 'text/plain';
-            return 200 "healthy\n";
-            access_log off;
-        }
         location = /teamsError.html { }
         location = /images/kubecost-logo.svg { }
 

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -124,11 +124,13 @@ data:
         location = /custom_504.html {
             internal;
         }
+        # Needs to be served outside of the auth middleware
         location /healthz {
             add_header 'Content-Type' 'text/plain';
             return 200 "healthy\n";
             access_log off;
         }
+
 {{- if or .Values.saml.enabled .Values.oidc.enabled }}
 
         add_header Cache-Control "max-age=0";


### PR DESCRIPTION
## Release Notes Headline

disabled healthz logs

The frontend healthz endpoint needs to be outside the saml block.

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

less logs, no impact

## Testing

```
k exec -it deployments/saml-okta-frontend -- curl 0:9090/healthz
healthy
```

## Documentation Updates
NA