### PR TITLE
Update agent to 1.0.16

### DIFF
--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
-  version: 1.0.15
-digest: sha256:240a7b81686e9848a851380421dcf28344fa5f0fa8a6165ea2b7681865d361fd
-generated: "2026-03-16T20:34:52.499319+05:30"
+  version: 1.0.16
+digest: sha256:30ee4172510c59004df1971523369f2973ff6451ad65ba1453df22d64eeb42d2
+generated: "2026-04-07T10:04:47.073321-04:00"

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: development
 description: Kubecost Helm chart - monitor your cloud costs!
 name: kubecost
-version: 0.0.0-dev  # This is a placeholder used on the develop branch. If installing Kubecost, please reference a release branch.
+version: 0.0.0-dev  # This is a placeholder used on the develop branch. If installing Kubecost from the github repo, please checkout a tagged version. https://github.com/kubecost/kubecost/tags
 icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
 annotations:
   "artifacthub.io/links": |
@@ -11,6 +11,6 @@ annotations:
 dependencies:
   - name: finops-agent
     alias: finopsagent
-    version: "v1.0.15"
+    version: "v1.0.16"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finopsagent.enabled

--- a/kubecost/values-storage.yaml
+++ b/kubecost/values-storage.yaml
@@ -15,12 +15,14 @@ localStore:
     ## Note that setting enabled to false means all data will be lost out on pod restart unless using federated storage.
     enabled: true
 
-## short-term (<2 days) metrics are stored by the finops agent.
+## The PV for the Finops Agent is only used when the object-store is unavailable.
+## It is generally not needed unless the object store connectivity is poor.
+## https://github.com/kubecost/finops-agent-chart/tree/main/charts/finops-agent#persistence for more detail
 finopsagent:
   persistence:
     storageClass: ""
     size: 8Gi
-    enabled: true
+    enabled: false
 
 aggregator:
   ## The aggregator pod has 2 PVCs and will need to be in the same availability zone unless using multi-zone storage.

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -606,9 +606,10 @@ finopsagent:
   #   name: finops-agent
   persistence:
     ## @param persistence.enabled Enable FinOps Agent data persistence for WAL and other local data
-    ## short-term (<2 days) metrics are stored by the finops agent.
+    ## This is only used when the object-store is unavailable. It is generally not needed unless the object store connectivity is poor.
+    ## https://github.com/kubecost/finops-agent-chart/tree/main/charts/finops-agent#persistence for more detail
     ##
-    enabled: true
+    enabled: false
     ## @param persistence.existingClaim A manually managed Persistent Volume and Claim
     ## If defined, PVC must be created manually before volume will be bound
     ## The value is evaluated as a template

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -605,8 +605,8 @@ finopsagent:
   #   create: true
   #   name: finops-agent
   persistence:
-    ## @param persistence.enabled Enable FinOps Agent data persistence for WAL and other local data
-    ## This is only used when the object-store is unavailable. It is generally not needed unless the object store connectivity is poor.
+    ## The PV for the Finops Agent is only used when the object-store is unavailable. 
+    ## It is generally not needed unless the object store connectivity is poor.
     ## https://github.com/kubecost/finops-agent-chart/tree/main/charts/finops-agent#persistence for more detail
     ##
     enabled: false

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -605,7 +605,7 @@ finopsagent:
   #   create: true
   #   name: finops-agent
   persistence:
-    ## The PV for the Finops Agent is only used when the object-store is unavailable. 
+    ## The PV for the Finops Agent is only used when the object-store is unavailable.
     ## It is generally not needed unless the object store connectivity is poor.
     ## https://github.com/kubecost/finops-agent-chart/tree/main/charts/finops-agent#persistence for more detail
     ##


### PR DESCRIPTION
## Update agent to 1.0.16
Update chart to use latest Finops agent.

## Commentary for Reviewers

Do we want to CP this in 3.1?

## User Impact and Risks

Remove PV for Finops Agent by default. It was not used previously, due to a bug in the path. The cost of the PV generally outsweighs the benefit it provides.

## Testing

Using internally for weeks, update to 1.0.16 works as expected.

## Documentation Updates

updated values and example storage configs.