### PR TITLE
Update agent chart to v1.0.6-rc.0 for resource quota access

### DIFF
--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
-  version: 1.0.5
-digest: sha256:c2cec135c32916fb3d434190c68a91cf25c0c3b7b6352a4f9e818d4054955111
-generated: "2025-11-21T20:17:54.243185+05:30"
+  version: 1.0.6-rc.0
+digest: sha256:348a4200e667cfe4a5f62c00a4b70ad6ce762c10ee18ecb0a827a6f5653629dc
+generated: "2025-11-26T10:56:26.448245-07:00"

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -11,6 +11,6 @@ annotations:
 dependencies:
   - name: finops-agent
     alias: finopsagent
-    version: "v1.0.5"
+    version: "v1.0.6-rc.0"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finopsagent.enabled


### PR DESCRIPTION
## Release Notes Headline

Provide access to resource quota objects.

## Commentary for Reviewers

No agent image changes. Only changing the agent chart to allow access to resource quota objects.

## Links to Issues or Tickets

N/A
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

N/A
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

Tested agent manually, verified access to resource quota data.
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

N/A
<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
