### PR TITLE
EKS Optimized retention1d

### DIFF
--- a/kubecost/values-eks-cost-monitoring.yaml
+++ b/kubecost/values-eks-cost-monitoring.yaml
@@ -7,6 +7,7 @@ frontend:
 aggregator:
   image:
     repository: kubecost/cost-model
+  retention1d: 16
 
 forecasting:
   image:


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
N/A

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
- Only affects the example `values.yaml` file for EKS Optimized users
- Sets Aggregator's `retention1d=16`. By default, EKS Optimized users are only able to view the last 2 weeks of data. This configuration will help ensure the Aggregator does not ingest more daily resolution data than it needs to. This should help reduce excess storage/memory consumption.
- https://docs.aws.amazon.com/eks/latest/userguide/cost-monitoring-kubecost-bundles.html

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
N/A

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
Only affects the example `values.yaml` file for EKS Optimized users

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
N/A

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A
