### PR TITLE
Add tmp dir to Grafana deployment to address regression

### DIFF
--- a/cost-analyzer/templates/grafana/grafana-deployment.yaml
+++ b/cost-analyzer/templates/grafana/grafana-deployment.yaml
@@ -113,6 +113,8 @@ spec:
           volumeMounts:
             - name: sc-dashboard-volume
               mountPath: {{ .Values.grafana.sidecar.dashboards.folder | quote }}
+            - name: tmp
+              mountPath: /tmp
       {{- end}}
       {{- if .Values.grafana.sidecar.datasources.enabled }}
         - name: {{ template "grafana.name" . }}-sc-datasources
@@ -247,6 +249,8 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: {{ template "grafana.fullname" . }}


### PR DESCRIPTION
## Release Notes Headline

Fixes this issue in the latest 2.8.4 release of Kubecost `"No usable temporary directory found in %s\" %\n dirlist)\nFileNotFoundError: [Errno 2] No usable temporary directory found in ['/tmp', '/var/tmp', '/usr/tmp', '/app']"`

## Commentary for Reviewers

Changes were fixed in 2.9, but are being backported into 2.8: https://github.com/kubecost/kubecost/pull/4336/files#diff-76de170412204d404dae053e17b3185656f06056af9472025878317f66d92cc2

## Links to Issues or Tickets

Resolves https://github.com/kubecost/kubecost/issues/4384

## User Impact and Risks

Grafana's dashboard sidecar bootloops looking for a /tmp dir to write in
 
## Testing

Deployed Kubecost 2.8.3; upgraded to Kubecost 2.8.4, and verified the boot loop noted in GitHub Issues.

Performed a `kubectl edit deployment -n kubecost kubecost-grafana` and applied the changes in this PR. Grafana is healthy, and the endpoint http://localhost:9090/grafana/ is working.

## Documentation Updates

N/A