### PR TITLE
Add useIDToken config to helm values

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -337,7 +337,7 @@ oidc:
   skipOnlineTokenValidation: false  # If true, validate JWT claims locally
   useClientSecretPost: false  # If true, only use client_secret_post method. Otherwise attempt to send the secret in both the header and the body.
   hostedDomain: ""  # Optional, blocks access to the auth domain specified in the hd claim of the provider ID token
-  useIDToken: false # If true, use ID token for authentication. Otherwise, use access token.
+  useIDToken: false # If true, use ID token for authentication. Otherwise, use access token. Set it to true if your identity providers communicate a user's group in the id_token (e.g. AzureAD).
   rbac:
     enabled: false
     # groups:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -337,6 +337,7 @@ oidc:
   skipOnlineTokenValidation: false  # If true, validate JWT claims locally
   useClientSecretPost: false  # If true, only use client_secret_post method. Otherwise attempt to send the secret in both the header and the body.
   hostedDomain: ""  # Optional, blocks access to the auth domain specified in the hd claim of the provider ID token
+  useIDToken: false # If true, use ID token for authentication. Otherwise, use access token.
   rbac:
     enabled: false
     # groups:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -337,7 +337,7 @@ oidc:
   skipOnlineTokenValidation: false  # If true, validate JWT claims locally
   useClientSecretPost: false  # If true, only use client_secret_post method. Otherwise attempt to send the secret in both the header and the body.
   hostedDomain: ""  # Optional, blocks access to the auth domain specified in the hd claim of the provider ID token
-  useIDToken: false # If true, use ID token for authentication. Otherwise, use access token. Set it to true if your identity providers communicate a user's group in the id_token (e.g. AzureAD).
+  useIDToken: false # If true, use ID token for authentication. Otherwise, use access token. Set it to true if your identity providers communicate a user's group in the id_token (e.g. Entra ID).
   rbac:
     enabled: false
     # groups:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -337,7 +337,7 @@ oidc:
   skipOnlineTokenValidation: false  # If true, validate JWT claims locally
   useClientSecretPost: false  # If true, only use client_secret_post method. Otherwise attempt to send the secret in both the header and the body.
   hostedDomain: ""  # Optional, blocks access to the auth domain specified in the hd claim of the provider ID token
-  useIDToken: false # If true, use ID token for authentication. Otherwise, use access token. Set it to true if your identity providers communicate a user's group in the id_token (e.g. Entra ID).
+  useIDToken: false  # If true, use ID token for authentication. Otherwise, use access token. Set it to true if your identity providers communicate a user's group in the id_token (e.g. Entra ID).
   rbac:
     enabled: false
     # groups:


### PR DESCRIPTION
## Release Notes Headline
Add `useIDToken` config to helm values

## Commentary for Reviewers
`useIDToken` config was missing from the helm values which is required to be set to true when using specific identity providers like Entra ID.
The docs asks it set https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=oidc-microsoft-entra-id-integration-kubecost but the helm chart values does not have it even though it is being set in the oidc configmap

## Links to Issues or Tickets
NA

## User Impact and Risks
NA
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
helm template with setting it to true and false
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
