### PR TITLE
v3.0 Cherry-pick/4512-to-v3.0

### DIFF
--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -8,6 +8,7 @@
 {{- include "kubecost.caCertsSecretConfig.check" . -}}
 {{- include "kubecost.actionsStorageSourceCheck" . -}}
 {{- include "kubecost.finopsagentCheck" . -}}
+{{- include "kubecost.cloudCost.persistentStorage.check" . -}}
 ================================================================================
 KUBECOST INSTALLATION SUCCESSFUL
 ================================================================================

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -477,6 +477,25 @@ kubecost.costEventsAudit.enabled flag for nginx configmap
   {{- end }}
 {{- end }}
 
+{{/*
+Check if cloud cost persistent storage is disabled and warn user
+*/}}
+{{- define "kubecost.cloudCost.persistentStorage.check" }}
+{{- if .Values.cloudCost.enabled }}
+{{- if not ((.Values.cloudCost).persistentConfigsStorage).enabled }}
+{{- if not (or .Values.cloudCost.cloudIntegrationSecret .Values.cloudCost.cloudIntegrationJSON .Values.kubecostProductConfigs.cloudIntegrationJSON .Values.kubecostProductConfigs.cloudIntegrationSecret) }}
+
+WARNING: Cloud Cost persistent storage is disabled and no cloud integration secret is configured.
+Cloud cost configuration data may be lost on pod restart.
+To resolve this, either:
+  1. Enable persistent storage: cloudCost.persistentConfigsStorage.enabled=true (recommended)
+  2. Configure a cloud integration secret to store configurations externally
+
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "kubecost.plugins.enabled" }}
 {{- if (.Values.plugins).enabled }}
 {{- printf "true" -}}

--- a/kubecost/templates/cloud-cost/cloud-cost-deployment.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-deployment.yaml
@@ -1,7 +1,4 @@
 {{- if .Values.cloudCost.enabled }}
-{{- /*
-  TODO add a pvc for persistent configs and maybe a warning if both the pv and secret are not enabled
-*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -68,10 +65,21 @@ spec:
               - key: cloud-integration.json
                 path: cloud-integration.json
         {{- end }}
-        {{- /* The cloud costs deployment does not need persistence.
-            The name is for compatibility with single-pod install. */}}
+        {{- if and ((.Values.cloudCost).persistentConfigsStorage).enabled }}
+        {{- if ((.Values.cloudCost).persistentConfigsStorage).existingClaim }}
+        - name: persistent-configs
+          persistentVolumeClaim:
+            claimName: {{ .Values.cloudCost.persistentConfigsStorage.existingClaim }}
+        {{- else }}
+        - name: persistent-configs
+          persistentVolumeClaim:
+            claimName: {{ include "kubecost.cloudCost.fullname" . }}-persistent-configs
+        {{- end }}
+        {{- else }}
+        {{- /* Fallback to emptyDir when persistent storage is disabled */}}
         - name: persistent-configs
           emptyDir: {}
+        {{- end }}
         {{- if .Values.plugins.enabled  }}
         {{- if .Values.plugins.install.enabled}}
         - name: install-script

--- a/kubecost/templates/cloud-cost/cloud-cost-persistent-configs-pvc.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-persistent-configs-pvc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.cloudCost.enabled }}
+{{- if and ((.Values.cloudCost).persistentConfigsStorage).enabled (not ((.Values.cloudCost).persistentConfigsStorage).existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "kubecost.cloudCost.fullname" . }}-persistent-configs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubecost.cloudCost.commonLabels" . | nindent 4 }}
+    {{- with .Values.global.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.global.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.cloudCost.persistentConfigsStorage.storageClass }}
+  storageClassName: {{ .Values.cloudCost.persistentConfigsStorage.storageClass }}
+  {{- else if .Values.global.defaultStorageClass }}
+  storageClassName: {{ .Values.global.defaultStorageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.cloudCost.persistentConfigsStorage.size }}
+{{- end -}}
+{{- end -}}

--- a/kubecost/values-storage.yaml
+++ b/kubecost/values-storage.yaml
@@ -1,0 +1,46 @@
+## There are 4 persistent volumes that are created when using default settings.
+## When installing on a cluster that does not have a default storage class, you will need to set the storageClass for each of the persistent volumes.
+## This can be done with the global.defaultStorageClass or the storageClass parameter in the finopsagent, aggregator, or localStore blocks.
+## The values below are the defaults that are used if not overridden - this file is just a summary of what is in ./values.yaml
+
+## global.defaultStorageClass will set the default storage class to use, unless overridden by the storageClass parameter in the finopsagent, aggregator, or localStore blocks.
+global:
+  defaultStorageClass: ""
+
+## When not using federated storage, the long-term metrics are stored in the localStore.
+localStore:
+  persistentVolume:
+    storageClass: ""
+    size: 32Gi
+    ## Note that setting enabled to false means all data will be lost out on pod restart unless using federated storage.
+    enabled: true
+
+## short-term (<2 days) metrics are stored by the finops agent.
+finopsagent:
+  persistence:
+    storageClass: ""
+    size: 8Gi
+    enabled: true
+
+aggregator:
+  ## The aggregator pod has 2 PVCs and will need to be in the same availability zone unless using multi-zone storage.
+  ## Storage classes that have 'volumeBindingMode: WaitForFirstConsumer' will do this automatically.
+  ## Settings and reports created via the UI are stored in the persistentConfigs volume.
+  persistentConfigsStorage:
+    storageClass: ""
+    ## If using high iops storage, the storageRequest may need to be increased to meet the provider's minimum ratio for gb/iops.
+    storageRequest: 1Gi
+  aggregatorDbStorage:
+    ## IOPS performance of the aggregatorDbStorage will have significant impact on the performance of queries.
+    ## block storage is REQUIRED for the aggregatorDbStorage. NFS/file is not supported.
+    storageClass: ""
+    storageRequest: 128Gi
+
+cloudCost:
+  ## Persistent storage for cloud cost configs
+  ## Settings and configurations created via the UI are stored in the persistentConfigs volume.
+  persistentConfigsStorage:
+    enabled: true
+    storageClass: ""  # Uses global.defaultStorageClass if not specified
+    storageRequest: 1Gi
+    existingClaim: ""  # Optional: use an existing PVC instead of creating a new one

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1213,6 +1213,14 @@ cloudCost:
   extraVolumes: []
   extraVolumeMounts: []
 
+  ## Persistent storage for cloud cost configs
+  ## Settings and configurations created via the UI are stored in the persistentConfigs volume.
+  persistentConfigsStorage:
+    enabled: true
+    storageClass: ""  # Uses global.defaultStorageClass if not specified
+    size: 1Gi
+    existingClaim: ""  # Optional: use an existing PVC instead of creating a new one
+
 ## Kubecost Cluster Controller for Automated Right Sizing and Turndown
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-cluster-controller
 ##


### PR DESCRIPTION
(cherry picked from commit 3e85fb8ba7af94ef15967843d6d0f51b4c5783c1)

the 3.0 branch didn't have the values-storage.yaml (because it is just an example). but the CP needs it. so manually fixed CP.
