### PR TITLE
consistent quoting/image templates

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -39,7 +39,7 @@ global:
     existingSecret: ""
     apiKey: ""
   ## @param global.imageRegistry The image registry used for all images in this chart and subcharts
-  imageRegistry: "icr.io"
+  imageRegistry: icr.io
   ## E.g.
   ## imagePullSecrets:
   ##   - myRegistryKeySecretName
@@ -582,6 +582,11 @@ localStore:
 ## for a complete list of values.
 finopsagent:
   enabled: true
+  image:
+    repository: ibm-finops/agent
+  #   registry: ""  # Default is "icr.io"
+  #   tag: ""  # Default is set in Chart.yaml
+  # fullImageName: ""  # fullImageName If set, will override the image registry, repo/name and tag.
   # serviceAccount:
   #   create: true
   #   name: finops-agent


### PR DESCRIPTION
## consistent quoting/image templates

this is to help with an automation script for ecr image pushes. 

## testing

- helm template without issue
- upgraded qa environment

```
ct lint --chart-dirs=kubecost/ --charts kubecost/ --validate-maintainers=false
```

```
Validating kubecost/Chart.yaml...
Validation success! 👍

Linting chart with values file "kubecost/ci/aggregator-values.yaml"...

==> Linting kubecost/

1 chart(s) linted, 0 chart(s) failed

Linting chart with values file "kubecost/ci/federatedetl-primary-netcosts-values.yaml"...

==> Linting kubecost/

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ kubecost => (version: "0.0.0-dev", path: "kubecost/")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```
