### PR TITLE
2.8.5 image bumps and grafana fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .dist
 .manifest
 .kubeconfig
+temp/

--- a/cost-analyzer/templates/grafana/grafana-deployment.yaml
+++ b/cost-analyzer/templates/grafana/grafana-deployment.yaml
@@ -113,6 +113,8 @@ spec:
           volumeMounts:
             - name: sc-dashboard-volume
               mountPath: {{ .Values.grafana.sidecar.dashboards.folder | quote }}
+            - name: tmp
+              mountPath: /tmp
       {{- end}}
       {{- if .Values.grafana.sidecar.datasources.enabled }}
         - name: {{ template "grafana.name" . }}-sc-datasources
@@ -247,6 +249,8 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: {{ template "grafana.fullname" . }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -916,7 +916,7 @@ prometheus:
       rollingUpdate: null
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v3.6.0
+      tag: v3.7.2
       pullPolicy: IfNotPresent
     priorityClassName: ""
     prefixURL: ""
@@ -1445,7 +1445,7 @@ networkCosts:
   enabled: false
   image:
     repository: gcr.io/kubecost1/kubecost-network-costs
-    tag: v0.17.11
+    tag: v0.18.0
   imagePullPolicy: IfNotPresent
   updateStrategy:
     type: RollingUpdate
@@ -2103,7 +2103,7 @@ grafana:
     failureThreshold: 10
   image:
     repository: grafana/grafana
-    tag: 12.2.0
+    tag: 12.2.1
     pullPolicy: IfNotPresent
     # pullSecrets:
   securityContext: {}


### PR DESCRIPTION
## v2.8.5

Kubecost 2.8.5 is a minor patch with the following changes:

Image bumps, (will also be updated in 2.8.5):
network-costs v0.17.11 > v0.18.0
prometheus v3.6.0 > v3.7.2
grafana v12.2.0 >v12.2.1

Fixes an issue with the grafana sidecar crashloop

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
