### PR TITLE
Change deployment guide to saas deployment

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -641,8 +641,8 @@ spec:
             - name: DISPLAY_CURRENCY
               value: {{ (.Values.kubecostProductConfigs).currencyCode }}
             {{- end }}
-            {{- if .Values.deploymentGuide.enabled }}
-            - name: ENABLE_DEPLOYMENT_GUIDE
+            {{- if .Values.saasDeployment }}
+            - name: SAAS_DEPLOYMENT
               value: "true"
             {{- end }}
             {{- if .Values.aggregator.extraEnv -}}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -505,9 +505,9 @@ data:
             return 200 '{"aggregatorEnabled": "true"}';
         }
 
-        location /model/enableDeploymentGuide {
+        location /model/isSaaSDeployment {
             default_type 'application/json';
-            return 200 '{"enableDeploymentGuide": {{ .Values.deploymentGuide.enabled | quote }} }';
+            return 200 '{"saasDeployment": {{ .Values.saasDeployment | quote }} }';
         }
 
         {{- if .Values.forecasting.enabled }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1552,9 +1552,8 @@ kubecostProductConfigs:
   #   squareLogoExt: "" # the extension of the square logo
   #   squareLogoAltText: "" # alt text to apply to the img tags for the square logo
 
-# Enable to display the deployment guide in the Kubecost UI for installing the FinOps Agent when provisioning via advanced containers
-deploymentGuide:
-  enabled: false
+# Set to true if the deployment is a SaaS deployment (Internal flag for Kubecost to use, users should not set this on their own)
+saasDeployment: false
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates


### PR DESCRIPTION
## Release Notes Headline
Update Deployment guide naming to saas deployment

## Commentary for Reviewers
Update Deployment guide naming to saas deployment so that `SAAS_DEPLOYMENT` env. var can be used for a more broader things to enable and disable few functionality
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
Related PR: 
https://github.com/kubecost/kubecost-cost-model/pull/4017
https://github.com/kubecost/kubecost-integration-tests/pull/375/changes
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
No user impact, this config is only required for SaaS customers, which we handle.
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
