### PR TITLE
Allow turbonomic integration using existing secret 

### DIFF
--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -501,6 +501,10 @@ kubecost.costEventsAudit.enabled flag for nginx configmap
 {{- end -}}
 {{- end -}}
 
+{{- define "kubecost.turbonomic.secretName" -}}
+{{- default "kubecost-integrations-turbonomic" .Values.global.integrations.turbonomic.secretName -}}
+{{- end -}}
+
 {{- /*
   Compute a checksum based on the rendered content of specific ConfigMaps and Secrets.
 */ -}}

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -185,7 +185,7 @@ spec:
         {{- if .Values.global.integrations.turbonomic.enabled }}
         - name: turbonomic-credentials
           secret:
-            secretName: kubecost-integrations-turbonomic
+            secretName: {{ template "kubecost.turbonomic.secretName" . }}
         {{- end }}
         {{- if .Values.global.updateCaTrust.enabled }}
         - name: ca-certs-secret

--- a/kubecost/templates/integrations-turbonomic-secret.yaml
+++ b/kubecost/templates/integrations-turbonomic-secret.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.global.integrations.turbonomic.enabled }}
+{{- if and .Values.global.integrations.turbonomic.enabled (not .Values.global.integrations.turbonomic.secretName) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kubecost-integrations-turbonomic
+  name: {{ template "kubecost.turbonomic.secretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -213,7 +213,7 @@ global:
   integrations:
     turbonomic:
       enabled: false         # Set to true to enable the Turbonomic integration
-      secretName: "kubecost-integrations-turbonomic"  # Name of K8s secret where the turbonomic credentials are stored instead of directly passing the configs via helm values. Ensure the credentials are stored in a key named "turbonomic-credentials.json" in the secret.
+      secretName: ""  # Name of K8s secret where the turbonomic credentials are stored instead of directly passing the configs via helm values. Ensure the credentials are stored in a key named "turbonomic-credentials.json" in the secret.
       clientId: ""           # Client ID generated from the OAuth Client created
       clientSecret: ""       # Client Secret generated from the OAuth Client created
       role: ""               # Role that the OAuth Client was created with (e.g. ADMINISTRATOR, SITE_ADMIN, etc.)

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -206,7 +206,7 @@ global:
       skipSanityChecks: false  # If true, skip all sanity/existence checks for resources like Secrets.
 
   ## Kubecost Integrations
-  ## Ref: 
+  ## Ref:
   ## Turbonomic: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-kubecost-turbonomic-integration
   ## Postgres: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-kubecost-postgres-integration
   ##

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -206,11 +206,14 @@ global:
       skipSanityChecks: false  # If true, skip all sanity/existence checks for resources like Secrets.
 
   ## Kubecost Integrations
-  ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=kubecost-postgres-integration
+  ## Ref: 
+  ## Turbonomic: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-kubecost-turbonomic-integration
+  ## Postgres: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-kubecost-postgres-integration
   ##
   integrations:
     turbonomic:
       enabled: false         # Set to true to enable the Turbonomic integration
+      secretName: "kubecost-integrations-turbonomic"  # Name of K8s secret where the turbonomic credentials are stored instead of directly passing the configs via helm values. Ensure the credentials are stored in a key named "turbonomic-credentials.json" in the secret.
       clientId: ""           # Client ID generated from the OAuth Client created
       clientSecret: ""       # Client Secret generated from the OAuth Client created
       role: ""               # Role that the OAuth Client was created with (e.g. ADMINISTRATOR, SITE_ADMIN, etc.)


### PR DESCRIPTION
## Release Notes Headline
Allow turbonomic integration using existing secret 

## Commentary for Reviewers
Right now users have to provide their turbonomic client secrets and other configs via helm values to get applied. The change allows users to mount an existing secret to the aggregator pod with turbonomic configuration so they now do not need to add it in their values file.
I need to add turbonomic configuration for a customer in our argoCD setup and we do not allow secrets being pushed to github repo
## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
No major impact as it adding an existing secret is disabled by default
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Helm teplate looks good
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
