### PR TITLE
Fix: frontend.service.type override ignored

### DIFF
--- a/kubecost/templates/frontend/frontend-service.yaml
+++ b/kubecost/templates/frontend/frontend-service.yaml
@@ -16,12 +16,8 @@ metadata:
 spec:
   selector:
     {{- include "kubecost.frontend.selectorLabels" . | nindent 4 }}
-{{- if .Values.service -}}
 {{- if .Values.frontend.service.type }}
   type: "{{ .Values.frontend.service.type }}"
-{{- else }}
-  type: ClusterIP
-{{- end }}
 {{- else }}
   type: ClusterIP
 {{- end }}


### PR DESCRIPTION
## Release Notes Headline

Fix: frontend.service.type was ignored when set.

## Commentary for Reviewers

The template always rendered `ClusterIP`. The fix makes the chart correctly use the value provided by the user.

## Links to Issues or Tickets

N/A

## User Impact and Risks

Users can now set frontend.service.type and get the expected result.
Very low risk.

## Testing

```
helm template .  --set frontend.service.type=NodePort -s templates/frontend/frontend-service.yaml
```

The output now correctly shows type: `NodePort`.

## Documentation Updates

N/A
