### PR TITLE
Fix diagnostics and heartbeat disable issue

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -507,18 +507,14 @@ spec:
             {{- end }}
             - name: CUSTOM_COST_ENABLED
               value: {{ .Values.plugins.enabled | quote }}
-            {{- if .Values.diagnostics.enabled }}
             - name: DIAGNOSTICS_ENABLED
-              value: "true"
+              value: {{ .Values.diagnostics.enabled | quote }}
             - name: DIAGNOSTICS_RETENTION
               value: {{ .Values.diagnostics.retention | quote }}
-            {{- end }}
-            {{- if .Values.heartbeat.enabled }}
             - name: HEARTBEAT_ENABLED
-              value: "true"
+              value: {{ .Values.heartbeat.enabled | quote }}
             - name: HEARTBEAT_RETENTION
               value: {{ .Values.heartbeat.retention | quote }}
-            {{- end }}
             {{- if .Values.kubecostProductConfigs.apiConfigMapName }}
             - name: API_CONFIGMAP_NAME
               value: {{ .Values.kubecostProductConfigs.apiConfigMapName }}


### PR DESCRIPTION
## Release Notes Headline
Make diagnostics and heartbeat to acknowledge disabled config
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
When diagnostics or heartbeat is disabled, we do not set its variable to either true or false. the aggregator defaults to diagnostics/heartbeat true if it does not find their env. vars., in turn making it impossible to disable the diagnostics by intended way.
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
helm template
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
