### PR TITLE
FIX: Standardize cloud-cost service account configuration

### DIFF
--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -620,7 +620,7 @@ This will block upgrades until the new value is used, which very few would have 
 */}}
 {{- define "kubecost.finopsagentCheck" -}}
 {{- if index .Values "finops-agent" }}
-  {{ fail "\nThe helm values for finops-agent have been updated.\nPlease change the finops-agent: key in your helm values to finopsagent:\nIf you are using helm with a local repo clone, be sure to run\nhelm dependency build ./kubecost\nbefore installing or upgrading.\n" }}
+  {{ fail "\nThe helm values for finops-agent have been updated.\nPlease change the finops-agent: key in your helm values to finopsagent:\nIf you are using helm with a local repo clone, be sure to run\nhelm dependency update kubecost/\nbefore installing or upgrading.\n" }}
 {{- end -}}
 {{- end -}}
 

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -620,7 +620,7 @@ This will block upgrades until the new value is used, which very few would have 
 */}}
 {{- define "kubecost.finopsagentCheck" -}}
 {{- if index .Values "finops-agent" }}
-  {{ fail "\nThe helm values for finops-agent have been updated.\nPlease change the finops-agent: key in your helm values to finopsagent:" }}
+  {{ fail "\nThe helm values for finops-agent have been updated.\nPlease change the finops-agent: key in your helm values to finopsagent:\nIf you are using helm with a local repo clone, be sure to run\nhelm dependency build ./kubecost\nbefore installing or upgrading.\n" }}
 {{- end -}}
 {{- end -}}
 

--- a/kubecost/templates/cloud-cost/_helpers.tpl
+++ b/kubecost/templates/cloud-cost/_helpers.tpl
@@ -60,10 +60,10 @@ support templating a chart which uses the lookup function.
 {{- end -}}
 
 {{- define "kubecost.cloudCost.serviceAccountName" -}}
-{{- if .Values.cloudCost.serviceAccountName -}}
-    {{ .Values.cloudCost.serviceAccountName }}
+{{- if .Values.cloudCost.serviceAccount.name -}}
+    {{ .Values.cloudCost.serviceAccount.name }}
 {{- else -}}
-    {{ template "kubecost.serviceAccountName" . }}
+    {{ include "kubecost.cloudCost.fullname" . }}
 {{- end -}}
 {{- end -}}
 

--- a/kubecost/templates/cloud-cost/_helpers.tpl
+++ b/kubecost/templates/cloud-cost/_helpers.tpl
@@ -62,6 +62,8 @@ support templating a chart which uses the lookup function.
 {{- define "kubecost.cloudCost.serviceAccountName" -}}
 {{- if .Values.cloudCost.serviceAccount.name -}}
     {{ .Values.cloudCost.serviceAccount.name }}
+{{- else if .Values.cloudCost.serviceAccount.useSharedServiceAccount -}}
+    {{ template "kubecost.serviceAccountName" . }}
 {{- else -}}
     {{ include "kubecost.cloudCost.fullname" . }}
 {{- end -}}

--- a/kubecost/templates/cloud-cost/cloud-cost-service-account.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-service-account.yaml
@@ -1,18 +1,15 @@
-{{- if and .Values.cloudCost.serviceAccount.create (not .Values.cloudCost.serviceAccount.name) }}
+{{- if and (.Values.cloudCost).enabled .Values.cloudCost.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "kubecost.cloudCost.serviceAccountName" . }}
+  name: {{ include "kubecost.cloudCost.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "kubecost.cloudCost.commonLabels" . | nindent 4 }}
-{{- with .Values.cloudCost.serviceAccount.annotations }}
+      {{- include "kubecost.commonLabels" . | nindent 4 }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-{{- else }}
-{{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
-{{- end }}
+  {{- if .Values.cloudCost.serviceAccount.annotations }}
+    {{- toYaml .Values.cloudCost.serviceAccount.annotations | nindent 4 }}
+  {{- else }}
+    {{-  toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/kubecost/templates/cloud-cost/cloud-cost-service-account.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-service-account.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.cloudCost.serviceAccountName }}
+{{- if and .Values.cloudCost.serviceAccount.create (not .Values.cloudCost.serviceAccount.name) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,8 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.cloudCost.commonLabels" . | nindent 4 }}
+{{- with .Values.cloudCost.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- else }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/kubecost/templates/cloud-cost/cloud-cost-service-account.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-service-account.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kubecost.cloudCost.fullname" . }}
+  name: {{ include "kubecost.cloudCost.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
       {{- include "kubecost.commonLabels" . | nindent 4 }}

--- a/kubecost/templates/cloud-cost/cloud-cost-service-account.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-service-account.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.cloudCost).enabled .Values.cloudCost.serviceAccount.create }}
+{{- if and .Values.cloudCost.enabled .Values.cloudCost.serviceAccount.create (not .Values.cloudCost.serviceAccount.useSharedServiceAccount) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1201,8 +1201,16 @@ cloudCost:
   queryWindowDays: "7"
   runWindowDays: "3"
 
+  ## Service account configuration for cloud cost pod
+  serviceAccount:
+    create: true
+    annotations: {}
+    ## Optionally specify an existing service account name to use instead of creating one
+    name: ""
+
   ## By default, the cloud cost pod will use the same service account as the aggregator pod.
   ## This can be overridden to use a different service account.
+  ## DEPRECATED: Use serviceAccount.name instead
   serviceAccountName: ""
 
   readinessProbe:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1208,6 +1208,9 @@ cloudCost:
     annotations: {}
     ## Optionally specify an existing service account name to use instead of creating one
     name: ""
+    ## When using a unique cloud-cost service account, set this to false
+    ## Default is true for backward compatibility
+    useSharedServiceAccount: true
 
   readinessProbe:
     enabled: true

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1209,11 +1209,6 @@ cloudCost:
     ## Optionally specify an existing service account name to use instead of creating one
     name: ""
 
-  ## By default, the cloud cost pod will use the same service account as the aggregator pod.
-  ## This can be overridden to use a different service account.
-  ## DEPRECATED: Use serviceAccount.name instead
-  serviceAccountName: ""
-
   readinessProbe:
     enabled: true
     initialDelaySeconds: 10


### PR DESCRIPTION
## Release Notes Headline

Standardize cloud-cost service account configuration to match cluster-controller pattern

## Commentary for Reviewers

This PR aligns the cloud-cost service account configuration with the cluster-controller pattern for consistency across the codebase. Key changes:

1. **Service Account Template**: Updated condition logic to check both `enabled` and `serviceAccount.create` flags, matching cluster-controller behavior
2. **Naming Convention**: Changed to use `kubecost.cloudCost.fullname` helper to include release name prefix (e.g., `my-release-cloud-cost` instead of just `cloud-cost`)
3. **Annotations Logic**: Simplified to use single-level if/else with fallback to global `serviceAccount.annotations`
4. **Helper Function**: Updated `kubecost.cloudCost.serviceAccountName` to use `fullname` instead of `name`
5. **Values Cleanup**: Removed deprecated `cloudCost.serviceAccountName` field in favor of `cloudCost.serviceAccount.name`

## Links to Issues or Tickets

N/A

## User Impact and Risks

**Impact:**
- Service account names will now include the release name prefix (e.g., `my-release-cloud-cost`)
- Users upgrading will see a new service account created with the prefixed name
- The old service account (without prefix) will remain but won't be used

**Risks:**
- **Breaking Change**: Existing deployments using the cloud-cost service account will need to update any references to the new prefixed name
- RBAC configurations referencing the old service account name will need updates
- Workload identity/IAM role bindings tied to the old service account name must be reconfigured

**Mitigation:**
- Users can override with `cloudCost.serviceAccount.name` to maintain the old name if needed
- Clear upgrade notes should be provided in release documentation

## Testing

- Verified template syntax matches cluster-controller pattern
- Confirmed `kubecost.cloudCost.fullname` helper generates correct name with release prefix
- Validated annotation fallback logic works correctly
- Checked that `serviceAccount.name` override still functions as expected
<img width="341" height="115" alt="image" src="https://github.com/user-attachments/assets/fe2749f4-7c1f-452a-bcc8-178b7de0247a" />

## Documentation Updates

Documentation should be updated to reflect:
- New service account naming convention
- Migration steps for existing deployments
- How to use `cloudCost.serviceAccount.name` to override the default name