### PR TITLE
chore: Use full template in persistentVolumeTemplates

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -24,7 +24,9 @@ spec:
     matchLabels:
     {{- include "kubecost.aggregator.selectorLabels" . | nindent 6 }}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       name: aggregator-db-storage
     spec:
       accessModes: [ "ReadWriteOnce" ]
@@ -36,7 +38,9 @@ spec:
       resources:
         requests:
           storage:  {{ .Values.aggregator.aggregatorDbStorage.storageRequest }}
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       # In the StatefulSet config, Aggregator should not share any filesystem
       # state with the cost-model to maintain independence and improve
       # stability (in the event of bad file-locking state). Still, there is


### PR DESCRIPTION
Use full template in persistentVolumeTemplate to make ArgoCD and helm diff understand there is no changes.

## Release Notes Headline

In aggregator statefulset, explicitly state the full template, including `apiVersion` and `kind`. 
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

Closes #4503.

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

I don't see any particular risks, as the `apiVersion` and `kind` is already default values.

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
Tested in 

- Openshift 4.20.8 (k8s 1.33) with ArgoCD 3.1.9 (openshift-gitops)
- Openshift 4.20.8 (k8s 1.33) with helm v4.0.4 and helm diff 3.14.1
- Kind 1.33.1 with ArgoCD 3.2.3
- Kind 1.33.1 with helm v4.0.4 and helm diff 3.14.1
- Kind 1.35.0 with helm v4.0.4 and helm diff 3.14.1

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
