### PR TITLE
KCM-5560 Add kubemodel flag for aggregator

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -677,6 +677,8 @@ spec:
             - name: SAAS_DEPLOYMENT
               value: "true"
             {{- end }}
+            - name: KUBEMODEL_INGESTION_ENABLED
+              value: {{ .Values.aggregator.kubemodelIngestionEnabled | quote }}
             {{- if .Values.aggregator.extraEnv -}}
             {{- toYaml .Values.aggregator.extraEnv | nindent 12 }}
             {{- end }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1082,7 +1082,9 @@ aggregator:
     failureThreshold: 200
 
   ## Set additional environment variables for the aggregator pod
-  extraEnv: []
+  extraEnv:
+    - name: KUBEMODEL_INGESTION_ENABLED
+      value: "false"
   # - name: SOME_VARIABLE
   #   value: "some_value"
 

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1081,10 +1081,11 @@ aggregator:
     periodSeconds: 10
     failureThreshold: 200
 
+  ## Enable or disable kubemodel ingestion
+  kubemodelIngestionEnabled: false
+
   ## Set additional environment variables for the aggregator pod
-  extraEnv:
-    - name: KUBEMODEL_INGESTION_ENABLED
-      value: "false"
+  extraEnv: []
   # - name: SOME_VARIABLE
   #   value: "some_value"
 


### PR DESCRIPTION
Add kubemodel flag (off by default) to enable the flag to be flipped in a future release.
Also, this will allow us to test the kubemodel when deploying with helm for integration tests