### PR TITLE
add global.ImagePullSecret to kubecost pods v2.9

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -28,3 +28,4 @@ Please allow 25 minutes for Kubecost to gather metrics. A progress indicator wil
 Having installation issues? View our Troubleshooting Guide at https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=troubleshoot-install
 
 {{- include "kubecostV2-3-notices" . -}}
+{{- include "kubecost.v3-postconditions" . -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1672,3 +1672,23 @@ federated storage config helpers
     {{- .Release.Name }}-federated-storage-config
   {{- end }}
 {{- end -}}
+
+{{- define "kubecost.imagePullSecrets" -}}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ range $.Values.imagePullSecrets }}
+  - name: {{ .name }}
+{{ end }}
+{{- else if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{ range $.Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{ end }}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubecost.v3-postconditions" -}}
+{{- if .Values.imagePullSecrets }}
+{{ printf "\nWARNING .Values.imagePullSecrets has been deprecated. Please use .Values.global.imagePullSecrets instead.\nThe finops-agent will only use the global.imagePullSecrets\n" }}
+{{- end -}}
+{{- end -}}

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -940,7 +940,7 @@ Begin Kubecost 2.0 templates
       # of the init container that gives everything under /var/configs 777.
       mountPath: /var/configs/waterfowl
       {{- if .Values.kubecostAggregator.useDBv3 }}
-      # mount the clickhouse directories on the same PV as the duckdb, 
+      # mount the clickhouse directories on the same PV as the duckdb,
       # this way they can seamlessly share the same PV before, during, and after the upgrade
     - name: aggregator-db-storage
       mountPath: /var/lib/clickhouse

--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1674,15 +1674,15 @@ federated storage config helpers
 {{- end -}}
 
 {{- define "kubecost.imagePullSecrets" -}}
-{{- if .Values.imagePullSecrets }}
-imagePullSecrets:
-{{ range $.Values.imagePullSecrets }}
-  - name: {{ .name }}
-{{ end }}
-{{- else if .Values.global.imagePullSecrets }}
+{{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ range $.Values.global.imagePullSecrets }}
   - name: {{ . }}
+{{ end }}
+{{- else if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ range $.Values.imagePullSecrets }}
+  - name: {{ .name }}
 {{ end }}
 {{- end -}}
 {{- end -}}

--- a/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
+++ b/cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
@@ -184,12 +184,7 @@ spec:
       {{- end}}
       containers:
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.kubecostAggregator.priority }}
       {{- if .Values.kubecostAggregator.priority.enabled }}
       {{- if .Values.kubecostAggregator.priority.name }}

--- a/cost-analyzer/templates/aggregator-statefulset.yaml
+++ b/cost-analyzer/templates/aggregator-statefulset.yaml
@@ -264,12 +264,7 @@ spec:
         {{ include "aggregator.jaeger.sidecarContainerTemplate" . | nindent 8 }}
         {{- end }}
 
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.kubecostAggregator.priority }}
       {{- if .Values.kubecostAggregator.priority.enabled }}
       {{- if .Values.kubecostAggregator.priority.name }}

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -1222,13 +1222,7 @@ spec:
         {{- end }}
         {{- include "aggregator.cloudCost.containerTemplate" . | nindent 8 }}
         {{- end }}
-
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.priority }}
       {{- if .Values.priority.enabled }}
       {{- if gt (len .Values.priority.name) 0 }}

--- a/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-network-costs-template.yaml
@@ -40,12 +40,7 @@ spec:
         {{- toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
         {{- end }}
     spec:
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       hostNetwork: true
       serviceAccountName: {{ template "cost-analyzer.serviceAccountName" . }}
       containers:

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -82,12 +82,6 @@ spec:
           {{- else }}
           imagePullPolicy: Always
           {{- end }}
-          {{- if .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- range $.Values.imagePullSecrets }}
-            - name: {{ .name }}
-            {{- end }}
-          {{- end }}
           {{- if .Values.diagnostics.deployment.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.diagnostics.deployment.containerSecurityContext | nindent 12 }}
@@ -182,6 +176,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/cost-analyzer/templates/etl-utils-deployment.yaml
+++ b/cost-analyzer/templates/etl-utils-deployment.yaml
@@ -108,12 +108,7 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
 
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- with .Values.etlUtils.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -115,12 +115,7 @@ spec:
             periodSeconds: {{ .Values.forecasting.livenessProbe.periodSeconds  }}
             failureThreshold: {{ .Values.forecasting.livenessProbe.failureThreshold  }}
           {{- end }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-        {{- end }}
-      {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.forecasting.priority }}
       {{- if .Values.forecasting.priority.enabled }}
       {{- if .Values.forecasting.priority.name }}

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -192,12 +192,7 @@ spec:
           securityContext:
           {{- toYaml .Values.global.containerSecuritycontext | nindent 12 }}
           {{- end }}
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-      {{- end }}
-    {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.priority }}
       {{- if .Values.priority.enabled }}
       {{- if gt (len .Values.priority.name) 0 }}

--- a/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
+++ b/cost-analyzer/templates/kubecost-cluster-controller-template.yaml
@@ -313,12 +313,7 @@ spec:
           containerPort: 9731
         resources:
           {{- toYaml .Values.clusterController.resources | nindent 12 }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range $.Values.imagePullSecrets }}
-        - name: {{ .name }}
-        {{- end }}
-      {{- end }}
+      {{- include "kubecost.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ template "kubecost.clusterControllerName" . }}
       serviceAccountName: {{ template "kubecost.clusterControllerName" . }}
       {{- with .Values.clusterController.tolerations }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -19,8 +19,9 @@ global:
     #       secret_key: xxx
     existingSecret: ""
   ## Kubecost 2.9 adds support for global.imagePullSecrets and this is the recommended method for this setting
-  # imagePullSecrets:
+  imagePullSecrets: []
   # - PULL_SECRET_NAME
+
   ## If your DNS server doesn't live in the same zone as Kubecost
   ##
   zone: ""  # cluster.local
@@ -578,6 +579,10 @@ systemProxy:
   httpsProxyUrl: ""
   noProxy: ""
 
+# deprecated: this image pull secret (on the root level) is for backwards compatibility.
+## Note that this format is different that what is used in global.imagePullSecrets
+## When both are set, global.imagePullSecrets will be used (and not this block below).
+## The below key will not be used for the finops-agent pod. Consider using global.imagePullSecrets instead.
 # imagePullSecrets:
 # - name: "image-pull-secret"
 

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -18,6 +18,9 @@ global:
     #       access_key: xxx
     #       secret_key: xxx
     existingSecret: ""
+  ## Kubecost 2.9 adds support for global.imagePullSecrets and this is the recommended method for this setting
+  # imagePullSecrets:
+  # - PULL_SECRET_NAME
   ## If your DNS server doesn't live in the same zone as Kubecost
   ##
   zone: ""  # cluster.local

--- a/examples/helmValues-kubecost2.9-agent-only.yaml
+++ b/examples/helmValues-kubecost2.9-agent-only.yaml
@@ -13,7 +13,9 @@ global:
         # access_key: YOUR_ACCESS_KEY
         # secret_key: YOUR_SECRET_KEY
     existingSecret: ""
-
+  ## note that the pull secret for the finops-agent has a different helm key (under global:) than the legacy 2.x kubecost values.
+  # imagePullSecrets:
+  # - PULL_SECRET_NAME
 ## When using assumed roles to access the bucket, the same service account that is used
 ## by the cost-analyzer pod can be used for the new finops-agent.
 ## Below- note that serviceAccount and finopsagent are top level keys (no space before them).


### PR DESCRIPTION
## add global.ImagePullSecret to all pods v2.9

Added support for .Values.global.imagePullSecrets to all pods, which should be used instead of .Values.imagePullSecrets in kubecost 2.9 and 3.x.


## Commentary for Reviewers

## Links to Issues or Tickets

[KCM-4761]

## User Impact and Risks

Added a warning to notes for old key.
```
WARNING .Values.imagePullSecrets has been deprecated. Please use .Values.global.imagePullSecrets instead.
The finops-agent will only use the global.imagePullSecrets
```

## Testing

when using root level:
```
imagePullSecrets:
  - name: root-values
```
Missing from finops-agent:
```
kgd kc29-finops-agent -oyaml|grep root-values -B1
```
works in ca:
```
kgd kc29-cost-analyzer -oyaml|grep root-values -B1  
      imagePullSecrets:
      - name: root-values
```
when using global:
```
global:
  imagePullSecrets:
  - global-secret
 ```
works in both:
```
kgd kc29-finops-agent -oyaml|grep global-secret -B1
      imagePullSecrets:
      - name: global-secret
```
```
kgd kc29-cost-analyzer -oyaml|grep global-secret -B1
      imagePullSecrets:
      - name: global-secret
```

## Documentation Updates

Added comments to values.


[KCM-4761]: https://apptio.atlassian.net/browse/KCM-4761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ