### PR TITLE
Add support for extraEnv to cloud cost - 2.9 (Take 2)

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -1357,6 +1357,9 @@ Begin Kubecost 2.0 templates
     - name: {{ $key | quote }}
       value: {{ $value | quote }}
     {{- end }}
+    {{- if .Values.kubecostAggregator.cloudCost.extraEnv -}}
+    {{- toYaml .Values.kubecostAggregator.cloudCost.extraEnv | nindent 4 }}
+    {{- end }}
     {{- if .Values.systemProxy.enabled }}
     - name: HTTP_PROXY
       value: {{ .Values.systemProxy.httpProxyUrl }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -1846,6 +1846,11 @@ kubecostAggregator:
     ## Define environment variables for cloud cost
     # env: {}
 
+    ## Set additional environment variables for the cloud cost
+    # extraEnv:
+    # - name: SOME_VARIABLE
+    #   value: "some_value"
+
     ## Define extra volumes for the cloud cost pod
     # extraVolumes: []
 


### PR DESCRIPTION
Signed-off-by: Sean Pomeroy <sean.pomeroy@gmail.com>

## Release Notes Headline

Adds support for `extraEnv` for the cloud-cost container which provides the ability for an env to pull its value from a secret or configmap.

## Commentary for Reviewers

I left the original `env` value to allow for backwards compatability.

## Links to Issues or Tickets

https://kubecost.slack.com/archives/GNS5G863C/p1764095337254209

## User Impact and Risks

Low risk/impact

## Testing

Tested using helm template to ensure backwards compatability.

`test-values.yaml`

``` yaml
global:
  clusterId: azure-cluster
  federatedStorage:
    config: |-
      type: AZURE
      config:
        container: CONTAINER
        storage_account: STORAGE_ACCOUNT
        max_retries: 0
kubecostProductConfigs:
  clusterName: azure-cluster
prometheus:
  server:
    global:
      external_labels:
        cluster_id: azure-cluster
federatedETL:
  federatedCluster: true
kubecostModel:
  extraEnv:
    - name: AZURE_CLIENT_SECRET
      valueFrom:
        secretKeyRef:
          name: kubecost-federated-spn
          key: client_secret
    - name: AZURE_CLIENT_ID
      valueFrom:
        secretKeyRef:
          name: kubecost-federated-spn
          key: client_id
    - name: AZURE_TENANT_ID
      valueFrom:
        secretKeyRef:
          name: kubecost-federated-spn
          key: tenant_id
kubecostFrontend:
  enabled: true
forecasting:
  enabled: false
kubecostAggregator:
  deployMethod: statefulset
  extraEnv:
    - name: AZURE_CLIENT_SECRET
      valueFrom:
        secretKeyRef:
          name: kubecost-federated-spn
          key: client_secret
    - name: AZURE_CLIENT_ID
      valueFrom:
        secretKeyRef:
          name: kubecost-federated-spn
          key: client_id
    - name: AZURE_TENANT_ID
      valueFrom:
        secretKeyRef:
          name: kubecost-federated-spn
          key: tenant_id
  cloudCost:
    env:
      SOME_ENV: SOME_VALUE
    extraEnv:
      - name: AZURE_CLIENT_SECRET
        valueFrom:
          secretKeyRef:
            name: kubecost-federated-spn
            key: client_secret
      - name: AZURE_CLIENT_ID
        valueFrom:
          secretKeyRef:
            name: kubecost-federated-spn
            key: client_id
      - name: AZURE_TENANT_ID
        valueFrom:
          secretKeyRef:
            name: kubecost-federated-spn
            key: tenant_id
networkCosts:
  enabled: false
```

Template the chart:

```shell
helm template ./cost-analyzer --namespace kubecost -f ./cost-analyzer/test-values.yaml > template.yaml
```

Generated cloud cost deployment showing both values for `env` and `extraEnv`:

```yaml
---
# Source: cost-analyzer/templates/aggregator-cloud-cost-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-cloud-cost
  namespace: kubecost
  labels:
    helm.sh/chart: cost-analyzer-2.9.3
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cloud-cost
    app.kubernetes.io/instance: release-name
    app: cloud-cost
  annotations:
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: cloud-cost
      app.kubernetes.io/instance: release-name
      app: cloud-cost
  strategy:
    type: Recreate
  template:
    ...
    spec:
      ...
      containers:
        - name: cloud-cost
          ...
          env:
            - name: CONFIG_PATH
              value: /var/configs/
            - name: FEDERATED_STORE_CONFIG
              value: /var/configs/etl/federated/federated-store.yaml
            - name: FEDERATED_CLUSTER
              value: "true"
            - name: ETL_DAILY_STORE_DURATION_DAYS
              value: "91"
            - name: CLOUD_COST_REFRESH_RATE_HOURS
              value: "6"
            - name: CLOUD_COST_QUERY_WINDOW_DAYS
              value: "7"
            - name: CLOUD_COST_RUN_WINDOW_DAYS
              value: "3"
            - name: CUSTOM_COST_ENABLED
              value: "false"
            - name: "SOME_ENV"
              value: "SOME_VALUE"
            - name: AZURE_CLIENT_SECRET
              valueFrom:
                secretKeyRef:
                  key: client_secret
                  name: kubecost-federated-spn
            - name: AZURE_CLIENT_ID
              valueFrom:
                secretKeyRef:
                  key: client_id
                  name: kubecost-federated-spn
            - name: AZURE_TENANT_ID
              valueFrom:
                secretKeyRef:
                  key: tenant_id
                  name: kubecost-federated-spn
---
```

## Documentation Updates

N/A
