### PR TITLE
[KCM-5084] Teams: Set up placeholder for resource quota filters

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -399,6 +399,7 @@ teams:
     #       value: cluster-one
     #     assetFilters: []
     #     cloudCostFilters: []
+    #     resourceQuotaFilters: []
     #   claims:
     #     NameID: email@domain.com
 


### PR DESCRIPTION
## Release Notes Headline

Add resource quota filters in Teams helm config.

## Commentary for Reviewers

Add resource quota filters in Teams helm config. Note that the filters must be added in a slice in format `key + operator + value`

## Links to Issues or Tickets

https://apptio.atlassian.net/browse/KCM-5084
Implementation in https://github.com/kubecost/kubecost-cost-model/pull/4086

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

https://apptio.atlassian.net/browse/KCM-5085
