### PR TITLE
fix chart alias

### DIFF
--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -10,7 +10,7 @@ annotations:
       url: https://www.kubecost.com
 dependencies:
   - name: finops-agent
-    alias: finops-agent
+    alias: finopsagent
     version: "v1.0.3"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finopsagent.enabled


### PR DESCRIPTION
## fix 2.9.0 chart alias for finops-agent

Testing:
```
helm template kc29 ~/git/kubecost29/cost-analyzer \
 -f helmValues-kc29.yaml \
  |ag ALLOCATION_EXPORT_INTERVAL -A1
            - name: ALLOCATION_EXPORT_INTERVAL
              value: "999d"
```

in 2.9.0:
```
helm template kc29 ~/git/kubecost29/cost-analyzer \
 -f helmValues-kc29.yaml \
  |ag ALLOCATION_EXPORT_INTERVAL -A1
            - name: ALLOCATION_EXPORT_INTERVAL
              value: "10m"
```
