### PR TITLE
KCM-5174 - Enable setting ECP spec via UI

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -209,9 +209,11 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- if (.Values.enterpriseCustomPricing).enabled }}
+        {{- if (.Values.enterpriseCustomPricing).configMapName }}
         - name: kubecost-enterprise-pricing
           configMap:
             name: {{ .Values.enterpriseCustomPricing.configMapName }}
+        {{- end }}
         {{- end }}
         {{- if ((.Values.kubecostProductConfigs).actions).config }}
         - name: actions-config
@@ -398,8 +400,10 @@ spec:
               readOnly: false
             {{- end }}
             {{- if (.Values.enterpriseCustomPricing).enabled }}
+            {{- if (.Values.enterpriseCustomPricing).configMapName }}
             - name: kubecost-enterprise-pricing
               mountPath: /var/configs/enterprise-pricing
+            {{- end }}
             {{- end }}
             {{- if ((.Values.kubecostProductConfigs).actions).config }}
             - name: actions-config
@@ -626,8 +630,10 @@ spec:
             {{- if (.Values.enterpriseCustomPricing).enabled }}
             - name: ENTERPRISE_CUSTOM_PRICING_ENABLED
               value: "true"
+            {{- if ((.Values.enterpriseCustomPricing).location).URI }}
             - name: ENTERPRISE_CUSTOM_PRICING_CSV_LOCATION_URI
               value: {{ (quote .Values.enterpriseCustomPricing.location.URI) }}
+            {{- end }}
             - name: ENTERPRISE_CUSTOM_PRICING_APPLY_RETROACTIVELY
               value: "true"
             {{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -275,6 +275,9 @@ enterpriseCustomPricing:
   # requires a CSV pricing spec to be provided at the location, below, using a
   # ConfigMap, for which we provide instructions, also below.
   enabled: false
+  # To allow for setting the Enterprise Custom Pricng CSV via the UI, comment out
+  # the configMapName and location fields below.
+  #
   # Use the following command to create a ConfigMap from your pricing spec CSV.
   # You may change the ConfigMap name, or file name, as long as you set the
   # correct configMapName and location.URI, respectively.


### PR DESCRIPTION
## Release Notes Headline
Users will now be able to set their Enterprise Custom Pricing spec via the UI.

## Commentary for Reviewers
These changes allow for KCM to be aware of whether setting the spec via the UI should be enabled.

## Links to Issues or Tickets
[KCM-5174](https://apptio.atlassian.net/browse/KCM-5174).

## User Impact and Risks
Users currently using ECP will be unaffected, but they will now be able to (optionally) enable UI-based ECP configuration.

## Testing
Tested alongside product at https://project-on-prem3x-ecp.qa-eks3.kubecost.xyz/.

## Documentation Updates
TBD.
<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->


[KCM-5174]: https://apptio.atlassian.net/browse/KCM-5174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ