### PR TITLE
add global.ImagePullSecret to all pods

### DIFF
--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -7,7 +7,6 @@
 {{- include "kubecost.clusterId.check" . -}}
 {{- include "kubecost.caCertsSecretConfig.check" . -}}
 {{- include "kubecost.actionsStorageSourceCheck" . -}}
-{{- include "kubecost.localStoreClusterIdCheck" . -}}
 {{- include "kubecost.finopsagentCheck" . -}}
 ================================================================================
 KUBECOST INSTALLATION SUCCESSFUL
@@ -40,3 +39,6 @@ Having installation issues? View our Troubleshooting Guide:
 https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=troubleshoot-install
 
 Copyright IBM Corp. 2019-2025
+
+{{- include "kubecost.localStoreClusterIdCheck" . -}}
+{{- include "kubecost.v3-postconditions" . -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -591,7 +591,7 @@ NOTE: added kubecostModel for backward compatibility
 
 {{- define "kubecost.localStoreClusterIdCheck" -}}
 {{- if eq (include "kubecost.clusterId" .) "cluster-one" -}}
-{{ printf "\n\nWARNING: The clusterId is set to the default value of 'cluster-one'. This is not recommended if you intend to use multi-cluster federation in the future. Please set a globally unique .Values.global.clusterId\n\n" }}
+{{ printf "\n\nWARNING: The clusterId is set to the default value of 'cluster-one'. This is not recommended if you intend to use multi-cluster federation in the future. Please set a globally unique .Values.global.clusterId\n" }}
 {{- end -}}
 {{- end -}}
 
@@ -616,5 +616,11 @@ imagePullSecrets:
 {{ range $.Values.global.imagePullSecrets }}
   - name: {{ . }}
 {{ end }}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubecost.v3-postconditions" -}}
+{{- if .Values.imagePullSecrets }}
+{{ printf "\nWARNING .Values.imagePullSecrets has been deprecated. Please use .Values.global.imagePullSecrets instead.\nThe finops-agent will only use the global.imagePullSecrets\n" }}
 {{- end -}}
 {{- end -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -606,15 +606,15 @@ This will block upgrades until the new value is used, which very few would have 
 {{- end -}}
 
 {{- define "kubecost.imagePullSecrets" -}}
-{{- if .Values.imagePullSecrets }}
-imagePullSecrets:
-{{ range $.Values.imagePullSecrets }}
-  - name: {{ .name }}
-{{ end }}
-{{- else if .Values.global.imagePullSecrets }}
+{{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ range $.Values.global.imagePullSecrets }}
   - name: {{ . }}
+{{ end }}
+{{- else if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ range $.Values.imagePullSecrets }}
+  - name: {{ .name }}
 {{ end }}
 {{- end -}}
 {{- end -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -604,3 +604,17 @@ This will block upgrades until the new value is used, which very few would have 
   {{ fail "\nThe helm values for finops-agent have been updated.\nPlease change the finops-agent: key in your helm values to finopsagent:" }}
 {{- end -}}
 {{- end -}}
+
+{{- define "kubecost.imagePullSecrets" -}}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ range $.Values.imagePullSecrets }}
+  - name: {{ .name }}
+{{ end }}
+{{- else if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{ range $.Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{ end }}
+{{- end -}}
+{{- end -}}

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -643,13 +643,7 @@ spec:
             {{- toYaml .Values.aggregator.jaeger.containerSecurityContext | nindent 12 }}
           image: {{ .Values.aggregator.jaeger.image }}:{{ .Values.aggregator.jaeger.imageVersion }}
         {{- end }}
-
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.aggregator.priority }}
       {{- if .Values.aggregator.priority.enabled }}
       {{- if .Values.aggregator.priority.name }}

--- a/kubecost/templates/cloud-cost/cloud-cost-deployment.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-deployment.yaml
@@ -251,12 +251,7 @@ spec:
             {{- toYaml .Values.cloudCost.extraEnv | nindent 12 }}
             {{- end }}
             {{- include "common.systemProxy" . | nindent 12 }}
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- if ((.Values.aggregator).priority).enabled }}
       {{- if .Values.aggregator.priority.name }}
       priorityClassName: {{ .Values.aggregator.priority.name }}

--- a/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
@@ -157,12 +157,7 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.clusterController.resources | nindent 12 }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-        {{- end }}
-      {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "kubecost.clusterController.name" . }}
       serviceAccountName: {{ include "kubecost.clusterController.name" . }}
       {{- with .Values.clusterController.tolerations }}

--- a/kubecost/templates/forecasting/forecasting-deployment.yaml
+++ b/kubecost/templates/forecasting/forecasting-deployment.yaml
@@ -112,12 +112,7 @@ spec:
             periodSeconds: {{ .Values.forecasting.livenessProbe.periodSeconds  }}
             failureThreshold: {{ .Values.forecasting.livenessProbe.failureThreshold  }}
           {{- end }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-        {{- end }}
-      {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.forecasting.priority }}
       {{- if .Values.forecasting.priority.enabled }}
       {{- if .Values.forecasting.priority.name }}

--- a/kubecost/templates/frontend/frontend-deployment.yaml
+++ b/kubecost/templates/frontend/frontend-deployment.yaml
@@ -186,12 +186,7 @@ spec:
           securityContext:
           {{- toYaml .Values.global.containerSecuritycontext | nindent 12 }}
           {{- end }}
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.frontend.priority }}
       {{- if .Values.frontend.priority.enabled }}
       {{- if gt (len .Values.frontend.priority.name) 0 }}

--- a/kubecost/templates/local-store/cluster-storage-deployment.yaml
+++ b/kubecost/templates/local-store/cluster-storage-deployment.yaml
@@ -115,12 +115,7 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- include "common.systemProxy" . | indent 12 }}
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- with (.Values.localStore).nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -40,12 +40,7 @@ spec:
         {{- toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
         {{- end }}
     spec:
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       hostNetwork: true
       serviceAccountName: {{ template "kubecost.networkCosts.name" . }}
       containers:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -426,7 +426,9 @@ systemProxy:
   noProxy: ""
 
 ## Image pull secrets to apply to all resources
-##
+## Note that this format is different that what is used in global.imagePullSecrets for backwards compatibility.
+## When both are set, imagePullSecrets will be used (and not global.imagePullSecrets).
+## The below key will not be used for the finops-agent. Consider using global.imagePullSecrets instead.
 imagePullSecrets: []
 # - name: "image-pull-secret"
 

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -425,10 +425,10 @@ systemProxy:
   httpsProxyUrl: ""
   noProxy: ""
 
-## Image pull secrets to apply to all resources
-## Note that this format is different that what is used in global.imagePullSecrets for backwards compatibility.
-## When both are set, imagePullSecrets will be used (and not global.imagePullSecrets).
-## The below key will not be used for the finops-agent. Consider using global.imagePullSecrets instead.
+## deprecated: this image pull secret (on the root level) is for backwards compatibility.
+## Note that this format is different that what is used in global.imagePullSecrets 
+## When both are set, global.imagePullSecrets will be used (and not this block below).
+## The below key will not be used for the finops-agent pod. Consider using global.imagePullSecrets instead.
 imagePullSecrets: []
 # - name: "image-pull-secret"
 

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -426,7 +426,7 @@ systemProxy:
   noProxy: ""
 
 ## deprecated: this image pull secret (on the root level) is for backwards compatibility.
-## Note that this format is different that what is used in global.imagePullSecrets 
+## Note that this format is different that what is used in global.imagePullSecrets
 ## When both are set, global.imagePullSecrets will be used (and not this block below).
 ## The below key will not be used for the finops-agent pod. Consider using global.imagePullSecrets instead.
 imagePullSecrets: []


### PR DESCRIPTION
## fix: add global.ImagePullSecret to all pods 

Added support for .Values.global.imagePullSecrets to all pods
Without this PR, it only works on the finops-agent.

This should be used instead of .Values.imagePullSecrets.

## Commentary for Reviewers

I also moved the warnings to the bottom of the helm notes:
```
helm upgrade kc30 ../kubecost -f imagepull-old.yaml
Release "kc30" has been upgraded. Happy Helming!
NAME: kc30
LAST DEPLOYED: Tue Oct 28 16:14:01 2025
NAMESPACE: kc30
STATUS: deployed
REVISION: 28
NOTES:
================================================================================
KUBECOST INSTALLATION SUCCESSFUL
================================================================================
Kubecost 0.0.0-dev has been successfully installed.

IMPORTANT: Kubecost 3.x is a major upgrade with breaking changes and a new 
architecture. Please review the release notes for migration details:
https://github.com/kubecost/kubecost/releases/tag/v3.0.0

QUICK START GUIDE
-----------------

1. Wait for pods to be Ready:
   kubectl get pods --namespace kc30

2. Enable port-forwarding:
   kubectl port-forward --namespace kc30 svc/kc30-frontend 9090

3. Open your browser and navigate to:
   http://localhost:9090

Note: Allow 25 minutes for Kubecost to gather metrics. A progress indicator 
will appear at the top of the UI.

TROUBLESHOOTING
---------------

Having installation issues? View our Troubleshooting Guide:
https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=troubleshoot-install

Copyright IBM Corp. 2019-2025

WARNING: The clusterId is set to the default value of 'cluster-one'. This is not recommended if you intend to use multi-cluster federation in the future. Please set a globally unique .Values.global.clusterId


WARNING .Values.imagePullSecrets has been deprecated. Please use .Values.global.imagePullSecrets instead.
The finops-agent will only use the global.imagePullSecrets
```

## Links to Issues or Tickets

[KCM-4761]

## User Impact and Risks

Added a warning to notes.

## Testing

when using root level:
```
imagePullSecrets:
  - name: root-values
```
Missing from finops-agent:
```
kgd kc30-finopsagent -oyaml|ag root-values -B1
```
works in aggregator:
```
kg sts kc30-aggregator -oyaml |grep root-values -B1  
      imagePullSecrets:
      - name: root-values
```
when using global:
```
global:
  imagePullSecrets:
  - global-secret
 ```
works in both:
```
kgd kc30-finopsagent -oyaml|ag global-secret -B1
      imagePullSecrets:
      - name: global-secret
```
```
kg sts kc30-aggregator -oyaml |grep global-secret -B1
      imagePullSecrets:
      - name: global-secret
```

## Documentation Updates

Added comments to values.


[KCM-4761]: https://apptio.atlassian.net/browse/KCM-4761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ