### PR TITLE
Add annotations to PVCs

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       # a need to "mount" ConfigMap files (using the watcher) to a file system;
       # that's what this per-replica Volume is used for.
       name: persistent-configs
-      {{- with .Values.aggregator.aggregatorDbStorage.annotations }}
+      {{- with .Values.aggregator.persistentConfigsStorage.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -28,6 +28,10 @@ spec:
     kind: PersistentVolumeClaim
     metadata:
       name: aggregator-db-storage
+      {{- with .Values.aggregator.aggregatorDbStorage.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.aggregator.aggregatorDbStorage.storageClass }}
@@ -47,6 +51,10 @@ spec:
       # a need to "mount" ConfigMap files (using the watcher) to a file system;
       # that's what this per-replica Volume is used for.
       name: persistent-configs
+      {{- with .Values.aggregator.aggregatorDbStorage.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.aggregator.persistentConfigsStorage.storageClass }}

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -28,10 +28,13 @@ spec:
     kind: PersistentVolumeClaim
     metadata:
       name: aggregator-db-storage
-      {{- with .Values.aggregator.aggregatorDbStorage.annotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- with .Values.global.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.aggregator.aggregatorDbStorage.annotations }}      
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.aggregator.aggregatorDbStorage.storageClass }}
@@ -51,8 +54,11 @@ spec:
       # a need to "mount" ConfigMap files (using the watcher) to a file system;
       # that's what this per-replica Volume is used for.
       name: persistent-configs
-      {{- with .Values.aggregator.persistentConfigsStorage.annotations }}
       annotations:
+        {{- with .Values.global.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.aggregator.persistentConfigsStorage.annotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/kubecost/templates/cloud-cost/cloud-cost-persistent-configs-pvc.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-persistent-configs-pvc.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- with .Values.global.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.global.annotations }}
+  {{- with .Values.cloudCost.persistentConfigsStorage.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/kubecost/templates/cloud-cost/cloud-cost-persistent-configs-pvc.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-persistent-configs-pvc.yaml
@@ -10,8 +10,11 @@ metadata:
     {{- with .Values.global.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cloudCost.persistentConfigsStorage.annotations }}
   annotations:
+  {{- with .Values.global.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cloudCost.persistentConfigsStorage.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/kubecost/templates/local-store/cluster-storage-pvc.yaml
+++ b/kubecost/templates/local-store/cluster-storage-pvc.yaml
@@ -10,8 +10,11 @@ metadata:
     {{- with .Values.localStore.persistentVolume.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.localStore.persistentVolume.annotations }}
   annotations:
+  {{- with .Values.localStore.persistentVolume.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.global.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -619,6 +619,7 @@ finopsagent:
     ##
     storageClass: ""
     size: 8Gi
+    annotations: {}
 
   agent:
     collectorDataSource:
@@ -1023,11 +1024,13 @@ aggregator:
     storageClass: ""
     ## If using high iops storage, the storageRequest may need to be increased to meet the provider's minimum ratio for gb/iops.
     storageRequest: 1Gi
+    annotations: {}
   aggregatorDbStorage:
     ## IOPS performance of the aggregatorDbStorage will have significant impact on the performance of queries.
     ## block storage is REQUIRED for the aggregatorDbStorage. NFS/file is not supported.
     storageClass: ""
     storageRequest: 128Gi
+    annotations: {}
   resources:
     ## Consider setting a limit after a baseline has been established
     limits: {}
@@ -1227,6 +1230,7 @@ cloudCost:
     storageClass: ""  # Uses global.defaultStorageClass if not specified
     size: 1Gi
     existingClaim: ""  # Optional: use an existing PVC instead of creating a new one
+    annotations: {}
 
 ## Kubecost Cluster Controller for Automated Right Sizing and Turndown
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-cluster-controller

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -619,8 +619,9 @@ finopsagent:
     ##
     storageClass: ""
     size: 8Gi
-    annotations: {}
-
+    annotations:
+      ## The "helm.sh/resource-policy: keep" annotation is used to prevent the persistent volume from being deleted when uninstalling or moving to a different deployment method.
+      helm.sh/resource-policy: keep
   agent:
     collectorDataSource:
       enabled: true
@@ -1024,13 +1025,17 @@ aggregator:
     storageClass: ""
     ## If using high iops storage, the storageRequest may need to be increased to meet the provider's minimum ratio for gb/iops.
     storageRequest: 1Gi
-    annotations: {}
+    annotations:
+      ## The "helm.sh/resource-policy: keep" annotation is used to prevent the persistent volume from being deleted when uninstalling or moving to a different deployment method.
+      helm.sh/resource-policy: keep
   aggregatorDbStorage:
     ## IOPS performance of the aggregatorDbStorage will have significant impact on the performance of queries.
     ## block storage is REQUIRED for the aggregatorDbStorage. NFS/file is not supported.
     storageClass: ""
     storageRequest: 128Gi
-    annotations: {}
+    annotations:
+      ## The "helm.sh/resource-policy: keep" annotation is used to prevent the persistent volume from being deleted when uninstalling or moving to a different deployment method.
+      helm.sh/resource-policy: keep
   resources:
     ## Consider setting a limit after a baseline has been established
     limits: {}
@@ -1230,7 +1235,9 @@ cloudCost:
     storageClass: ""  # Uses global.defaultStorageClass if not specified
     size: 1Gi
     existingClaim: ""  # Optional: use an existing PVC instead of creating a new one
-    annotations: {}
+    annotations:
+      ## The "helm.sh/resource-policy: keep" annotation is used to prevent the persistent volume from being deleted when uninstalling or moving to a different deployment method.
+      helm.sh/resource-policy: keep
 
 ## Kubecost Cluster Controller for Automated Right Sizing and Turndown
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-cluster-controller


### PR DESCRIPTION
## Release Notes Headline
Add annotations to PVCs

## Commentary for Reviewers
Add helm config to allow users to add annotations to PVCs.
Also added a default PVC annotation `helm.sh/resource-policy: keep` to prevent them from getting deleted
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
helm template
helm install and confirmed the created PVCs had custom annotations and if no custom annotations were given, it had the default `helm.sh/resource-policy: keep` annotation.
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
