### PR TITLE
v2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ There are no new features in v2.9 compared to v2.8 other than the addition of a 
  
 See [./examples](./examples) for more information on how to use this version.
 
+All agents must run version 2.9 for at least 2 days before upgrading to v3.0.
+
+Of note, the Kubecost 3.0 chart is stored in a different repo than 2.x. To install version 2.9, you will need to use the 2.x legacy chart location.
+
+```sh
+helm upgrade kubecost -n kubecost \
+  --repo https://kubecost.github.io/cost-analyzer/ cost-analyzer
+  -f new-2.9x-values.yaml
+```
+
+
 ## Version Support
 
 Kubecost strives to support as many versions of Kubernetes as possible. Below is the version support matrix which has been tested. Versions outside of the stated range may still work but are untested.

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "2.9.0-rc.0"
+appVersion: "2.9.0"
 description: Kubecost Helm chart - monitor your cloud costs!
 name: cost-analyzer
-version: "2.9.0-rc.0"
+version: "2.9.0"
 icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
 annotations:
   "artifacthub.io/links": |

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1631,7 +1631,7 @@ data:
                 "carbonEstimatesEnabled": "{{ template "carbonEstimatesEnabled" . }}",
                 "clusterControllerEnabled": "{{ template "clusterControllerEnabled" . }}",
                 "forecastingEnabled": "{{ template "forecastingEnabled" . }}",
-                "chartVersion": "2.9.0-rc.0",
+                "chartVersion": "2.9.0",
                 "hourlyDataRetention": "{{ (.Values.kubecostAggregator.etlHourlyStoreDurationHours) }}",
                 "dailyDataRetention": "{{ (.Values.kubecostAggregator.etlDailyStoreDurationDays) }}",
                 "hideDiagnostics": "{{ default false ((.Values.kubecostProductConfigs).hideDiagnostics) }}",


### PR DESCRIPTION
## Release Notes Headline

This release is designed to facilitate seamless upgrades to v3.0. A federated storage configuration is required when installing v2.9.

There are no new features in v2.9 compared to v2.8- other than the addition of a finops-agent container that will begin collecting metrics in preparation for a seamless upgrade to 3.0.
 
See <https://github.com/kubecost/kubecost/tree/v2.9/examples> for more information on how to use this version.

Image bumps, (will also be updated in 2.8.5):
network-costs v0.17.11 > v0.18.0
prometheus v3.6.0 > v3.7.2
grafana v12.2.0 >v12.2.1

## Minor changes

2.9.0 also fixes an issue with the grafana sidecar crashloop, which will be fixed in 2.8.5 as well.

Network costs was bumped to eliminate a high CVE. It also introduces new functionality that is disabled by default: https://github.com/kubecost/kubecost/pull/4330

## Known issues

The settings page will display a version mismatch due to the frontend version 2.8.4. This is purely cosmetic.


## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
