### PR TITLE
add default-storageclass

### DIFF
--- a/kubecost/README.md
+++ b/kubecost/README.md
@@ -2,6 +2,8 @@
 
 The following table lists commonly used configuration parameters for the Kubecost Helm chart and their default values. Please see the [values file](values.yaml) for the complete set of definable values.
 
+Additionally, see the root of the chart for examples of commonly changed values ("values-*.yaml").
+
 | Parameter                                                                          | Description                                                                                                                                                  | Default                                               |
 |------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
 | `ingress.enabled`                                                                  | If true, Ingress will be created                                                                                                                             | `false`                                               |

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -28,7 +28,13 @@ spec:
       name: aggregator-db-storage
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      {{- if or .Values.aggregator.aggregatorDbStorage.storageClass .Values.global.defaultStorageClass }}
+      {{- if .Values.aggregator.aggregatorDbStorage.storageClass }}
       storageClassName: {{ .Values.aggregator.aggregatorDbStorage.storageClass }}
+      {{- else }}
+      storageClassName: {{ .Values.global.defaultStorageClass }}
+      {{- end }}
+      {{- end }}
       resources:
         requests:
           storage:  {{ .Values.aggregator.aggregatorDbStorage.storageRequest }}
@@ -41,7 +47,13 @@ spec:
       name: persistent-configs
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      {{- if or .Values.aggregator.persistentConfigsStorage.storageClass .Values.global.defaultStorageClass }}
+      {{- if .Values.aggregator.persistentConfigsStorage.storageClass }}
       storageClassName: {{ .Values.aggregator.persistentConfigsStorage.storageClass }}
+      {{- else }}
+      storageClassName: {{ .Values.global.defaultStorageClass }}
+      {{- end }}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.aggregator.persistentConfigsStorage.storageRequest }}

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -28,12 +28,10 @@ spec:
       name: aggregator-db-storage
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      {{- if or .Values.aggregator.aggregatorDbStorage.storageClass .Values.global.defaultStorageClass }}
       {{- if .Values.aggregator.aggregatorDbStorage.storageClass }}
       storageClassName: {{ .Values.aggregator.aggregatorDbStorage.storageClass }}
-      {{- else }}
+      {{- else if .Values.global.defaultStorageClass }}
       storageClassName: {{ .Values.global.defaultStorageClass }}
-      {{- end }}
       {{- end }}
       resources:
         requests:
@@ -47,12 +45,10 @@ spec:
       name: persistent-configs
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      {{- if or .Values.aggregator.persistentConfigsStorage.storageClass .Values.global.defaultStorageClass }}
       {{- if .Values.aggregator.persistentConfigsStorage.storageClass }}
       storageClassName: {{ .Values.aggregator.persistentConfigsStorage.storageClass }}
-      {{- else }}
+      {{- else if .Values.global.defaultStorageClass }}
       storageClassName: {{ .Values.global.defaultStorageClass }}
-      {{- end }}
       {{- end }}
       resources:
         requests:

--- a/kubecost/templates/local-store/cluster-storage-pvc.yaml
+++ b/kubecost/templates/local-store/cluster-storage-pvc.yaml
@@ -17,12 +17,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if or .Values.localStore.persistentVolume.storageClass .Values.global.defaultStorageClass}}
   {{- if .Values.localStore.persistentVolume.storageClass }}
   storageClassName: {{ .Values.localStore.persistentVolume.storageClass }}
-  {{- else }}
+  {{- else if .Values.global.defaultStorageClass }}
   storageClassName: {{ .Values.global.defaultStorageClass }}
-  {{- end }}
   {{- end }}
   resources:
     requests:

--- a/kubecost/templates/local-store/cluster-storage-pvc.yaml
+++ b/kubecost/templates/local-store/cluster-storage-pvc.yaml
@@ -17,9 +17,13 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  {{- if or .Values.localStore.persistentVolume.storageClass .Values.global.defaultStorageClass}}
   {{- if .Values.localStore.persistentVolume.storageClass }}
   storageClassName: {{ .Values.localStore.persistentVolume.storageClass }}
-  {{ end }}
+  {{- else }}
+  storageClassName: {{ .Values.global.defaultStorageClass }}
+  {{- end }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.localStore.persistentVolume.size }}

--- a/kubecost/values-storage.yaml
+++ b/kubecost/values-storage.yaml
@@ -1,0 +1,32 @@
+## There are 4 persistent volumes that are created when using default settings.
+## When installing on a cluster that does not have a default storage class, you will need to set the storageClass for each of the persistent volumes.
+## In the values below, "gp3" is used as an example. All other values are the defaults.
+
+## When not using federated storage, the long-term metrics are stored in the localStore.
+localStore:
+  persistentVolume:
+    storageClass: gp3
+    size: 32Gi
+    ## Note that setting enabled to false means all data will be lost out on pod restart unless using federated storage.
+    enabled: true
+
+## short-term (<2 days) metrics are stored by the finops agent.
+finopsagent:
+  persistence:
+    storageClass: gp3
+    size: 8Gi
+    enabled: true
+
+aggregator:
+  ## The aggregator pod has 2 PVCs and will need to be in the same availability zone unless using multi-zone storage.
+  ## Storage classes that have 'volumeBindingMode: WaitForFirstConsumer' will do this automatically.
+  ## Settings and reports created via the UI are stored in the persistentConfigs volume.
+  persistentConfigsStorage:
+    storageClass: gp3
+    ## If using high iops storage, the storageRequest may need to be increased to meet the provider's minimum ratio for gb/iops.
+    storageRequest: 1Gi
+  aggregatorDbStorage:
+    ## IOPS performance of the aggregatorDbStorage will have significant impact on the performance of queries.
+    ## block storage is REQUIRED for the aggregatorDbStorage. NFS/file is not supported.
+    storageClass: gp3
+    storageRequest: 128Gi

--- a/kubecost/values-storage.yaml
+++ b/kubecost/values-storage.yaml
@@ -1,11 +1,16 @@
 ## There are 4 persistent volumes that are created when using default settings.
 ## When installing on a cluster that does not have a default storage class, you will need to set the storageClass for each of the persistent volumes.
-## In the values below, "gp3" is used as an example. All other values are the defaults.
+## This can be done with the global.defaultStorageClass or the storageClass parameter in the finopsagent, aggregator, or localStore blocks.
+## The values below are the defaults that are used if not overridden - this file is just a summary of what is in ./values.yaml
+
+## global.defaultStorageClass will set the default storage class to use, unless overridden by the storageClass parameter in the finopsagent, aggregator, or localStore blocks.
+global:
+  defaultStorageClass: ""
 
 ## When not using federated storage, the long-term metrics are stored in the localStore.
 localStore:
   persistentVolume:
-    storageClass: gp3
+    storageClass: ""
     size: 32Gi
     ## Note that setting enabled to false means all data will be lost out on pod restart unless using federated storage.
     enabled: true
@@ -13,7 +18,7 @@ localStore:
 ## short-term (<2 days) metrics are stored by the finops agent.
 finopsagent:
   persistence:
-    storageClass: gp3
+    storageClass: ""
     size: 8Gi
     enabled: true
 
@@ -22,11 +27,11 @@ aggregator:
   ## Storage classes that have 'volumeBindingMode: WaitForFirstConsumer' will do this automatically.
   ## Settings and reports created via the UI are stored in the persistentConfigs volume.
   persistentConfigsStorage:
-    storageClass: gp3
+    storageClass: ""
     ## If using high iops storage, the storageRequest may need to be increased to meet the provider's minimum ratio for gb/iops.
     storageRequest: 1Gi
   aggregatorDbStorage:
     ## IOPS performance of the aggregatorDbStorage will have significant impact on the performance of queries.
     ## block storage is REQUIRED for the aggregatorDbStorage. NFS/file is not supported.
-    storageClass: gp3
+    storageClass: ""
     storageRequest: 128Gi

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -46,7 +46,10 @@ global:
   ##   - myRegistryKeySecretName
   ##
   imagePullSecrets: []
-  ## If your DNS server doesn't live in the same zone as Kubecost
+  ## @param global.defaultStorageClass The default storage class to use, unless overridden by the storageClass parameter in the finopsagent, aggregator, or localStore blocks.
+  ##
+  defaultStorageClass: ""
+  ## @param global.zone The zone to use for the finops agent
   ##
   zone: ""  # cluster.local
   ## Compatibility adaptations for Kubernetes platforms

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -572,7 +572,8 @@ localStore:
 
   persistentVolume:
     size: 32Gi
-    enabled: true  # Note that setting this to false means cluster storage will be wiped out on pod restart.
+    ## Note that setting enabled: false means all data will be lost out on pod restart unless using federated storage.
+    enabled: true
     storageClass: ""
     existingClaim: ""  # kubecost-cost-analyzer # use this if upgrading from kubecost 2.x
     labels: {}
@@ -598,6 +599,7 @@ finopsagent:
   #   name: finops-agent
   persistence:
     ## @param persistence.enabled Enable FinOps Agent data persistence for WAL and other local data
+    ## short-term (<2 days) metrics are stored by the finops agent.
     ##
     enabled: true
     ## @param persistence.existingClaim A manually managed Persistent Volume and Claim
@@ -963,12 +965,17 @@ aggregator:
   collections:
     cache:
       enabled: true
-  ## use fast IOPS storage for the aggregator db and persistent configs.
+  ## The aggregator pod has 2 PVCs that will need to be in the same availability zone unless using multi-zone storage.
+  ## Storage classes that have 'volumeBindingMode: WaitForFirstConsumer' will do this automatically.
+  ## Settings and reports created via the UI are stored in the persistentConfigs volume.
   persistentConfigsStorage:
-    storageClass: ""  # default storage class. Using the same storage class as the aggregator db storage is recommended for node placement concerns.
-    storageRequest: 1Gi  # may need to be increased if the storage class requires a certain size per IOPS
+    storageClass: ""
+    ## If using high iops storage, the storageRequest may need to be increased to meet the provider's minimum ratio for gb/iops.
+    storageRequest: 1Gi
   aggregatorDbStorage:
-    storageClass: ""  # default storage class. NFS is not supported.
+    ## IOPS performance of the aggregatorDbStorage will have significant impact on the performance of queries.
+    ## block storage is REQUIRED for the aggregatorDbStorage. NFS/file is not supported.
+    storageClass: ""
     storageRequest: 128Gi
   resources:
     ## Consider setting a limit after a baseline has been established


### PR DESCRIPTION
## add default-storageClass

Added helm option for global.defaultStorageClass

## Commentary for Reviewers

Tested extensively on real deployments and had AI write a yq command below.

## Links to Issues or Tickets

[KCM-4866]

## User Impact and Risks

easier storage configuration, support already existing finops-chart global.defaultStorageClass

## Testing
Default values are the same before and after, no storageClass set.

With only global defaultStorageClass set to gp2:
```
helm template kc-helm-storage-test ./kubecost \
  -f temp/helmValues-stoage.yaml | yq eval -N 'select(.spec.storageClassName != null or (.spec.volumeClaimTemplates[].spec.storageClassName != null)) | [.metadata.name, (.spec.volumeClaimTemplates[].metadata.name // .metadata.name), (.spec.storageClassName // .spec.volumeClaimTemplates[].spec.storageClassName)] | @csv' \ 
  | grep -v '^$'
```
```csv
kc-helm-storage-test-finopsagent,kc-helm-storage-test-finopsagent,gp3
kc-helm-storage-test-local-store,kc-helm-storage-test-local-store,gp3
kc-helm-storage-test-aggregator,aggregator-db-storage,persistent-configs,gp3,gp3
```

set global and each replicaset:
```yaml
global:
  defaultStorageClass: gp3
localStore:
  persistentVolume:
    storageClass: gp2
finopsagent:
  persistence:
    storageClass: gp2
aggregator:
  persistentConfigsStorage:
    storageClass: gp2
  aggregatorDbStorage:
    storageClass: gp2
```
```csv
kc-helm-storage-test-finopsagent,kc-helm-storage-test-finopsagent,gp2
kc-helm-storage-test-local-store,kc-helm-storage-test-local-store,gp2
kc-helm-storage-test-aggregator,aggregator-db-storage,persistent-configs,gp2,gp2
```


## Documentation Updates
updated ./kubecost/values-storage.yaml

[KCM-4866]: https://apptio.atlassian.net/browse/KCM-4866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ