### PR TITLE
Feat: add cluster controller rate limiter parameters in helm

### DIFF
--- a/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-deployment.yaml
@@ -145,6 +145,16 @@ spec:
         - name: CC_KUBESCALER_DEFAULT_RESIZE_ALL
           value: {{ .Values.clusterController.kubescaler.defaultResizeAll | default "false" | quote }}
         {{- end }}
+        {{- if .Values.clusterController.rateLimiter }}
+        {{- if .Values.clusterController.rateLimiter.eventsPerSecond }}
+        - name: RATE_LIMITER_EVENTS_PER_SECOND
+          value: {{ .Values.clusterController.rateLimiter.eventsPerSecond | quote }}
+        {{- end }}
+        {{- if .Values.clusterController.rateLimiter.eventBurst }}
+        - name: RATE_LIMITER_EVENT_BURST
+          value: {{ .Values.clusterController.rateLimiter.eventBurst | quote }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.clusterController.extraEnv -}}
         {{ toYaml .Values.clusterController.extraEnv | nindent 8 }}
         {{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1323,6 +1323,9 @@ clusterController:
   extraEnv: []
   # - name: EXTRA_ENV_VAR
   #   value: "extra_env_var_value"
+  rateLimiter:
+    eventsPerSecond: 0.1
+    eventBurst: 10
   priorityClassName: ""
   tolerations: []
   annotations: {}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1323,9 +1323,6 @@ clusterController:
   extraEnv: []
   # - name: EXTRA_ENV_VAR
   #   value: "extra_env_var_value"
-  rateLimiter:
-    eventsPerSecond: 0.1
-    eventBurst: 10
   priorityClassName: ""
   tolerations: []
   annotations: {}
@@ -1381,6 +1378,11 @@ clusterController:
     clusterRightSizing: false
     clusterTurndown: false
     namespaceTurndown: false
+
+  # Controls the rate at which the cluster controller executes operations against the k8s API.
+  # rateLimiter:
+  #   eventsPerSecond: 0.1
+  #   eventBurst: 10
 
 ## Kubecost Bug Reports
 ## Enables k8s role bindings to access pods/logs limited to .Release.Namespace


### PR DESCRIPTION
## Release Notes Headline

Add rate limiter configuration to cluster controller Helm values

## Commentary for Reviewers

Added `rateLimiter.eventsPerSecond` and `rateLimiter.eventBurst` parameters under `clusterController` in values.yaml, wired to `RATE_LIMITER_EVENTS_PER_SECOND` and `RATE_LIMITER_EVENT_BURST` environment variables in the deployment spec. Both parameters are optional.

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-5396

## User Impact and Risks

Users can now configure cluster controller rate limiting via Helm values. Low risk - parameters are optional and backward compatible.

## Testing

Verified Helm template syntax and conditional logic for environment variables.

## Documentation Updates

N/A