### PR TITLE
Default all Kubecost images to ICR (v2.8)

### DIFF
--- a/cost-analyzer/templates/_helpers.tpl
+++ b/cost-analyzer/templates/_helpers.tpl
@@ -913,10 +913,10 @@ Begin Kubecost 2.0 templates
   {{- else if eq "development" .Chart.AppVersion }}
   image: gcr.io/kubecost1/cost-model-nightly:latest
   {{- else }}
-  image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+  image: {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
   {{- end }}
   {{- else }}
-  image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+  image: icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
   {{- end }}
   {{- if .Values.kubecostAggregator.readinessProbe.enabled }}
   readinessProbe:
@@ -1314,10 +1314,10 @@ Begin Kubecost 2.0 templates
   {{- else if eq "development" .Chart.AppVersion }}
   image: gcr.io/kubecost1/cost-model-nightly:latest
   {{- else }}
-  image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+  image: {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
   {{ end }}
   {{- else }}
-  image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+  image: icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
   {{ end }}
   {{- if .Values.kubecostAggregator.cloudCost.readinessProbe.enabled }}
   readinessProbe:
@@ -1674,10 +1674,10 @@ for more information
   {{- else if eq "development" .Chart.AppVersion }}
     gcr.io/kubecost1/cost-model-nightly:latest
   {{- else }}
-    {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+    {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
   {{- end }}
 {{- else }}
-  gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+  icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
 {{- end }}
 {{- end }}
 

--- a/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-deployment-template.yaml
@@ -1142,10 +1142,10 @@ spec:
         {{- else if eq "development" .Chart.AppVersion }}
         - image: gcr.io/kubecost1/frontend-nightly:latest
         {{- else }}
-        - image: {{ .Values.kubecostFrontend.image }}:prod-{{ $.Chart.AppVersion }}
+        - image: {{ .Values.kubecostFrontend.image }}:{{ $.Chart.AppVersion }}
         {{- end }}
         {{- else }}
-        - image: gcr.io/kubecost1/frontend:prod-{{ $.Chart.AppVersion }}
+        - image: icr.io/kubecost/frontend:{{ $.Chart.AppVersion }}
         {{- end }}
           env:
             - name: GET_HOSTS_FROM

--- a/cost-analyzer/templates/diagnostics-deployment.yaml
+++ b/cost-analyzer/templates/diagnostics-deployment.yaml
@@ -72,10 +72,10 @@ spec:
           {{- else if eq "development" .Chart.AppVersion }}
           image: gcr.io/kubecost1/cost-model-nightly:latest
           {{- else }}
-          image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+          image: {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
           {{- end }}
           {{- else }}
-          image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+          image: icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
           {{- end }}
           {{- if .Values.kubecostModel.imagePullPolicy }}
           imagePullPolicy: {{ .Values.kubecostModel.imagePullPolicy }}

--- a/cost-analyzer/templates/etl-utils-deployment.yaml
+++ b/cost-analyzer/templates/etl-utils-deployment.yaml
@@ -64,10 +64,10 @@ spec:
           {{- else if eq "development" .Chart.AppVersion }}
           image: gcr.io/kubecost1/cost-model-nightly:latest
           {{- else }}
-          image: {{ .Values.kubecostModel.image }}:prod-{{ $.Chart.AppVersion }}
+          image: {{ .Values.kubecostModel.image }}:{{ $.Chart.AppVersion }}
           {{ end }}
           {{- else }}
-          image: gcr.io/kubecost1/cost-model:prod-{{ $.Chart.AppVersion }}
+          image: icr.io/kubecost/cost-model:{{ $.Chart.AppVersion }}
           {{ end }}
           readinessProbe:
             httpGet:

--- a/cost-analyzer/templates/forecasting-deployment.yaml
+++ b/cost-analyzer/templates/forecasting-deployment.yaml
@@ -58,7 +58,7 @@ spec:
           {{- else if .Values.forecasting.image }}
           image: {{ .Values.forecasting.image.repository }}:{{ .Values.forecasting.image.tag }}
           {{- else }}
-          image: gcr.io/kubecost1/kubecost-modeling:prod-{{ $.Chart.AppVersion }}
+          image: icr.io/kubecost/modeling:{{ $.Chart.AppVersion }}
           {{ end }}
           {{- if .Values.forecasting.readinessProbe.enabled }}
           volumeMounts:

--- a/cost-analyzer/templates/frontend-deployment-template.yaml
+++ b/cost-analyzer/templates/frontend-deployment-template.yaml
@@ -117,10 +117,10 @@ spec:
         {{- else if eq "development" .Chart.AppVersion }}
         - image: gcr.io/kubecost1/frontend-nightly:latest
         {{- else }}
-        - image: {{ .Values.kubecostFrontend.image }}:prod-{{ $.Chart.AppVersion }}
+        - image: {{ .Values.kubecostFrontend.image }}:{{ $.Chart.AppVersion }}
         {{- end }}
         {{- else }}
-        - image: gcr.io/kubecost1/frontend:prod-{{ $.Chart.AppVersion }}
+        - image: icr.io/kubecost/frontend:{{ $.Chart.AppVersion }}
         {{- end }}
           name: cost-analyzer-frontend
           ports:

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -514,7 +514,7 @@ kubecostFrontend:
   enabled: true
   deployMethod: singlepod  # haMode or singlepod - haMode is currently only supported with Enterprise tier
   haReplicas: 2  # only used with haMode
-  image: "gcr.io/kubecost1/frontend"
+  image: "icr.io/kubecost/frontend"
   imagePullPolicy: IfNotPresent
   # fullImageName overrides the default image construction logic. The exact
   # image provided (registry, image, tag) will be used for the frontend.
@@ -602,7 +602,7 @@ sigV4Proxy:
   resources: {}
 
 kubecostModel:
-  image: "gcr.io/kubecost1/cost-model"
+  image: "icr.io/kubecost/cost-model"
   imagePullPolicy: IfNotPresent
   # fullImageName overrides the default image construction logic. The exact
   # image provided (registry, image, tag) will be used for cost-model.
@@ -1444,8 +1444,8 @@ prometheus:
 networkCosts:
   enabled: false
   image:
-    repository: gcr.io/kubecost1/kubecost-network-costs
-    tag: v0.18.0
+    repository: icr.io/kubecost/network-costs
+    tag: v0.18.2
   imagePullPolicy: IfNotPresent
   updateStrategy:
     type: RollingUpdate
@@ -1568,7 +1568,7 @@ forecasting:
   enabled: true
   fullImageName: ""
   image:
-    repository: gcr.io/kubecost1/kubecost-modeling
+    repository: icr.io/kubecost/modeling
     tag: v0.1.34
   imagePullPolicy: IfNotPresent
 
@@ -1891,8 +1891,8 @@ diagnosticsFullnameOverride: ""
 clusterController:
   enabled: false
   image:
-    repository: gcr.io/kubecost1/cluster-controller
-    tag: v0.16.20
+    repository: icr.io/kubecost/cluster-controller
+    tag: v0.16.32
   imagePullPolicy: IfNotPresent
   extraEnv: []
   # - name: EXTRA_ENV_VAR


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
All Kubecost images now default to `icr.io`. Hosting in the `gcr.io` registry is deprecated. See [IBM Registry Migration Guide](https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=overview-registry-migration-guide).

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
This PR applies the ICR registry migration from [PR #4613](https://github.com/kubecost/kubecost/pull/4613) (v2.9) to the v2.8 release branch. All Kubecost images now default to `icr.io/kubecost` instead of `gcr.io/kubecost1`. Nightly images remain on `gcr.io` as they are not yet published to ICR.

**Key Changes:**
- Registry migration: `gcr.io/kubecost1/` → `icr.io/kubecost/`
- Image renames: `kubecost-network-costs` → `network-costs`, `kubecost-modeling` → `modeling`
- Removed `prod-` prefix from production image tags
- Version updates: network-costs v0.18.2, cluster-controller v0.16.32

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- https://apptio.atlassian.net/browse/KCM-5238
- Related v2.9 PR: https://github.com/kubecost/kubecost/pull/4613

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
Users installing the next v2.8 release will automatically pull images from `icr.io`. Custom image configurations remain functional. Users have until July 2026 to migrate from `gcr.io` if needed.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
<details>
<summary>Helm Template Rendering and Image Verification</summary>

**Test Command:**
```bash
helm template cost-analyzer ./cost-analyzer \
  --set global.clusterId=test-cluster \
  --set networkCosts.enabled=true \
  --set clusterController.enabled=true \
  --set forecasting.enabled=true \
  2>&1 | grep -E "image:" | grep "icr.io/kubecost" | sed 's/.*image: *//; s/"//g' | sort -u
```

**Rendered ICR Images:**
```
icr.io/kubecost/cluster-controller:v0.16.32
icr.io/kubecost/cost-model:2.8.6
icr.io/kubecost/frontend:2.8.6
icr.io/kubecost/modeling:v0.1.34
icr.io/kubecost/network-costs:v0.18.2
```
</details>

<details>
<summary>Verification of No gcr.io References (Except Nightly)</summary>

**Test Command:**
```bash
helm template cost-analyzer ./cost-analyzer \
  --set global.clusterId=test-cluster \
  --set networkCosts.enabled=true \
  --set clusterController.enabled=true \
  2>&1 | grep -E "image:.*gcr.io/kubecost1" | grep -v "nightly"
```

**Result:** No output ✓ (no non-nightly gcr.io images found)
</details>

<details>
<summary>Image Availability Verification</summary>

All images verified pullable from `icr.io`:

```bash
crane digest --platform linux/amd64 icr.io/kubecost/cost-model:2.8.6
crane digest --platform linux/amd64 icr.io/kubecost/frontend:2.8.6
crane digest --platform linux/amd64 icr.io/kubecost/network-costs:v0.18.2
crane digest --platform linux/amd64 icr.io/kubecost/modeling:v0.1.34
crane digest --platform linux/amd64 icr.io/kubecost/cluster-controller:v0.16.32
```
</details>

<details>
<summary>Kubernetes Validation</summary>

```bash
helm template cost-analyzer ./cost-analyzer \
  --set global.clusterId=test-cluster \
  --set networkCosts.enabled=true \
  --set clusterController.enabled=true \
  | kubectl apply --dry-run=client -f -
```

**Result:** No validation errors ✓
</details>

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=overview-registry-migration-guide
