### PR TITLE
remove hyphen from finops-agent helm key

### DIFF
--- a/examples/agentOnly/helmValues-kubecost-aws.yaml
+++ b/examples/agentOnly/helmValues-kubecost-aws.yaml
@@ -24,7 +24,7 @@ cloudCost:
   enabled: false
 forecasting:
   enabled: false
-finopsAgent:
+finopsagent:
   enabled: true
 localStore:
   enabled: false

--- a/examples/agentOnly/helmValues-kubecost-aws.yaml
+++ b/examples/agentOnly/helmValues-kubecost-aws.yaml
@@ -24,7 +24,7 @@ cloudCost:
   enabled: false
 forecasting:
   enabled: false
-finops-agent:
+finopsAgent:
   enabled: true
 localStore:
   enabled: false

--- a/examples/agentOnly/helmValues-kubecost-azure.yaml
+++ b/examples/agentOnly/helmValues-kubecost-azure.yaml
@@ -23,7 +23,7 @@ cloudCost:
   enabled: false
 forecasting:
   enabled: false
-finops-agent:
+finopsAgent:
   enabled: true
 localStore:
   enabled: false

--- a/examples/agentOnly/helmValues-kubecost-azure.yaml
+++ b/examples/agentOnly/helmValues-kubecost-azure.yaml
@@ -23,7 +23,7 @@ cloudCost:
   enabled: false
 forecasting:
   enabled: false
-finopsAgent:
+finopsagent:
   enabled: true
 localStore:
   enabled: false

--- a/examples/agentOnly/helmValues-kubecost-gcp.yaml
+++ b/examples/agentOnly/helmValues-kubecost-gcp.yaml
@@ -28,7 +28,7 @@ cloudCost:
   enabled: false
 forecasting:
   enabled: false
-finopsAgent:
+finopsagent:
   enabled: true
 localStore:
   enabled: false

--- a/examples/agentOnly/helmValues-kubecost-gcp.yaml
+++ b/examples/agentOnly/helmValues-kubecost-gcp.yaml
@@ -28,7 +28,7 @@ cloudCost:
   enabled: false
 forecasting:
   enabled: false
-finops-agent:
+finopsAgent:
   enabled: true
 localStore:
   enabled: false

--- a/examples/federatedStorage/helmValues-kubecost-primary.yaml
+++ b/examples/federatedStorage/helmValues-kubecost-primary.yaml
@@ -31,9 +31,9 @@ cloudCost:
   enabled: true
 forecasting:
   enabled: true
-## The finops-agent can be installed with the primary, or it can be disabled to allow for a global 
+## The finopsAgent can be installed with the primary, or it can be disabled to allow for a global 
 ## agent deployment that is consistent across all clusters.
-finops-agent:
+finopsAgent:
   enabled: true
 ## The localStore should be disabled when using federated storage as it is not used
 localStore:

--- a/examples/federatedStorage/helmValues-kubecost-primary.yaml
+++ b/examples/federatedStorage/helmValues-kubecost-primary.yaml
@@ -31,9 +31,9 @@ cloudCost:
   enabled: true
 forecasting:
   enabled: true
-## The finopsAgent can be installed with the primary, or it can be disabled to allow for a global 
+## The finopsagent can be installed with the primary, or it can be disabled to allow for a global 
 ## agent deployment that is consistent across all clusters.
-finopsAgent:
+finopsagent:
   enabled: true
 ## The localStore should be disabled when using federated storage as it is not used
 localStore:

--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
   version: 1.0.3
-digest: sha256:c5fc7c9e84f58dddbd7c61f66afbb7282a02a88ad5789ba34b5398ca3d882842
-generated: "2025-10-27T17:12:36.221125-04:00"
+digest: sha256:5987ec403bf0816393a3cccab4f99dbe8a8d6f8c5850f98dd0527fa66d53dc52
+generated: "2025-10-27T19:42:17.292784-04:00"

--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
   version: 1.0.3
-digest: sha256:5987ec403bf0816393a3cccab4f99dbe8a8d6f8c5850f98dd0527fa66d53dc52
-generated: "2025-10-27T19:42:17.292784-04:00"
+digest: sha256:7ae04fec2131ae6a789a8f0266d359aaed083993e6d1a12d9a997d5ecbac6909
+generated: "2025-10-28T08:36:24.884626-04:00"

--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
   version: 1.0.3
-digest: sha256:25a0eb3f2d063493c5dbe845c5a0857d5a4226b64a8e1ede3a6fe8d4b60ecf5b
-generated: "2025-10-24T03:18:34.432881+05:30"
+digest: sha256:c5fc7c9e84f58dddbd7c61f66afbb7282a02a88ad5789ba34b5398ca3d882842
+generated: "2025-10-27T17:12:36.221125-04:00"

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -12,4 +12,4 @@ dependencies:
   - name: finops-agent
     version: "v1.0.3"
     repository: https://kubecost.github.io/finops-agent-chart
-    condition: finops-agent.enabled
+    condition: finopsAgent.enabled

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -10,6 +10,7 @@ annotations:
       url: https://www.kubecost.com
 dependencies:
   - name: finops-agent
+    alias: finopsAgent
     version: "v1.0.3"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finopsAgent.enabled

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -10,7 +10,7 @@ annotations:
       url: https://www.kubecost.com
 dependencies:
   - name: finops-agent
-    alias: finopsAgent
+    alias: finopsagent
     version: "v1.0.3"
     repository: https://kubecost.github.io/finops-agent-chart
-    condition: finopsAgent.enabled
+    condition: finopsagent.enabled

--- a/kubecost/ci/aggregator-values.yaml
+++ b/kubecost/ci/aggregator-values.yaml
@@ -15,5 +15,5 @@ aggregator:
 cloudCost:
   enabled: true
   cloudIntegrationSecret: cloud-integration
-finops-agent:
+finopsAgent:
   enabled: false

--- a/kubecost/ci/aggregator-values.yaml
+++ b/kubecost/ci/aggregator-values.yaml
@@ -15,5 +15,5 @@ aggregator:
 cloudCost:
   enabled: true
   cloudIntegrationSecret: cloud-integration
-finopsAgent:
+finopsagent:
   enabled: false

--- a/kubecost/ci/federatedetl-primary-netcosts-values.yaml
+++ b/kubecost/ci/federatedetl-primary-netcosts-values.yaml
@@ -22,5 +22,5 @@ aggregator:
     requests:
       cpu: 500m
       memory: 2Gi
-finops-agent:
+finopsAgent:
   enabled: false

--- a/kubecost/ci/federatedetl-primary-netcosts-values.yaml
+++ b/kubecost/ci/federatedetl-primary-netcosts-values.yaml
@@ -22,5 +22,5 @@ aggregator:
     requests:
       cpu: 500m
       memory: 2Gi
-finopsAgent:
+finopsagent:
   enabled: false

--- a/kubecost/ci/statefulsets-cc.yaml
+++ b/kubecost/ci/statefulsets-cc.yaml
@@ -26,6 +26,6 @@ clusterController:
         start: "2034-02-09T00:00:00Z"
         end: "2034-02-09T01:00:00Z"
         repeat: none
-finopsAgent:
+finopsagent:
   enabled: false
 

--- a/kubecost/ci/statefulsets-cc.yaml
+++ b/kubecost/ci/statefulsets-cc.yaml
@@ -26,6 +26,6 @@ clusterController:
         start: "2034-02-09T00:00:00Z"
         end: "2034-02-09T01:00:00Z"
         repeat: none
-finops-agent:
+finopsAgent:
   enabled: false
-  clusterId: cluster-one
+

--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -8,6 +8,7 @@
 {{- include "kubecost.caCertsSecretConfig.check" . -}}
 {{- include "kubecost.actionsStorageSourceCheck" . -}}
 {{- include "kubecost.localStoreClusterIdCheck" . -}}
+{{- include "kubecost.finopsAgentCheck" . -}}
 ================================================================================
 KUBECOST INSTALLATION SUCCESSFUL
 ================================================================================

--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -8,7 +8,7 @@
 {{- include "kubecost.caCertsSecretConfig.check" . -}}
 {{- include "kubecost.actionsStorageSourceCheck" . -}}
 {{- include "kubecost.localStoreClusterIdCheck" . -}}
-{{- include "kubecost.finopsAgentCheck" . -}}
+{{- include "kubecost.finopsagentCheck" . -}}
 ================================================================================
 KUBECOST INSTALLATION SUCCESSFUL
 ================================================================================

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -594,3 +594,13 @@ NOTE: added kubecostModel for backward compatibility
 {{ printf "\n\nWARNING: The clusterId is set to the default value of 'cluster-one'. This is not recommended if you intend to use multi-cluster federation in the future. Please set a globally unique .Values.global.clusterId\n\n" }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Prior to kubecost 3.0.3, the finops-agent had a hyphen. It was removed in 3.0.3.
+This will block upgrades until the new value is used, which very few would have changed.
+*/}}
+{{- define "kubecost.finopsAgentCheck" -}}
+{{- if index .Values "finops-agent" }}
+  {{ fail "\nThe helm values for finops-agent have been updated.\nPlease change the finops-agent: key in your helm values to finopsAgent:" }}
+{{- end -}}
+{{- end -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -17,13 +17,13 @@ Kubecost 3.0 preconditions
     {{ fail "`.Values.kubecostModel.federatedStorageConfigSecret` is no longer supported. Please use `.Values.global.federatedStorage.existingSecret` instead." }}
   {{- end -}}
   {{- if (.Values.federatedETL).federatedCluster -}}
-    {{ fail "`.Values.federatedETL.federatedCluster` is no longer supported. Please use `.Values.finops-agent.enabled=true` instead if you want to push this cluster's metrics to the federated storage." }}
+    {{ fail "`.Values.federatedETL.federatedCluster` is no longer supported. Please use `.Values.finopsAgent.enabled=true` instead if you want to push this cluster's metrics to the federated storage." }}
   {{- end -}}
   {{- if (.Values.federatedETL).agentOnly -}}
     {{ fail "`.Values.federatedETL.agentOnly` is no longer supported. Please use `.Values.aggregator.enabled=false` instead. You may also choose to disable the frontend, cloudcost, and forecasting components." }}
   {{- end -}}
   {{- if (.Values.federatedETL).readOnlyPrimary -}}
-    {{ fail "`.Values.federatedETL.readOnlyPrimary` is no longer supported. Please use `.Values.finops-agent.enabled=false` instead if you don't want to push this cluster's metrics to the federated storage." }}
+    {{ fail "`.Values.federatedETL.readOnlyPrimary` is no longer supported. Please use `.Values.finopsAgent.enabled=false` instead if you don't want to push this cluster's metrics to the federated storage." }}
   {{- end -}}
   {{- if .Values.federatedETL -}}
     {{ fail "`.Values.federatedETL` is no longer supported. Please remove this configuration." }}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -17,13 +17,13 @@ Kubecost 3.0 preconditions
     {{ fail "`.Values.kubecostModel.federatedStorageConfigSecret` is no longer supported. Please use `.Values.global.federatedStorage.existingSecret` instead." }}
   {{- end -}}
   {{- if (.Values.federatedETL).federatedCluster -}}
-    {{ fail "`.Values.federatedETL.federatedCluster` is no longer supported. Please use `.Values.finopsAgent.enabled=true` instead if you want to push this cluster's metrics to the federated storage." }}
+    {{ fail "`.Values.federatedETL.federatedCluster` is no longer supported. Please use `.Values.finopsagent.enabled=true` instead if you want to push this cluster's metrics to the federated storage." }}
   {{- end -}}
   {{- if (.Values.federatedETL).agentOnly -}}
     {{ fail "`.Values.federatedETL.agentOnly` is no longer supported. Please use `.Values.aggregator.enabled=false` instead. You may also choose to disable the frontend, cloudcost, and forecasting components." }}
   {{- end -}}
   {{- if (.Values.federatedETL).readOnlyPrimary -}}
-    {{ fail "`.Values.federatedETL.readOnlyPrimary` is no longer supported. Please use `.Values.finopsAgent.enabled=false` instead if you don't want to push this cluster's metrics to the federated storage." }}
+    {{ fail "`.Values.federatedETL.readOnlyPrimary` is no longer supported. Please use `.Values.finopsagent.enabled=false` instead if you don't want to push this cluster's metrics to the federated storage." }}
   {{- end -}}
   {{- if .Values.federatedETL -}}
     {{ fail "`.Values.federatedETL` is no longer supported. Please remove this configuration." }}
@@ -599,8 +599,8 @@ NOTE: added kubecostModel for backward compatibility
 Prior to kubecost 3.0.3, the finops-agent had a hyphen. It was removed in 3.0.3.
 This will block upgrades until the new value is used, which very few would have changed.
 */}}
-{{- define "kubecost.finopsAgentCheck" -}}
+{{- define "kubecost.finopsagentCheck" -}}
 {{- if index .Values "finops-agent" }}
-  {{ fail "\nThe helm values for finops-agent have been updated.\nPlease change the finops-agent: key in your helm values to finopsAgent:" }}
+  {{ fail "\nThe helm values for finops-agent have been updated.\nPlease change the finops-agent: key in your helm values to finopsagent:" }}
 {{- end -}}
 {{- end -}}

--- a/kubecost/values-eks-cost-monitoring.yaml
+++ b/kubecost/values-eks-cost-monitoring.yaml
@@ -20,6 +20,6 @@ clusterController:
   image:
     repository: kubecost/cluster-controller
 
-finopsAgent:
+finopsagent:
   image:
     repository: kubecost/agent

--- a/kubecost/values-eks-cost-monitoring.yaml
+++ b/kubecost/values-eks-cost-monitoring.yaml
@@ -20,6 +20,6 @@ clusterController:
   image:
     repository: kubecost/cluster-controller
 
-finops-agent:
+finopsAgent:
   image:
     repository: kubecost/agent

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -404,8 +404,8 @@ teams:
 ## Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml
 ##
 ## You must also set the finops-agent systemProxy values independently.
-## Please merge these values below with the finops-agent values for your release.
-# finops-agent:
+## Please merge these values below with the finopsAgent: values for your release.
+# finopsAgent:
 #   extraEnvVars:
 #   - name: HTTP_PROXY
 #     value: httpProxyUrl
@@ -575,10 +575,10 @@ localStore:
       # This can be used to allow the agent history to be uploaded to cloud storage when upgrading to Enterprise.
       helm.sh/resource-policy: keep
 
-## Below are a subset of values for the finops-agent sub-chart that are most commonly changed.
-## See https://github.com/kubecost/finops-agent-chart/
+## Below are a subset of values for the finopsAgent sub-chart that are most commonly changed.
+## See https://github.com/kubecost/finopsAgent-chart/
 ## for a complete list of values.
-finops-agent:
+finopsAgent:
   enabled: true
   persistence:
     ## @param persistence.enabled Enable FinOps Agent data persistence for WAL and other local data

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -576,7 +576,7 @@ localStore:
       helm.sh/resource-policy: keep
 
 ## Below are a subset of values for the finopsAgent sub-chart that are most commonly changed.
-## See https://github.com/kubecost/finopsAgent-chart/
+## See https://github.com/kubecost/finops-agent-chart/
 ## for a complete list of values.
 finopsAgent:
   enabled: true

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -404,8 +404,8 @@ teams:
 ## Ref: https://www.oreilly.com/library/view/security-with-go/9781788627917/5ea6a02b-3d96-44b1-ad3c-6ab60fcbbe4f.xhtml
 ##
 ## You must also set the finops-agent systemProxy values independently.
-## Please merge these values below with the finopsAgent: values for your release.
-# finopsAgent:
+## Please merge these values below with the finopsagent: values for your release.
+# finopsagent:
 #   extraEnvVars:
 #   - name: HTTP_PROXY
 #     value: httpProxyUrl
@@ -575,11 +575,14 @@ localStore:
       # This can be used to allow the agent history to be uploaded to cloud storage when upgrading to Enterprise.
       helm.sh/resource-policy: keep
 
-## Below are a subset of values for the finopsAgent sub-chart that are most commonly changed.
+## Below are a subset of values for the finopsagent sub-chart that are most commonly changed.
 ## See https://github.com/kubecost/finops-agent-chart/
 ## for a complete list of values.
-finopsAgent:
+finopsagent:
   enabled: true
+  # serviceAccount:
+  #   create: true
+  #   name: finops-agent
   persistence:
     ## @param persistence.enabled Enable FinOps Agent data persistence for WAL and other local data
     ##


### PR DESCRIPTION
## remove hyphen from finops-agent helm key

## Commentary for Reviewers

After an internal discussion, we all agreed that the hyphen in finops-agent is going to be problematic and we are early enough where the user impact is minimal.

## Links to Issues or Tickets

[KCM-4816]

## User Impact and Risks

The Kubecost 3.0 helm chart added a new helm section for finops-agent using a `-` in the key. Any user that has defined values using that key will need to change it to `finopsagent:` before upgrading to 3.0.3. 

> note that we intentionally are not using camelCase due to the key being used in k8s objects where uppercase letters are not valid.

## Testing

fail if using old finops-agent key:
```
helm template temp ../kubecost --set global.clusterId="test1" \ 
 --set finops-agent.agent.cloudability.enabled=false
```
```
Error: execution error at (kubecost/templates/NOTES.txt:11:4): 
The helm values for finops-agent have been updated.
Please change the finops-agent: key in your helm values to finopsagent:
```

Correctly passing value to sub chart:
```
helm template temp ../kubecost --set global.clusterId="test1" \
  --set finopsagent.agent.cloudability.enabled=true \
  |grep CLOUDABILITY_EMITTER_ENABLED -A1

```
```
            - name: CLOUDABILITY_EMITTER_ENABLED
              value: "true"
```

The above var is disabled by default:
```
helm template temp ../kubecost --set global.clusterId="test1" \ 
 |grep CLOUDABILITY_EMITTER_ENABLED -A1
```
```
            - name: CLOUDABILITY_EMITTER_ENABLED
              value: "false"
```

install is successful 
```
helm upgrade --install kc30 ../kubecost -n kc30 --create-namespace
Release "kc30" has been upgraded. Happy Helming!
NAME: kc30
LAST DEPLOYED: Tue Oct 28 08:36:29 2025
NAMESPACE: kc30
STATUS: deployed
REVISION: 2
NOTES:
WARNING: The clusterId is set to the default value of 'cluster-one'. This is not recommended if you intend to use multi-cluster federation in the future. Please set a globally unique .Values.global.clusterId

================================================================================
KUBECOST INSTALLATION SUCCESSFUL
```

## Documentation Updates

Need to do a find a replace on docs.

[KCM-4816]: https://apptio.atlassian.net/browse/KCM-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ