### PR TITLE
add flag to disable cloud costs

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -554,6 +554,7 @@ data:
                 "hideCloudIntegrationsUI": "{{ default false ((.Values.kubecostProductConfigs).hideCloudIntegrationsUI) }}",
                 "hideBellIcon": "{{ default true ((.Values.kubecostProductConfigs).hideBellIcon) }}",
                 "hideTeams": "{{ default false ((.Values.kubecostProductConfigs).hideTeams) }}",
+                "hideCloudCosts": "{{ default false ((.Values.kubecostProductConfigs).hideCloudCosts)}}",
                 "legacyModeEnabled": "{{ .Values.aggregator.legacyMode }}",
                 "clusterId": "{{ include "kubecost.clusterId" . }}",
                 "defaultSavingsProfile": "{{ .Values.kubecostProductConfigs.clusterProfile }}"

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1521,6 +1521,7 @@ kubecostProductConfigs:
   hideCloudIntegrationsUI: false
   hideBellIcon: true  # Deprecated in v2.7. Default is true, which hides the bell icon in the top right corner of the UI. The new diagnostics is top level in left nav. Change to false to restore the bell icon.
   hideTeams: false
+  hideCloudCosts: false
 
 #   savingsProfiles: # Define custom profiles used in the Right-Size Container Request savings card. Supported parameters are explained in https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=apis-container-request-right-sizing-recommendation-api.
 #     requestSizing:


### PR DESCRIPTION
## Release Notes Headline

Add a flag to disable cloud costs in the application (partial support)

## Commentary for Reviewers

Adds a new value `kubecostProductConfigs.hideCloudCosts` and pipes it through to the `model/productConfigs` endpoint. The main use for this atm it to have a more explicit check for advanced containers to disable certain features.

## Links to Issues or Tickets

## User Impact and Risks

Low risk, the biggest risks are:

1. the FE not fully honoring this flag everywhere leading to confusion
2. this is purely a presentation flag, it doesn't affect any of the data pipelines. Which might also cause confusion?

## Testing

Created a test values file, and validated the template output had the expected NGINX block

## Documentation Updates
