### PR TITLE
Removes `/model/getConfigs`

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -573,25 +573,6 @@ data:
             ';
         }
 
-        # TODO: Remove this endpoint. All these configs will become available in the backend's `/model/getApiConfigs` and `/model/setApiConfigs`. They will also be configured in a ConfigMap. https://github.com/kubecost/kubecost/pull/4472.
-        location = /model/getConfigs {
-            default_type 'application/json';
-            return 200 '{
-                "code": 200,
-                "status": "success",
-                "data": {
-                    "defaultIdle": "{{ .Values.kubecostProductConfigs.defaultIdle }}",
-                    "currencyCode": "{{ .Values.kubecostProductConfigs.currencyCode }}",
-                    "negotiatedDiscount": "{{ .Values.kubecostProductConfigs.negotiatedDiscount }}",
-                    "sharedOverhead": "{{ .Values.kubecostProductConfigs.sharedOverhead }}",
-                    "sharedNamespaces": "{{ .Values.kubecostProductConfigs.sharedNamespaces }}",
-                    "sharedLabelNames": "{{ .Values.kubecostProductConfigs.sharedLabelNames }}",
-                    "sharedLabelValues": "{{ .Values.kubecostProductConfigs.sharedLabelValues }}",
-                    "shareTenancyCosts": "{{ .Values.kubecostProductConfigs.shareTenancyCosts }}"
-                }
-            }';
-        }
-
         # Branding Routes
         {{- $branding := .Values.kubecostProductConfigs.branding}}
         location /custom-branding/info {


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
N/A

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
- We can now remove this API from the Nginx config. The frontend will no longer call `/model/getConfigs`. Instead it will call `/model/getApiConfig`, `/model/setApiConfig`, or `/model/productConfigs`.

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Closes https://apptio.atlassian.net/browse/KCM-5000
- Related to https://apptio.atlassian.net/browse/KCM-4998 and https://github.com/kubecost/kubecost-frontend/pull/3383

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
N/A

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
N/A

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A
