### PR TITLE
Always fallback to last PVC Annotation in statefulset 

### DIFF
--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -644,17 +644,18 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 
-
 {{/*
-Return the annotations from the existing Aggregator StatefulSet PVC
-named "aggregator-db-storage", if present.
+Compute the effective annotations block for the Aggregator StatefulSet
+PVC named "aggregator-db-storage".
 */}}
-{{- define "kubecost.lastPVCAnnotations.aggregator-db-storage" -}}
+{{- define "kubecost.aggregatorStatefulset.pvcAnnotations.aggregator-db-storage" -}}
   {{- $annotations := dict -}}
+  {{- $foundSts := false -}}
   {{- $stsList := (lookup "apps/v1" "StatefulSet" .Release.Namespace "") -}}
   {{- if and $stsList (not (empty $stsList.items)) -}}
     {{- range $i, $s := $stsList.items -}}
       {{- if contains "aggregator" $s.metadata.name -}}
+        {{- $foundSts = true -}}
         {{- $volumeClaimTemplates := $s.spec.volumeClaimTemplates -}}
         {{- range $j, $volumeClaimTemplate := $volumeClaimTemplates -}}
           {{- if and $volumeClaimTemplate.metadata.annotations (eq $volumeClaimTemplate.metadata.name "aggregator-db-storage") -}}
@@ -664,21 +665,34 @@ named "aggregator-db-storage", if present.
       {{- end -}}
     {{- end -}}
   {{- end -}}
-  {{- if $annotations }}
-{{ $annotations | toYaml | nindent 8 }}
-  {{- end -}}
+
+{{- if $foundSts }}
+annotations:
+  {{- if not (empty $annotations) }}
+    {{ $annotations | toYaml | nindent 2 }}
+  {{- else -}}
+    {{- with .Values.global.annotations }}
+      {{ toYaml . | nindent 2 }}
+    {{- end }}
+    {{- with .Values.aggregator.aggregatorDbStorage.annotations }}
+      {{ toYaml . | nindent 2 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
 {{- end -}}
 
 {{/*
-Return the annotations from the existing Aggregator StatefulSet PVC
-named "persistent-configs", if present.
+Compute the effective annotations block for the Aggregator StatefulSet
+PVC named "persistent-configs".
 */}}
-{{- define "kubecost.lastPVCAnnotations.persistent-configs" -}}
+{{- define "kubecost.aggregatorStatefulset.pvcAnnotations.persistent-configs" -}}
   {{- $annotations := dict -}}
+  {{- $foundSts := false -}}
   {{- $stsList := (lookup "apps/v1" "StatefulSet" .Release.Namespace "") -}}
   {{- if and $stsList (not (empty $stsList.items)) -}}
     {{- range $i, $s := $stsList.items -}}
       {{- if contains "aggregator" $s.metadata.name -}}
+        {{- $foundSts = true -}}
         {{- $volumeClaimTemplates := $s.spec.volumeClaimTemplates -}}
         {{- range $j, $volumeClaimTemplate := $volumeClaimTemplates -}}
           {{- if and $volumeClaimTemplate.metadata.annotations (eq $volumeClaimTemplate.metadata.name "persistent-configs") -}}
@@ -688,7 +702,18 @@ named "persistent-configs", if present.
       {{- end -}}
     {{- end -}}
   {{- end -}}
-  {{- if $annotations }}
-{{ $annotations | toYaml | nindent 8 }}
-  {{- end -}}
+
+{{- if $foundSts }}
+annotations:
+  {{- if not (empty $annotations) }}
+    {{ $annotations | toYaml | nindent 2 }}
+  {{- else -}}
+    {{- with .Values.global.annotations }}
+      {{ toYaml . | nindent 2 }}
+    {{- end }}
+    {{- with .Values.aggregator.persistentConfigsStorage.annotations }}
+      {{ toYaml . | nindent 2 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
 {{- end -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -645,11 +645,11 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Compute the effective annotations block for the Aggregator StatefulSet
-PVC named "aggregator-db-storage".
+Persistent db storage annotations block for the Aggregator StatefulSet
+Check if there was an aggregator statefulset previously, if yes apply the annotations from the statefulset, otherwise use the annotations as given in the values
 */}}
 {{- define "kubecost.aggregatorStatefulset.pvcAnnotations.aggregator-db-storage" -}}
-  {{- $annotations := dict -}}
+  {{- $pastAnnotations := dict -}}
   {{- $foundSts := false -}}
   {{- $stsList := (lookup "apps/v1" "StatefulSet" .Release.Namespace "") -}}
   {{- if and $stsList (not (empty $stsList.items)) -}}
@@ -659,7 +659,7 @@ PVC named "aggregator-db-storage".
         {{- $volumeClaimTemplates := $s.spec.volumeClaimTemplates -}}
         {{- range $j, $volumeClaimTemplate := $volumeClaimTemplates -}}
           {{- if and $volumeClaimTemplate.metadata.annotations (eq $volumeClaimTemplate.metadata.name "aggregator-db-storage") -}}
-            {{- $annotations = $volumeClaimTemplate.metadata.annotations -}}
+            {{- $pastAnnotations = $volumeClaimTemplate.metadata.annotations -}}
           {{- end -}}
         {{- end -}}
       {{- end -}}
@@ -667,9 +667,8 @@ PVC named "aggregator-db-storage".
   {{- end -}}
 
 annotations:
-  # If there was a statefulset previously, use the annotations from the statefulset
   {{- if $foundSts }}
-    {{- $annotations | toYaml | nindent 2 }}
+    {{- $pastAnnotations | toYaml | nindent 2 }}
   {{- else -}}
     {{- with .Values.global.annotations }}
       {{- toYaml . | nindent 2 }}
@@ -681,11 +680,11 @@ annotations:
 {{- end -}}
 
 {{/*
-Compute the effective annotations block for the Aggregator StatefulSet
-PVC named "persistent-configs".
+Persistent db storage annotations block for the Aggregator StatefulSet
+Check if there was an aggregator statefulset previously, if yes apply the annotations from the statefulset, otherwise use the annotations as given in the values
 */}}
 {{- define "kubecost.aggregatorStatefulset.pvcAnnotations.persistent-configs" -}}
-  {{- $annotations := dict -}}
+  {{- $pastAnnotations := dict -}}
   {{- $foundSts := false -}}
   {{- $stsList := (lookup "apps/v1" "StatefulSet" .Release.Namespace "") -}}
   {{- if and $stsList (not (empty $stsList.items)) -}}
@@ -695,7 +694,7 @@ PVC named "persistent-configs".
         {{- $volumeClaimTemplates := $s.spec.volumeClaimTemplates -}}
         {{- range $j, $volumeClaimTemplate := $volumeClaimTemplates -}}
           {{- if and $volumeClaimTemplate.metadata.annotations (eq $volumeClaimTemplate.metadata.name "persistent-configs") -}}
-            {{- $annotations = $volumeClaimTemplate.metadata.annotations -}}
+            {{- $pastAnnotations = $volumeClaimTemplate.metadata.annotations -}}
           {{- end -}}
         {{- end -}}
       {{- end -}}
@@ -703,9 +702,8 @@ PVC named "persistent-configs".
   {{- end -}}
 
 annotations:
-  # If there was a statefulset previously, use the annotations from the statefulset
   {{- if $foundSts }}
-    {{- $annotations | toYaml | nindent 2 }}
+    {{- $pastAnnotations | toYaml | nindent 2 }}
   {{- else -}}
     {{- with .Values.global.annotations }}
       {{- toYaml . | nindent 2 }}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -666,19 +666,18 @@ PVC named "aggregator-db-storage".
     {{- end -}}
   {{- end -}}
 
-{{- if $foundSts }}
 annotations:
-  {{- if not (empty $annotations) }}
-    {{ $annotations | toYaml | nindent 2 }}
+  # If there was a statefulset previously, use the annotations from the statefulset
+  {{- if $foundSts }}
+    {{- $annotations | toYaml | nindent 2 }}
   {{- else -}}
     {{- with .Values.global.annotations }}
-      {{ toYaml . | nindent 2 }}
+      {{- toYaml . | nindent 2 }}
     {{- end }}
     {{- with .Values.aggregator.aggregatorDbStorage.annotations }}
-      {{ toYaml . | nindent 2 }}
+      {{- toYaml . | nindent 2 }}
     {{- end }}
   {{- end }}
-{{- end -}}
 {{- end -}}
 
 {{/*
@@ -703,17 +702,16 @@ PVC named "persistent-configs".
     {{- end -}}
   {{- end -}}
 
-{{- if $foundSts }}
 annotations:
-  {{- if not (empty $annotations) }}
-    {{ $annotations | toYaml | nindent 2 }}
+  # If there was a statefulset previously, use the annotations from the statefulset
+  {{- if $foundSts }}
+    {{- $annotations | toYaml | nindent 2 }}
   {{- else -}}
     {{- with .Values.global.annotations }}
-      {{ toYaml . | nindent 2 }}
+      {{- toYaml . | nindent 2 }}
     {{- end }}
     {{- with .Values.aggregator.persistentConfigsStorage.annotations }}
-      {{ toYaml . | nindent 2 }}
+      {{- toYaml . | nindent 2 }}
     {{- end }}
   {{- end }}
-{{- end -}}
 {{- end -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -643,3 +643,52 @@ imagePullSecrets:
 {{ printf "\nWARNING .Values.imagePullSecrets has been deprecated. Please use .Values.global.imagePullSecrets instead.\nThe finops-agent will only use the global.imagePullSecrets\n" }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Return the annotations from the existing Aggregator StatefulSet PVC
+named "aggregator-db-storage", if present.
+*/}}
+{{- define "kubecost.lastPVCAnnotations.aggregator-db-storage" -}}
+  {{- $annotations := dict -}}
+  {{- $stsList := (lookup "apps/v1" "StatefulSet" .Release.Namespace "") -}}
+  {{- if and $stsList (not (empty $stsList.items)) -}}
+    {{- range $i, $s := $stsList.items -}}
+      {{- if contains "aggregator" $s.metadata.name -}}
+        {{- $volumeClaimTemplates := $s.spec.volumeClaimTemplates -}}
+        {{- range $j, $volumeClaimTemplate := $volumeClaimTemplates -}}
+          {{- if and $volumeClaimTemplate.metadata.annotations (eq $volumeClaimTemplate.metadata.name "aggregator-db-storage") -}}
+            {{- $annotations = $volumeClaimTemplate.metadata.annotations -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $annotations }}
+{{ $annotations | toYaml | nindent 8 }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return the annotations from the existing Aggregator StatefulSet PVC
+named "persistent-configs", if present.
+*/}}
+{{- define "kubecost.lastPVCAnnotations.persistent-configs" -}}
+  {{- $annotations := dict -}}
+  {{- $stsList := (lookup "apps/v1" "StatefulSet" .Release.Namespace "") -}}
+  {{- if and $stsList (not (empty $stsList.items)) -}}
+    {{- range $i, $s := $stsList.items -}}
+      {{- if contains "aggregator" $s.metadata.name -}}
+        {{- $volumeClaimTemplates := $s.spec.volumeClaimTemplates -}}
+        {{- range $j, $volumeClaimTemplate := $volumeClaimTemplates -}}
+          {{- if and $volumeClaimTemplate.metadata.annotations (eq $volumeClaimTemplate.metadata.name "persistent-configs") -}}
+            {{- $annotations = $volumeClaimTemplate.metadata.annotations -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $annotations }}
+{{ $annotations | toYaml | nindent 8 }}
+  {{- end -}}
+{{- end -}}

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -29,12 +29,16 @@ spec:
     metadata:
       name: aggregator-db-storage
       annotations:
+      {{- if "kubecost.lastPVCAnnotations.aggregator-db-storage" -}}
+        {{- include "kubecost.lastPVCAnnotations.aggregator-db-storage" . | nindent 8 }}
+      {{- else -}}
         {{- with .Values.global.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.aggregator.aggregatorDbStorage.annotations }}      
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end -}}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.aggregator.aggregatorDbStorage.storageClass }}
@@ -55,12 +59,16 @@ spec:
       # that's what this per-replica Volume is used for.
       name: persistent-configs
       annotations:
+      {{- if "kubecost.lastPVCAnnotations.persistent-configs"-}}
+        {{- include "kubecost.lastPVCAnnotations.persistent-configs" . | nindent 8 }}
+      {{- else -}}
         {{- with .Values.global.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.aggregator.persistentConfigsStorage.annotations }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end -}}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.aggregator.persistentConfigsStorage.storageClass }}

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       name: aggregator-db-storage
       annotations:
-      {{- if "kubecost.lastPVCAnnotations.aggregator-db-storage" -}}
+      {{- if "kubecost.lastPVCAnnotations.aggregator-db-storage" }}
         {{- include "kubecost.lastPVCAnnotations.aggregator-db-storage" . | nindent 8 }}
       {{- else -}}
         {{- with .Values.global.annotations }}
@@ -38,7 +38,7 @@ spec:
         {{- with .Values.aggregator.aggregatorDbStorage.annotations }}      
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- end -}}
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.aggregator.aggregatorDbStorage.storageClass }}
@@ -59,7 +59,7 @@ spec:
       # that's what this per-replica Volume is used for.
       name: persistent-configs
       annotations:
-      {{- if "kubecost.lastPVCAnnotations.persistent-configs"-}}
+      {{- if "kubecost.lastPVCAnnotations.persistent-configs" }}
         {{- include "kubecost.lastPVCAnnotations.persistent-configs" . | nindent 8 }}
       {{- else -}}
         {{- with .Values.global.annotations }}
@@ -68,7 +68,7 @@ spec:
         {{- with .Values.aggregator.persistentConfigsStorage.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- end -}}
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.aggregator.persistentConfigsStorage.storageClass }}

--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -28,17 +28,7 @@ spec:
     kind: PersistentVolumeClaim
     metadata:
       name: aggregator-db-storage
-      annotations:
-      {{- if "kubecost.lastPVCAnnotations.aggregator-db-storage" }}
-        {{- include "kubecost.lastPVCAnnotations.aggregator-db-storage" . | nindent 8 }}
-      {{- else -}}
-        {{- with .Values.global.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.aggregator.aggregatorDbStorage.annotations }}      
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- end }}
+      {{- include "kubecost.aggregatorStatefulset.pvcAnnotations.aggregator-db-storage" . | nindent 6 }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.aggregator.aggregatorDbStorage.storageClass }}
@@ -58,17 +48,7 @@ spec:
       # a need to "mount" ConfigMap files (using the watcher) to a file system;
       # that's what this per-replica Volume is used for.
       name: persistent-configs
-      annotations:
-      {{- if "kubecost.lastPVCAnnotations.persistent-configs" }}
-        {{- include "kubecost.lastPVCAnnotations.persistent-configs" . | nindent 8 }}
-      {{- else -}}
-        {{- with .Values.global.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.aggregator.persistentConfigsStorage.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- end }}
+      {{- include "kubecost.aggregatorStatefulset.pvcAnnotations.persistent-configs" . | nindent 6 }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.aggregator.persistentConfigsStorage.storageClass }}


### PR DESCRIPTION
## Release Notes Headline
Always fallback to last PVC Annotation in statefulset 
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
The statefulset do not allow updating pvc spec annotations. Error reference:
```sh
level=WARN msg="upgrade failed" name=ishaan error="StatefulSet.apps \"ishaan-aggregator\" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden"
Error: UPGRADE FAILED: StatefulSet.apps "ishaan-aggregator" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```
After this change, the chart would only update pvc spec annotations in statefulset, if it failed to find any statefulset from previous install, otherwise it would always default to previous statefulset pvc spec annotations.

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-5221
https://github.com/kubecost/kubecost/pull/4558
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
A normal downgrade from this PR chart to previous versions will give a statefulset warning/error:
```
level=WARN msg="upgrade failed" name=ishaan error="StatefulSet.apps \"ishaan-aggregator\" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden"
Error: UPGRADE FAILED: StatefulSet.apps "ishaan-aggregator" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```
A workaround for it is to orphan delete the aggregator statefulset and run the upgrade install again
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Tested multiple scinerios:
```
Previous install: This PR change chart
Upgrade Install: This PR change chart
No custom annotations-> No Custom annotations
No custom annotations -> Custom annotations
Custom annotations -> No Custom annotations
Custom annotations -> Different Custom annotations
Previous install: 3.1.3
Upgrade Install: This PR change chart
No custom annotations -> No Custom annotations
No custom annotations -> Custom annotations
Custom annotations -> Custom annotations
Custom annotations -> No Custom annotations
```


<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
