### PR TITLE
2x-finops-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ While the below versions may work with the given versions of Kubernetes, Kubecos
 | 2.4                            | 1.22           | 1.31           |
 | 2.5                            | 1.22           | 1.32           |
 | 2.6                            | 1.22           | 1.32           |
-| 2.8                            | 1.30           | 1.34           |
-| 2.9                            | 1.30           | 1.34           |
+| 2.8                            | 1.22           | 1.34           |
+| 2.9                            | 1.29           | 1.34           |
 
 ## Installation
 

--- a/cost-analyzer/Chart.lock
+++ b/cost-analyzer/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
   version: 1.0.3
-digest: sha256:c5fc7c9e84f58dddbd7c61f66afbb7282a02a88ad5789ba34b5398ca3d882842
-generated: "2025-10-27T16:20:38.900925-04:00"
+digest: sha256:92ed1309631e401815bdd703774dde6033a9617598fa771d0ed4e859f0704609
+generated: "2025-10-28T12:54:30.306319-04:00"

--- a/cost-analyzer/Chart.lock
+++ b/cost-analyzer/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
   version: 1.0.3
-digest: sha256:25a0eb3f2d063493c5dbe845c5a0857d5a4226b64a8e1ede3a6fe8d4b60ecf5b
-generated: "2025-10-24T15:20:50.131541-04:00"
+digest: sha256:c5fc7c9e84f58dddbd7c61f66afbb7282a02a88ad5789ba34b5398ca3d882842
+generated: "2025-10-27T16:20:38.900925-04:00"

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -10,6 +10,7 @@ annotations:
       url: https://www.kubecost.com
 dependencies:
   - name: finops-agent
+    alias: finops-agent
     version: "v1.0.3"
     repository: https://kubecost.github.io/finops-agent-chart
-    condition: finopsAgent.enabled
+    condition: finopsagent.enabled

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -12,4 +12,4 @@ dependencies:
   - name: finops-agent
     version: "v1.0.3"
     repository: https://kubecost.github.io/finops-agent-chart
-    condition: finops-agent.enabled
+    condition: finopsAgent.enabled

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1647,6 +1647,9 @@ for more information
 {{- if ne ((((.Values.prometheus.server).global).external_labels).cluster_id) "cluster-one" }}
 {{- fail "\n\nKubecost 2.9.x is only used for preparing agents to upgrade to 3.0.\nIn kubecost 2.9, the location of the cluster_id configuration has changed.\n\nPlease set global.clusterId and remove .Values.prometheus.server.global.external_labels.cluster_id\nFor more information, see: https://github.com/kubecost/cost-analyzer/tree/v2.9/examples" }}
 {{- end -}}
+{{- if not (.Values.finopsAgent.enabled) -}}
+{{- fail "\n\nKubecost 2.9.x is only used for preparing agents to upgrade to 3.0.\nPlease set, finopsAgent.enabled=true" -}}
+{{- end -}}
 {{- if (.Values.kubecostModel.federatedStorageConfigSecret) -}}
 {{ fail "\n\nKubecost 2.9.x is only used for preparing agents to upgrade to 3.0.\nThis key is no longer used and must be removed: .Values.kubecostModel.federatedStorageConfigSecret\nFor more information, see: https://github.com/kubecost/cost-analyzer/tree/v2.9/examples" }}
 {{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1647,8 +1647,8 @@ for more information
 {{- if ne ((((.Values.prometheus.server).global).external_labels).cluster_id) "cluster-one" }}
 {{- fail "\n\nKubecost 2.9.x is only used for preparing agents to upgrade to 3.0.\nIn kubecost 2.9, the location of the cluster_id configuration has changed.\n\nPlease set global.clusterId and remove .Values.prometheus.server.global.external_labels.cluster_id\nFor more information, see: https://github.com/kubecost/cost-analyzer/tree/v2.9/examples" }}
 {{- end -}}
-{{- if not (.Values.finopsAgent.enabled) -}}
-{{- fail "\n\nKubecost 2.9.x is only used for preparing agents to upgrade to 3.0.\nPlease set, finopsAgent.enabled=true" -}}
+{{- if not (.Values.finopsagent.enabled) -}}
+{{- fail "\n\nKubecost 2.9.x is only used for preparing agents to upgrade to 3.0.\nPlease set, finopsagent.enabled=true" -}}
 {{- end -}}
 {{- if (.Values.kubecostModel.federatedStorageConfigSecret) -}}
 {{ fail "\n\nKubecost 2.9.x is only used for preparing agents to upgrade to 3.0.\nThis key is no longer used and must be removed: .Values.kubecostModel.federatedStorageConfigSecret\nFor more information, see: https://github.com/kubecost/cost-analyzer/tree/v2.9/examples" }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -368,9 +368,9 @@ global:
 upgrade:
   toV2: false
 
-finopsAgent:
+finopsagent:
   ## Kubecost 2.9 is intended to facilitate the upgrade to Kubecost 3.0.
-  ## When upgrading to Kubecost 2.9, the finopsAgent is enabled by default.
+  ## When upgrading to Kubecost 2.9, the finopsagent is enabled by default.
   ## This can be disabled if you are not upgrading the cluster to Kubecost 3.0 or do not mind losing a partial day of data.
   enabled: true
   serviceAccount:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -368,9 +368,9 @@ global:
 upgrade:
   toV2: false
 
-finops-agent:
+finopsAgent:
   ## Kubecost 2.9 is intended to facilitate the upgrade to Kubecost 3.0.
-  ## When upgrading to Kubecost 2.9, the finops-agent is enabled by default.
+  ## When upgrading to Kubecost 2.9, the finopsAgent is enabled by default.
   ## This can be disabled if you are not upgrading the cluster to Kubecost 3.0 or do not mind losing a partial day of data.
   enabled: true
   serviceAccount:

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ There are two values that will need to be modified before upgrading to 2.9, whic
 
 1. Move the old `prometheus.server.global.external_labels.cluster_id` to `global.clusterId`
 2. Move the federated storage configuration from the `kubecostModel` section to the `global` section.
-3. If your existing Kubecost deployment uses an assumed role (opposed to an IAM user/key), you will need to configure the finops-agent to use the existing service account. In the values provided, uncomment the `serviceAccount` and `finopsAgent` sections and set the `name` to the name of the service account used by the cost-analyzer pod.
+3. The finops agent will need to write and read access to the bucket. If your existing Kubecost deployment uses an assumed role (opposed to an IAM user/key), you will need to configure the finops-agent to use the existing service account. In the values provided, uncomment the `serviceAccount` and `finopsagent` sections and set the `name` to the name of the service account used by the cost-analyzer pod.
 ![upgrade-values-2.9](settings-migration.png)
 4. Upgrade to 2.9.x
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ There are two values that will need to be modified before upgrading to 2.9, whic
 
 1. Move the old `prometheus.server.global.external_labels.cluster_id` to `global.clusterId`
 2. Move the federated storage configuration from the `kubecostModel` section to the `global` section.
-3. If your existing Kubecost deployment uses an assumed role (opposed to an IAM user/key), you will need to configure the finops-agent to use the existing service account. In the values provided, uncomment the `serviceAccount` and `finops-agent` sections and set the `name` to the name of the service account used by the cost-analyzer pod.
+3. If your existing Kubecost deployment uses an assumed role (opposed to an IAM user/key), you will need to configure the finops-agent to use the existing service account. In the values provided, uncomment the `serviceAccount` and `finopsAgent` sections and set the `name` to the name of the service account used by the cost-analyzer pod.
 ![upgrade-values-2.9](settings-migration.png)
 4. Upgrade to 2.9.x
 

--- a/examples/helmValues-kubecost2.9-agent-only.yaml
+++ b/examples/helmValues-kubecost2.9-agent-only.yaml
@@ -16,12 +16,12 @@ global:
 
 ## When using assumed roles to access the bucket, the same service account that is used
 ## by the cost-analyzer pod can be used for the new finops-agent.
-## Below- note that serviceAccount and finopsAgent are top level keys (no space before them).
+## Below- note that serviceAccount and finopsagent are top level keys (no space before them).
 # serviceAccount:  ## used by cost-analyzer
 #   create: false
 #   name: ""  ## keep existing values
 #   annotations: {}  ## keep existing values
-# finopsAgent:  ## used by finopsAgent
+# finopsagent:  ## used by finopsagent
 #   serviceAccount:
 #     create: false
 #     name: ""

--- a/examples/helmValues-kubecost2.9-agent-only.yaml
+++ b/examples/helmValues-kubecost2.9-agent-only.yaml
@@ -16,12 +16,12 @@ global:
 
 ## When using assumed roles to access the bucket, the same service account that is used
 ## by the cost-analyzer pod can be used for the new finops-agent.
-## Below- note that serviceAccount and finops-agent are top level keys (no space before them).
+## Below- note that serviceAccount and finopsAgent are top level keys (no space before them).
 # serviceAccount:  ## used by cost-analyzer
 #   create: false
 #   name: ""  ## keep existing values
 #   annotations: {}  ## keep existing values
-# finops-agent:  ## used by finops-agent
+# finopsAgent:  ## used by finopsAgent
 #   serviceAccount:
 #     create: false
 #     name: ""


### PR DESCRIPTION
## Release Notes Headline

rename finops-agent to finopsagent.
https://github.com/kubecost/kubecost/pull/4381

## Commentary for Reviewers

I have tested locally. I'm not going to fix the chart tests because they would break anything we need in 2.8 patches

## Links to Issues or Tickets

[KCM-4761]
[KCM-4816]

## User Impact and Risks

Same as https://github.com/kubecost/kubecost/pull/4378

## Testing

valid results:
```
helm template test ~/git/kubecost/cost-analyzer \
  --set global.federatedStorage.existingSecret=federated-store \
  --set global.clusterId="test"
```
```
<chart yaml>
```

expected failures:
```
helm template temp ./cost-analyzer --set finopsagent.enabled=false
Error: execution error at (cost-analyzer/templates/NOTES.txt:2:4): 
```
```
Kubecost 2.9.x is only used for preparing agents to upgrade to 3.0.
Please set, finopsagent.enabled=true
```

```
helm template test ~/git/kubecost/cost-analyzer \
  --set global.federatedStorage.existingSecret=federated-store \
  --set global.clusterId=""
```
```Error: execution error at (cost-analyzer/charts/finops-agent/templates/deployment.yaml:161:25): 

clusterId is required. Please set .Values.global.clusterId
```
## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->


[KCM-4761]: https://apptio.atlassian.net/browse/KCM-4761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KCM-4816]: https://apptio.atlassian.net/browse/KCM-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ