### PR TITLE
Default all Kubecost images to ICR

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -883,10 +883,10 @@ Begin Kubecost 2.0 templates
   {{- else if eq "development" .Chart.AppVersion }}
   image: gcr.io/kubecost1/cost-model-nightly:latest
   {{- else }}
-  image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+  image: {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
   {{- end }}
   {{- else }}
-  image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+  image: icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
   {{- end }}
   {{- if .Values.kubecostAggregator.readinessProbe.enabled }}
   readinessProbe:
@@ -1271,10 +1271,10 @@ Begin Kubecost 2.0 templates
   {{- else if eq "development" .Chart.AppVersion }}
   image: gcr.io/kubecost1/cost-model-nightly:latest
   {{- else }}
-  image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+  image: {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
   {{ end }}
   {{- else }}
-  image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+  image: icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
   {{ end }}
   {{- if .Values.kubecostAggregator.cloudCost.readinessProbe.enabled }}
   readinessProbe:
@@ -1631,10 +1631,10 @@ for more information
   {{- else if eq "development" .Chart.AppVersion }}
     gcr.io/kubecost1/cost-model-nightly:latest
   {{- else }}
-    {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+    {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- else }}
-  gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+  icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
 {{- end }}
 {{- end }}
 

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -1133,10 +1133,10 @@ spec:
         {{- else if eq "development" .Chart.AppVersion }}
         - image: gcr.io/kubecost1/frontend-nightly:latest
         {{- else }}
-        - image: {{ .Values.kubecostFrontend.image }}:prod-{{ $.Chart.AppVersion }}
+        - image: {{ .Values.kubecostFrontend.image }}:{{ $.Chart.AppVersion }}
         {{- end }}
         {{- else }}
-        - image: gcr.io/kubecost1/frontend:prod-{{ $.Chart.AppVersion }}
+        - image: icr.io/kubecost/frontend:{{ $.Chart.AppVersion }}
         {{- end }}
           env:
             - name: GET_HOSTS_FROM

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -68,10 +68,10 @@ spec:
           {{- else if eq "development" .Chart.AppVersion }}
           image: gcr.io/kubecost1/cost-model-nightly:latest
           {{- else }}
-          image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+          image: {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
           {{- end }}
           {{- else }}
-          image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+          image: icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
           {{- end }}
           {{- if .Values.kubecostModel.imagePullPolicy }}
           imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}

--- a/cost-analyzer/templates/etl-utils-deployment.yaml
+++ b/cost-analyzer/templates/etl-utils-deployment.yaml
@@ -64,10 +64,10 @@ spec:
           {{- else if eq "development" .Chart.AppVersion }}
           image: gcr.io/kubecost1/cost-model-nightly:latest
           {{- else }}
-          image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+          image: {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
           {{ end }}
           {{- else }}
-          image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+          image: icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
           {{ end }}
           readinessProbe:
             httpGet:

--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -58,7 +58,7 @@ spec:
           {{- else if .Values.forecasting.image }}
           image: {{ .Values.forecasting.image.repository }}:{{ .Values.forecasting.image.tag }}
           {{- else }}
-          image: gcr.io/kubecost1/kubecost-modeling:prod-{{ $.Chart.AppVersion }}
+          image: icr.io/kubecost/modeling:{{ $.Chart.AppVersion }}
           {{ end }}
           {{- if .Values.forecasting.readinessProbe.enabled }}
           volumeMounts:

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -117,10 +117,10 @@ spec:
         {{- else if eq "development" .Chart.AppVersion }}
         - image: gcr.io/kubecost1/frontend-nightly:latest
         {{- else }}
-        - image: {{ .Values.kubecostFrontend.image }}:prod-{{ $.Chart.AppVersion }}
+        - image: {{ .Values.kubecostFrontend.image }}:{{ $.Chart.AppVersion }}
         {{- end }}
         {{- else }}
-        - image: gcr.io/kubecost1/frontend:prod-{{ $.Chart.AppVersion }}
+        - image: icr.io/kubecost/frontend:{{ $.Chart.AppVersion }}
         {{- end }}
           name: cost-analyzer-frontend
           ports:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -595,7 +595,7 @@ kubecostFrontend:
   enabled: true
   deployMethod: singlepod  # haMode or singlepod - haMode is currently only supported with Enterprise tier
   haReplicas: 2  # only used with haMode
-  image: "gcr.io/kubecost1/frontend"
+  image: "icr.io/kubecost/frontend"
   imagePullPolicy: IfNotPresent
   # fullImageName overrides the default image construction logic. The exact
   # image provided (registry, image, tag) will be used for the frontend.
@@ -683,7 +683,7 @@ sigV4Proxy:
   resources: {}
 
 kubecostModel:
-  image: "gcr.io/kubecost1/cost-model"
+  image: "icr.io/kubecost/cost-model"
   imagePullPolicy: IfNotPresent
   # fullImageName overrides the default image construction logic. The exact
   # image provided (registry, image, tag) will be used for cost-model.
@@ -1477,8 +1477,8 @@ prometheus:
 networkCosts:
   enabled: false
   image:
-    repository: gcr.io/kubecost1/kubecost-network-costs
-    tag: v0.18.0
+    repository: icr.io/kubecost/network-costs
+    tag: v0.18.2
   imagePullPolicy: IfNotPresent
   updateStrategy:
     type: RollingUpdate
@@ -1601,7 +1601,7 @@ forecasting:
   enabled: true
   fullImageName: ""
   image:
-    repository: gcr.io/kubecost1/kubecost-modeling
+    repository: icr.io/kubecost/modeling
     tag: v0.1.34
   imagePullPolicy: IfNotPresent
 
@@ -1924,8 +1924,8 @@ diagnosticsFullnameOverride: ""
 clusterController:
   enabled: false
   image:
-    repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.20
+    repository: icr.io/kubecost/cluster-controller
+    tag: v0.16.32
   imagePullPolicy: IfNotPresent
   extraEnv: []
   # - name: EXTRA_ENV_VAR


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
All Kubecost images now default to `icr.io`. Hosting in the `gcr.io` registry is now deprecated https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=overview-registry-migration-guide.

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
- Will need a similar PR for the v2.8 branch
- For now, nightly images are still on `gcr.io`, as we are not yet pushing nightly images to `icr.io`

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- https://apptio.atlassian.net/browse/KCM-5238

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
If users are unable to pull from `icr.io`, they will still have until July 2026 to pull from `gcr.io`.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
<details>
<summary>Helm Template Rendering and Image Verification</summary>

**Test Command**:
```bash
helm template kubecost ./cost-analyzer \
  --set global.clusterId=test-cluster \
  --set prometheus.server.global.external_labels.cluster_id=test-cluster \
  --set 'global.federatedStorage.config=type: S3' \
  --set networkCosts.enabled=true \
  --set clusterController.enabled=true \
  2>&1 | grep -E "image:" | grep "icr.io/kubecost" | sed 's/.*image: *//; s/"//g' | sort -u
```

**Rendered ICR Images**:
```
icr.io/kubecost/cluster-controller:v0.16.32
icr.io/kubecost/cost-model:2.9.6
icr.io/kubecost/frontend:2.9.6
icr.io/kubecost/modeling:v0.1.34
icr.io/kubecost/network-costs:v0.18.2
```

**Image Digest Verification**:
```bash
crane digest --platform linux/amd64 icr.io/kubecost/cost-model:2.9.6
# sha256:20607ae55f74433c697d3f635d325b99bf61b118189163362aeea42c60100701 ✓

crane digest --platform linux/amd64 icr.io/kubecost/frontend:2.9.6
# sha256:db4756a2e29fdc909f6218f33b6c3952aaaf8501d375fb06220465a6f21c3fcf ✓

crane digest --platform linux/amd64 icr.io/kubecost/network-costs:v0.18.2
# sha256:3ea70649cc574a19fc41e3b8dcf2b2a50d5bc2ba3aa2a0f478ca5efe98069ec4 ✓

crane digest --platform linux/amd64 icr.io/kubecost/modeling:v0.1.34
# sha256:438efab426839afd9a43253e917586bb28d06c56810d988c9b9b1de3b5063e9a ✓

crane digest --platform linux/amd64 icr.io/kubecost/cluster-controller:v0.16.32
# sha256:27c8289c1567a85b4d743b20f037bbe7c3e76e012844889f1cbdb7274ddb0690 ✓
```
</details>

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=overview-registry-migration-guide
