### PR TITLE
fix service monitor indentations in 3.1

### DIFF
--- a/kubecost/templates/aggregator/aggregator-servicemonitor.yaml
+++ b/kubecost/templates/aggregator/aggregator-servicemonitor.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels:
     {{- include "kubecost.aggregator.commonLabels" . | nindent 6 }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if .Values.aggregator.service.labels }}
     {{- toYaml .Values.aggregator.service.labels | nindent 6 }}
     {{- end }}
@@ -62,7 +62,7 @@ spec:
   selector:
     matchLabels:
     {{- include "kubecost.aggregator.commonLabels" . | nindent 6 }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if .Values.aggregator.service.labels }}
     {{- toYaml .Values.aggregator.service.labels | nindent 6 }}
     {{- end }}


### PR DESCRIPTION
## fix service monitor indentations in 3.1

fixes indentation on https://github.com/kubecost/kubecost/pull/4636
backport failure: https://github.com/kubecost/kubecost/pull/4637

which causes:

```yaml
level=WARN msg="upgrade failed" name=kc-error="failed to create typed patch object (kc-test/kc--aggregator; monitoring.coreos.com/v1, Kind=ServiceMonitor): .spec.selector.app.kubernetes.io/instance: field not declared in schema && failed to create typed patch object (kc/kc--aggregator-clickhouse; monitoring.coreos.com/v1, Kind=ServiceMonitor): .spec.selector.app.kubernetes.io/instance: field not declared in schema"
Error: UPGRADE FAILED: failed to create typed patch object (kc-/kc--aggregator; monitoring.coreos.com/v1, Kind=ServiceMonitor): .spec.selector.app.kubernetes.io/instance: field not declared in schema && failed to create typed patch object (kc-/kc--aggregator-clickhouse; monitoring.coreos.com/v1, Kind=ServiceMonitor): .spec.selector.app.kubernetes.io/instance: field not declared in schema
```

## Commentary for Reviewers

develop is correct already.

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
