### PR TITLE
[DO NOT MERGE] Testing alias of finopsAgent subchart

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -10,6 +10,7 @@ annotations:
       url: https://www.kubecost.com
 dependencies:
   - name: finops-agent
+    alias: finopsAgent
     version: "v1.0.3"
     repository: https://kubecost.github.io/finops-agent-chart
-    condition: finops-agent.enabled
+    condition: finopsAgent.enabled

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1656,6 +1656,9 @@ for more information
 {{- if (.Values.prometheus.server.clusterIDConfigmap) -}}
 {{ fail "\n\nKubecost 2.9.x is only used for preparing agents to upgrade to 3.0.\nThis key is no longer used and must be removed: .Values.prometheus.server.clusterIDConfigmap\nFor more information, see: https://github.com/kubecost/cost-analyzer/tree/v2.9/examples" }}
 {{- end -}}
+{{- if not ((.Values.finopsAgent).enabled) -}}
+{{- fail "\n\nKubecost 2.9.x is only used for preparing agents to upgrade to 3.0.\nFinOps Agent is not enabled. Please enable FinOps Agent to use Kubecost 2.9.\nFor more information, see: https://github.com/kubecost/cost-analyzer/tree/v2.9/examples" }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -368,11 +368,11 @@ global:
 upgrade:
   toV2: false
 
-finops-agent:
+finopsAgent:
   ## Kubecost 2.9 is intended to facilitate the upgrade to Kubecost 3.0.
   ## When upgrading to Kubecost 2.9, the finops-agent is enabled by default.
   ## This can be disabled if you are not upgrading the cluster to Kubecost 3.0 or do not mind losing a partial day of data.
-  enabled: true
+  enabled: false
   serviceAccount:
     create: true
     name: ""  # Set this to the same value as `.Values.serviceAccount.name` if you have attached an IAM role to your ServiceAccount.


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
DO NOT MERGE

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
This does work! When setting `.Values.finopsAgent.enabled=false` to test our helper function, we see the following:

```
$ helm template ./cost-analyzer
Error: execution error at (cost-analyzer/templates/NOTES.txt:2:4):

Kubecost 2.9.x is only used for preparing agents to upgrade to 3.0.
FinOps Agent is not enabled. Please enable FinOps Agent to use Kubecost 2.9.
For more information, see: https://github.com/kubecost/cost-analyzer/tree/v2.9/examples

Use --debug flag to render out invalid YAML
```

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
