### PR TITLE
add default noProxy value to systemProxy values

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -424,7 +424,7 @@ systemProxy:
   enabled: false
   httpProxyUrl: ""
   httpsProxyUrl: ""
-  noProxy: "localhost, 127.0.0.1" # localhost and 127.0.0.1 are required to communicate with ClickHouse when systemProxy is enabled.
+  noProxy: "localhost, 127.0.0.1"  # localhost and 127.0.0.1 are required to communicate with ClickHouse when systemProxy is enabled.
 
 ## deprecated: this image pull secret (on the root level) is for backwards compatibility.
 ## Note that this format is different that what is used in global.imagePullSecrets

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -424,7 +424,7 @@ systemProxy:
   enabled: false
   httpProxyUrl: ""
   httpsProxyUrl: ""
-  noProxy: ""
+  noProxy: "localhost, 127.0.0.1" # localhost and 127.0.0.1 are required to communicate with ClickHouse when systemProxy is enabled.
 
 ## deprecated: this image pull secret (on the root level) is for backwards compatibility.
 ## Note that this format is different that what is used in global.imagePullSecrets


### PR DESCRIPTION
## Release Notes Headline

Add defaults for localhost and 127.0.0.1 for .Values.systemProxy.noProxy.

## Commentary for Reviewers

Minor change

## Links to Issues or Tickets

https://apptio.atlassian.net/browse/KCM-4860

## User Impact and Risks

Identified in an environment using systemProxy and ClickHouse would not start.

## Testing

Verified in an environment using systemProxy

## Documentation Updates

N/A