### PR TITLE
cluster role permissions for namespace turndown

### DIFF
--- a/kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
@@ -60,8 +60,8 @@ rules:
     verbs: ['create', 'patch']
   {{- end }}
   {{- if .Values.clusterController.rbac.namespaceTurndown }}
-  - apiGroups: ['*']
-    resources: ['*']
+  - apiGroups: ['']
+    resources: ['namespaces']
     verbs: ['list', 'get', 'delete']
   {{- end }}
   {{- if .Values.clusterController.rbac.resourceQuotaRightSizing }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1373,12 +1373,12 @@ clusterController:
   #       }
 
   rbac:
-    # In 3.x, only containerRequestRightSizing and resourceQuotaRightSizing are supported, all other features are in progress.
+    # In 3.x, only containerRequestRightSizing, resourceQuotaRightSizing, and namespaceTurndown are supported, all other features are in progress.
     containerRequestRightSizing: true
     resourceQuotaRightSizing: true
+    namespaceTurndown: true
     clusterRightSizing: false
     clusterTurndown: false
-    namespaceTurndown: false
 
   # Controls the rate at which the cluster controller executes operations against the k8s API.
   # rateLimiter:
@@ -1484,16 +1484,22 @@ kubecostProductConfigs:
     #       enabled: true
     #     resourceQuotaRightSizing:
     #       enabled: true
+    #     namespaceTurndown:
+    #       enabled: true
     #   clusters: # Define cluster-specific action configuration, where top-level keys are cluster names
     #     cluster-1:
     #       containerRequestRightSizing:
     #         enabled: false
     #       resourceQuotaRightSizing:
     #         enabled: false
+    #       namespaceTurndown:
+    #         enabled: false
     #     cluster-2:
     #       containerRequestRightSizing:
     #         enabled: false
     #       resourceQuotaRightSizing:
+    #         enabled: false
+    #       namespaceTurndown:
     #         enabled: false
     #   actions:
     #     containerRequestRightSizing:
@@ -1504,6 +1510,13 @@ kubecostProductConfigs:
     #           memory: true
     #           profile: "Development"
     #           rightSizingWindow: "24h"
+    #     namespaceTurndown:
+    #       turndown-my-namespace:
+    #         dryRun: false
+    #         enabled: true
+    #         exclusionWindow: ""
+    #         filter: "cluster:\"my-cluster\"+namespace:\"my-namespace\""
+    #         maintenanceWindow: "* 5-9 * * 0||* 5-9 * * 1||* 5-9 * * 2||* 5-9 * * 3||* 5-9 * * 4||* 5-9 * * 5||* 5-9 * * 6"
 
   ## Kubecost Budgets and Budgets Actions
   ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=ui-budgets


### PR DESCRIPTION
## Release Notes Headline
Adds namespace turndown action functionality
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
Tightens the clusterRole permissions for namespace turndown and adds an example helm config for the action
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
N/A
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
Allows users to turn down their namespaces through the use of kubecost actions
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Tested on a running cluster, observed namespaces get turned down as expected
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
