### PR TITLE
bump cluster controller to v0.16.35 for free actions

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1331,7 +1331,7 @@ clusterController:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/cluster-controller
-    tag: v0.16.34
+    tag: v0.16.35
   imagePullPolicy: IfNotPresent
   logLevel: info
   extraEnv: []


### PR DESCRIPTION
## Release Notes Headline
Bumps cluster-controller image to v0.16.35 to include free actions work
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
cluster-controller v0.16.34 -> v0.16.35
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
N/A
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
free actions now available
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Tested v0.16.35 image on a free install, actions worked as expected
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
