### PR TITLE
bump modeling

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -833,7 +833,7 @@ forecasting:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/modeling
-    tag: v0.1.32
+    tag: v0.1.33
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -833,7 +833,7 @@ forecasting:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/modeling
-    tag: v0.1.31
+    tag: v0.1.32
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.


### PR DESCRIPTION
## bump forecasting image to 0.1.33

fixes a bug where the prediction_window defaults to None, but is wrapped as a str: "None". The existing logic is None does not work. Addressed this by defaulting to an empty string to avoid type issues

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

Tested on qa-eks3

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
