### PR TITLE
Add forecasting /anomaly endpoints back to frontend nginx config

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -480,14 +480,14 @@ data:
         }
 
         {{- if .Values.forecasting.enabled }}
-        location /model/forecast/ {
-            default_type 'application/json';
-            proxy_read_timeout          300;
-            proxy_pass http://forecasting/forecast/;
-            proxy_redirect off;
-            proxy_set_header Connection "";
-            proxy_set_header  X-Real-IP  $remote_addr;
-            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        location /forecasting/ {
+          default_type 'application/json';
+          proxy_read_timeout 300;
+          proxy_pass http://forecasting/;
+          proxy_redirect off;
+          proxy_set_header Connection "";
+          proxy_set_header  X-Real-IP  $remote_addr;
+          proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         {{- else }}
         location /forecasting {

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -481,13 +481,13 @@ data:
 
         {{- if .Values.forecasting.enabled }}
         location /forecasting/ {
-          default_type 'application/json';
-          proxy_read_timeout 300;
-          proxy_pass http://forecasting/;
-          proxy_redirect off;
-          proxy_set_header Connection "";
-          proxy_set_header  X-Real-IP  $remote_addr;
-          proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+            default_type 'application/json';
+            proxy_read_timeout 300;
+            proxy_pass http://forecasting/;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
         {{- else }}
         location /forecasting {


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
Change the routing of `/forecasting` endpoints from `/model/forecast` to `/forecasting`, and this will also now include the anomaly detection endpoints.

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

Collectively, these endpoints will now be accessed via `/forecasting/forecast/<type>`, where type is `allocation` or `cloudCost`, and `/forecasting/anomaly/detect`.

The `/model/forecast` endpoint, which is removed here, _only_ supported the kc-modeling pod's `forecast` endpoints, not the `/anomaly/detect` endpoints. The reason it is changed here is that (1) I don't think we should have two different prefixes for routing to the forecasting pod, and (2) `/model` is largely overloaded.

**NOTE**: this change is co-dependent with a forthcoming change to the Kubecost UI so that it will target `/forecasting` instead of `/model/forecast`. This PR and that one will need to merge together, or the UI will be broken.

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

- Closes https://apptio.atlassian.net/browse/KCM-4861

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
This does change the API contract of the frontend pod. I believe that contract was changed recently (during the 2.0 re-arch), and that this takes us back closer to the original contract. Consumers that have come to rely on the `/model/forecast` API path recently will be broken by this change.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
Manual testing by deploying to a cluster and seeing that the `/anomaly/detect` and `/forecast` endpoints are accessible after the change. Screenshots to follow.

### Before
<img width="1727" height="971" alt="image" src="https://github.com/user-attachments/assets/e447d766-886b-4805-ac88-b15ca3723e36" />
<img width="1727" height="968" alt="image" src="https://github.com/user-attachments/assets/4ab8f6e2-a03f-4e9a-8e87-2554c11e8197" />


### After
<img width="1728" height="973" alt="image" src="https://github.com/user-attachments/assets/cf1f52f2-ffcb-4411-ab05-4621c41df1a3" />
<img width="1726" height="973" alt="image" src="https://github.com/user-attachments/assets/682d9c7c-7db5-4dc7-9ebe-4cbe03e6304e" />
<img width="1728" height="975" alt="image" src="https://github.com/user-attachments/assets/3456f141-ca4e-4ed8-98fb-b64be326a57b" />



## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
Funny enough, no updates required. This change actually brings the product into alignment with the current documentation: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=apis-forecast-api
