### PR TITLE
Add proxy for `/cloud/config/test`

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -437,6 +437,14 @@ data:
             proxy_set_header  X-Real-IP  $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+        location = /model/cloud/config/test {
+            proxy_read_timeout          {{ .Values.frontend.timeoutSeconds | default 300 }};
+            proxy_pass http://cloudCost/cloud/config/test;
+            proxy_redirect off;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         location = /model/cloudCost/integration/validate {
             proxy_read_timeout          {{ .Values.frontend.timeoutSeconds | default 300 }};
             proxy_pass http://cloudCost/cloudCost/integration/validate;


### PR DESCRIPTION
## Release Notes Headline
Users can now test cloud integrations before saving them.

## Commentary for Reviewers
Relates to https://github.com/kubecost/kubecost-cost-model/pull/3931.

## Links to Issues or Tickets
[KCM-3472](https://apptio.atlassian.net/browse/KCM-3472).

## User Impact and Risks
N/A.

## Testing
Validated that the proxy works as expected.

## Documentation Updates
N/A.


[KCM-3472]: https://apptio.atlassian.net/browse/KCM-3472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ