### PR TITLE
Removes "auto" dbConcurrentIngestionCount for v3.2 release.

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -559,10 +559,8 @@ spec:
               value: {{ .Values.aggregator.dbReadThreads | quote }}
             - name: DB_WRITE_THREADS
               value: {{ .Values.aggregator.dbWriteThreads | quote }}
-            {{- if ne (toString .Values.aggregator.dbConcurrentIngestionCount) "auto" }}
             - name: DB_CONCURRENT_INGESTION_COUNT
               value: {{ .Values.aggregator.dbConcurrentIngestionCount | quote }}
-            {{- end }}
             {{- if ne .Values.aggregator.dbMemoryLimit "0GB" }}
             - name: DB_MEMORY_LIMIT
               value: {{ .Values.aggregator.dbMemoryLimit | quote }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -984,8 +984,8 @@ aggregator:
 
   # How many threads to use when ingesting Asset/Allocation/CloudCost data
   # from the federated storage bucket.
-  # default: auto (2x the current number of cores available to the process)
-  dbConcurrentIngestionCount: auto
+  # default: 1
+  dbConcurrentIngestionCount: 1
 
   # Memory limit applied to read database and write database connections. The
   # default of "no limit" is appropriate when first establishing a baseline of


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
N/A

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
- Removes "auto" dbConcurrentIngestionCount for v3.2 release.
- This change remains on the "develop" branch, and will be picked up in the v3.3 release.

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Reverts https://github.com/kubecost/kubecost/pull/4647

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
N/A. This config change goes back to the original default that existed in all versions prior.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
N/A

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A
