### PR TITLE
Sample CAC values file

### DIFF
--- a/kubecost/templates/aggregator/aggregator-role-binding.yaml
+++ b/kubecost/templates/aggregator/aggregator-role-binding.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.aggregator).enabled }}
 {{- if (.Values.reporting).logCollection }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -14,4 +15,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kubecost.aggregator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/kubecost/templates/aggregator/aggregator-role.yaml
+++ b/kubecost/templates/aggregator/aggregator-role.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.aggregator).enabled }}
 {{- if (.Values.reporting).logCollection -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -21,4 +22,5 @@ rules:
       - pods
     verbs:
       - list
+{{- end }}
 {{- end }}

--- a/kubecost/templates/aggregator/aggregator-values-configmap.yaml
+++ b/kubecost/templates/aggregator/aggregator-values-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.aggregator).enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,4 @@ metadata:
 data:
   user-values.json: |
     {{- .Values | toJson | nindent 4 }}
+{{- end }}

--- a/kubecost/templates/kubecost-role-binding-template.yaml
+++ b/kubecost/templates/kubecost-role-binding-template.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.aggregator.enabled .Values.cloudCost.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kubecost.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/kubecost/templates/kubecost-role-template.yaml
+++ b/kubecost/templates/kubecost-role-template.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.aggregator.enabled .Values.cloudCost.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -24,7 +25,4 @@ rules:
       - update
       - patch
       - delete
-  
-
-
-
+{{- end }}

--- a/kubecost/templates/kubecost-service-account.yaml
+++ b/kubecost/templates/kubecost-service-account.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.aggregator.enabled .Values.cloudCost.enabled }}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,5 +10,6 @@ metadata:
 {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/kubecost/values-cac.yaml
+++ b/kubecost/values-cac.yaml
@@ -15,6 +15,8 @@ clusterController:
 networkCosts:
   enabled: true
 
+# The below values should not be modified when using Cloudability Advanced
+# Containers (CAC)
 finopsagent:
   enabled: false
 aggregator:

--- a/kubecost/values-cac.yaml
+++ b/kubecost/values-cac.yaml
@@ -1,4 +1,4 @@
-# Sample values.yaml file for Cloudability Advanced Contaienrs (CAC) users who
+# Sample values.yaml file for Cloudability Advanced Containers (CAC) users who
 # want to run Cluster Controller and Network Costs
 
 global:

--- a/kubecost/values-cac.yaml
+++ b/kubecost/values-cac.yaml
@@ -1,0 +1,29 @@
+# Sample values.yaml file for Cloudability Advanced Contaienrs (CAC) users who
+# want to run Cluster Controller and Network Costs
+
+global:
+  clusterId: ""  # MUST MATCH THE CLUSTERID SET IN THE FINOPS AGENT CHART
+  federatedStorage:
+    # This is the default kubernetes secret name of the finops agent's federated
+    # storage config. This can be overridden or a config can be provided via
+    # string.
+    existingSecret: "ibm-finops-agent-federated-storage-config"
+    config: ""
+
+clusterController:
+  enabled: true
+networkCosts:
+  enabled: true
+
+finopsagent:
+  enabled: false
+aggregator:
+  enabled: false
+frontend:
+  enabled: false
+localStore:
+  enabled: false
+forecasting:
+  enabled: false
+cloudCost:
+  enabled: false


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
Only templates Aggregator-specific manifests, if the Aggregator is enabled.

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
- Only templates Aggregator or CloudCost specific manifests if those services are enabled. This allows for a cleaner installation if users only want to enable ClusterController or NetworkCosts.
- Provide a sample `values.yaml` file for Cloudability Advanced Containers users

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- https://apptio.atlassian.net/browse/KCM-5115

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
In environments where Aggregator or CloudCosts are disabled (for example on secondary clusters), upon upgrade we will remove some Roles, RoleBindings, ServiceAccounts, and ConfigMaps. This should not affect the Kubecost product, as those manifests were only required by Aggregator/CloudCosts, but it's unclear if users have built other dependencies on these resources.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

### Templating

Running `helm template` shows that all ClusterController and NetworkCosts templates are being rendered. No additional unnecessary resources are templated.

```
$ cd kubecost
$ helm template test-cac . -f values-cac.yaml --set global.clusterId=test-cluster 2>&1 | grep -E "^# Source:" | sort | uniq

# Source: kubecost/templates/cluster-controller/cluster-controller-cluster-role-binding.yaml
# Source: kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
# Source: kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
# Source: kubecost/templates/cluster-controller/cluster-controller-service-account.yaml
# Source: kubecost/templates/cluster-controller/cluster-controller-service.yaml
# Source: kubecost/templates/network-costs/network-costs-cluster-role-binding.yaml
# Source: kubecost/templates/network-costs/network-costs-cluster-role.yaml
# Source: kubecost/templates/network-costs/network-costs-configmap.yaml
# Source: kubecost/templates/network-costs/network-costs-daemonset.yaml
# Source: kubecost/templates/network-costs/network-costs-service-account.yaml
# Source: kubecost/templates/network-costs/network-costs-service.yaml
# Source: kubecost/templates/tests/basic-health.yaml
```

When Aggregator is enabled, all its templates and the kubecost-service-account are rendered.

```
$ helm template test-cac . -f values-cac.yaml --set global.clusterId=test-cluster --set aggregator.enabled=true 2>&1 | grep -E "^# Source:" | sort | uniq

# Source: kubecost/templates/aggregator/aggregator-api-configmap.yaml
# Source: kubecost/templates/aggregator/aggregator-role-binding.yaml
# Source: kubecost/templates/aggregator/aggregator-role.yaml
# Source: kubecost/templates/aggregator/aggregator-service.yaml
# Source: kubecost/templates/aggregator/aggregator-statefulset.yaml
# Source: kubecost/templates/aggregator/aggregator-values-configmap.yaml
# Source: kubecost/templates/cluster-controller/cluster-controller-cluster-role-binding.yaml
# Source: kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
# Source: kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
# Source: kubecost/templates/cluster-controller/cluster-controller-service-account.yaml
# Source: kubecost/templates/cluster-controller/cluster-controller-service.yaml
# Source: kubecost/templates/kubecost-role-binding-template.yaml
# Source: kubecost/templates/kubecost-role-template.yaml
# Source: kubecost/templates/kubecost-service-account.yaml
# Source: kubecost/templates/network-costs/network-costs-cluster-role-binding.yaml
# Source: kubecost/templates/network-costs/network-costs-cluster-role.yaml
# Source: kubecost/templates/network-costs/network-costs-configmap.yaml
# Source: kubecost/templates/network-costs/network-costs-daemonset.yaml
# Source: kubecost/templates/network-costs/network-costs-service-account.yaml
# Source: kubecost/templates/network-costs/network-costs-service.yaml
# Source: kubecost/templates/tests/basic-health.yaml
```

### Applying

```
$ kubectl create secret generic ibm-finops-agent-federated-storage-config --from-file examples/federatedStorage/aws/federated-store.yaml
secret/ibm-finops-agent-federated-storage-config created
```

```
$ cd kubecost
$ helm upgrade -i thomasn-kcm5115 . -f values-cac.yaml --set global.clusterId=test-cluster
```

Validated that only NetworkCosts and ClusterController resources were created.

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A
