### PR TITLE
fix dbConcurrentIngestionCount template issue

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -546,7 +546,7 @@ spec:
               value: {{ .Values.aggregator.dbReadThreads | quote }}
             - name: DB_WRITE_THREADS
               value: {{ .Values.aggregator.dbWriteThreads | quote }}
-            {{- if ne .Values.aggregator.dbConcurrentIngestionCount "auto" }}
+            {{- if ne (toString .Values.aggregator.dbConcurrentIngestionCount) "auto" }}
             - name: DB_CONCURRENT_INGESTION_COUNT
               value: {{ .Values.aggregator.dbConcurrentIngestionCount | quote }}
             {{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -984,8 +984,8 @@ aggregator:
 
   # How many threads to use when ingesting Asset/Allocation/CloudCost data
   # from the federated storage bucket.
-  # default: "auto" (2x the current number of cores available to the process)
-  dbConcurrentIngestionCount: "auto"
+  # default: auto (2x the current number of cores available to the process)
+  dbConcurrentIngestionCount: auto
 
   # Memory limit applied to read database and write database connections. The
   # default of "no limit" is appropriate when first establishing a baseline of


### PR DESCRIPTION
## fixes dbConcurrentIngestionCount helm templating failures
This issue was only in nightly, no release note needed.

Tested all options:
1. default
2. upgrade from default to `--set aggregator.dbConcurrentIngestionCount=10`
3. upgrade back to default
4. upgrade with hardcoded `--set aggregator.dbConcurrentIngestionCount=auto`