### PR TITLE
Bump the patch version of default network costs image to resolve CVEs

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -731,7 +731,7 @@ networkCosts:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/network-costs
-    tag: v0.18.2
+    tag: v0.18.3
   imagePullPolicy: IfNotPresent
 
   updateStrategy:


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
Update the 3.1 branch to target the network-costs image at tag `v0.18.3`. This tag resolves a HIGH CVE in `v0.18.2` related to OpenSSL, among others.

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
