### PR TITLE
Nit fix product config response json that got missed in #4557

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -557,7 +557,7 @@ data:
                 "hideCloudCosts": "{{ default false ((.Values.kubecostProductConfigs).hideCloudCosts)}}",
                 "legacyModeEnabled": "{{ .Values.aggregator.legacyMode }}",
                 "clusterId": "{{ include "kubecost.clusterId" . }}",
-                "defaultSavingsProfile": "{{ .Values.kubecostProductConfigs.clusterProfile }}"
+                "defaultSavingsProfile": "{{ .Values.kubecostProductConfigs.clusterProfile }}",
                 "defaultIdle": "{{ .Values.kubecostProductConfigs.defaultIdle }}",
                 "currencyCode": "{{ .Values.kubecostProductConfigs.currencyCode }}"
                 }


### PR DESCRIPTION
## Release Notes Headline
Nit fix product config response json that got missed in #4557
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
#4557 was missing a , from the response of `/productConfig` endpoint causing the frontend to break
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
https://github.com/kubecost/kubecost/pull/4557
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
