### PR TITLE
KCM-4903: Add annotations and creation logic to cluster controller SA

### DIFF
--- a/kubecost/templates/cluster-controller/cluster-controller-service-account.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-service-account.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.clusterController).enabled }}
+{{- if and (.Values.clusterController).enabled .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,4 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
       {{- include "kubecost.commonLabels" . | nindent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/kubecost/templates/cluster-controller/cluster-controller-service-account.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-service-account.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.clusterController).enabled .Values.serviceAccount.create }}
+{{- if and (.Values.clusterController).enabled .Values.clusterController.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
       {{- include "kubecost.commonLabels" . | nindent 4 }}
-{{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+  {{- if .Values.clusterController.serviceAccount.annotations }}
+    {{- toYaml .Values.clusterController.serviceAccount.annotations | nindent 4 }}
+  {{- else }}
+    {{-  toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1224,9 +1224,12 @@ cloudCost:
 ##
 clusterController:
   enabled: true
+  serviceAccount:
+    create: true
+    annotations: {}
 
-  # Enables legacy mode for cluster controller actions (v1)
-  # Only used with kubecost versions < 3.0.0
+  ## Enables legacy mode for cluster controller actions (v1)
+  ## Only used with kubecost versions < 3.0.0
   legacyMode: false
 
   ## Override the image name and version for the cluster controller.


### PR DESCRIPTION
## Release Notes Headline

Adjust the Cluster Controller's Service account to take into account `.Values.serviceAccount.create` and adds the appropriate annotations `.Values.serviceAccount.annotations` so that IRSA/Pod Identity annotations are appropriately added.

## Commentary for Reviewers

Mimic of Cloud Cost's Service Account ([ref](https://github.com/kubecost/kubecost/blob/b8c044792a64c5a83a2a6406e10c55200ccfa53a/kubecost/templates/cloud-cost/cloud-cost-service-account.yaml#L9))

## Links to Issues or Tickets

Addresses a known bug.

## User Impact and Risks

No risk. SA is not created if `.Values.serviceAccount.create` is false respecting the original intent of the flag.

## Testing

Using the workflow
```
cd kubecost
helm dependency update
helm template . --values.yaml > manifest.yaml
```

Adjusted the values.yaml for the following and verified the SA is not created in the `manifest.yaml`
```
clusterController:
   serviceAccount:
      create: false
```

Adjusted the `values.yaml` to add
```
clusterController:
   serviceAccount:
      create: true
      annotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/kubecost-role
```

Rendered `manifest.yaml`
```
# Source: kubecost/templates/cluster-controller/cluster-controller-service-account.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-cluster-controller
  namespace: default
  labels:
    app.kubernetes.io/name: kubecost
    helm.sh/chart: kubecost-0.0.0-dev
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: kubecost
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/kubecost-role
```

## Documentation Updates

N/A