### PR TITLE
add a config to switch to the IBM font

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -559,9 +559,10 @@ data:
             {{- if $branding}}
             default_type 'application/json';
             return 200 '{
-               "productName": "{{ $branding.productName }}",
+                "productName": "{{ $branding.productName }}",
                 "footerHTML": "{{ $branding.footerHTML }}",
                 "primaryAccentColor": "{{ $branding.primaryAccentColor }}",
+                "font": "{{ $branding.font }}"
                 "fullLogoAltText": "{{ $branding.fullLogoAltText }}",
                 "squareLogoAltText": "{{ $branding.squareLogoAltText }}"
             }';

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1424,6 +1424,7 @@ kubecostProductConfigs:
   #   productName: "" # Name to use to refer to the product in messaging
   #   footerHTML: "" # HTML to use on the footer
   #   primaryAccentColor: "" # Needs to be legible on #ffffff and #343434 backgrounds
+  #   font: "" # Either not set or set to 'ibm'
   #   fullLogoBase64: "" # base64 encoded binary asset to use as the full logo, used in the nav bar when the nav is expanded
   #   fullLogoExt: "" # the extension of the full logo
   #   fullLogoAltText: "" # alt text to apply to the img tags for the full logo


### PR DESCRIPTION
## Release Notes Headline

Expand custom branding options to include switching to IBM's Plex font

## Commentary for Reviewers

Add a branding option to switch the UI to IBM Plex font.

## Links to Issues or Tickets

N/A

## User Impact and Risks

Possibly confusing since you have to have a special license to take advantage of custom branding.

## Testing

Deployed to my namespace with a custom FE image built to handle switching fonts

## Documentation Updates

