### PR TITLE
Kubecost HA Configuration

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -51,13 +51,23 @@ data:
         text/x-component
         text/x-cross-domain-policy;
 
+    {{- if (.Values.frontend.upstreamAggregatorConfiguration) }}
+    # Resolver for runtime DNS resolution
+    resolver 127.0.0.11;
+    {{- end }}
+
     upstream aggregator {
+        {{- if (.Values.frontend.upstreamAggregatorConfiguration) }}
+            {{- tpl .Values.frontend.upstreamAggregatorConfiguration . | nindent 8 }}
+        {{- else }}
+        {{- /* Standard Mode: Single upstream server */}}
         {{- if .Values.frontend.useDefaultFqdn }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
         {{- else if (.Values.frontend.aggregator).fqdn }}
         server {{ .Values.frontend.aggregator.fqdn }};
         {{- else }}
         server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
+        {{- end }}
         {{- end }}
     }
 
@@ -182,15 +192,28 @@ data:
 {{- end }}
         
         location /model/ {
+            {{- if (.Values.frontend.upstreamAggregatorConfiguration) }}
+            # Shorter timeout for faster failover when backup server is configured
+            proxy_connect_timeout       2s;
+            proxy_send_timeout          {{ .Values.frontend.timeoutSeconds | default 300 }};
+            proxy_read_timeout          {{ .Values.frontend.timeoutSeconds | default 300 }};
+            {{- else }}
             proxy_connect_timeout       {{ .Values.frontend.timeoutSeconds | default 300 }};
             proxy_send_timeout          {{ .Values.frontend.timeoutSeconds | default 300 }};
             proxy_read_timeout          {{ .Values.frontend.timeoutSeconds | default 300 }};
+            {{- end }}
             proxy_pass http://aggregator/;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+            {{- if (.Values.frontend.upstreamAggregatorConfiguration) }}
+            # Enable failover to next upstream server on errors/timeouts
+            proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+            proxy_next_upstream_tries 2;
+            proxy_next_upstream_timeout 0;
+            {{- end }}
             {{- if .Values.frontend.extraModelConfigs }}
             {{- .Values.frontend.extraModelConfigs | toString | nindent 12 -}}
             {{- end }}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -62,11 +62,11 @@ data:
         {{- else }}
         {{- /* Standard Mode: Single upstream server */}}
         {{- if .Values.frontend.useDefaultFqdn }}
-        server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
+            server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}.svc.cluster.local:9004;
         {{- else if (.Values.frontend.aggregator).fqdn }}
-        server {{ .Values.frontend.aggregator.fqdn }};
+            server {{ .Values.frontend.aggregator.fqdn }};
         {{- else }}
-        server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
+            server {{ .Release.Name }}-aggregator.{{ .Release.Namespace }}:9004;
         {{- end }}
         {{- end }}
     }

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -450,6 +450,7 @@ frontend:
     registry: ""  # Default is "icr.io"
     repository: kubecost/frontend
     tag: ""  # Default is to match the Chart.AppVersion
+  upstreamAggregatorConfiguration: ""
 
   imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
This PR makes it possible to configure a backup aggregator in the frontend for failover

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
https://apptio.atlassian.net/browse/KCM-4888

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
Minimal

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
Deployed Kubecost in two separate clusters, but only configured the primary to read data. I then scaled down the primary aggregator and refreshed the page for the primary frontend, confirming failover took place as expected. I then scaled back up the primary aggregator and refreshed the page (after waiting a few minutes) and confirmed the primary frontend was showing data from the primary aggregator again. 

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A - My understanding is this is a short-term HA solution to get us through the holidays until we can build out true HA. 
