### PR TITLE
fix ECP set up via UI

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -276,7 +276,7 @@ enterpriseCustomPricing:
   # ConfigMap, for which we provide instructions, also below.
   enabled: false
   # To allow for setting the Enterprise Custom Pricing CSV via the UI, leave
-  # the configMapName and location fields commented out (or unset).
+  # the configMapName and location fields unset.
   #
   # Use the following command to create a ConfigMap from your pricing spec CSV.
   # You may change the ConfigMap name, or file name, as long as you set the

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -283,11 +283,11 @@ enterpriseCustomPricing:
   # correct configMapName and location.URI, respectively.
   #
   #  kubectl create configmap -n kubecost kubecost-enterprise-pricing --from-file pricing.csv
-  #
-  # configMapName: kubecost-enterprise-pricing
+  #             
+  configMapName: "" # e.g. kubecost-enterprise-pricing
   # The file name (e.g. pricing.csv) needs to match the file name used to make the ConfigMap (above)
-  # location:
-  #   URI: /var/configs/enterprise-pricing/pricing.csv
+  location:
+    URI: "" # e.g. /var/configs/enterprise-pricing/pricing.csv
 
 ## Kubecost SAML (enterprise key required)
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-user-management-saml

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -275,8 +275,8 @@ enterpriseCustomPricing:
   # requires a CSV pricing spec to be provided at the location, below, using a
   # ConfigMap, for which we provide instructions, also below.
   enabled: false
-  # To allow for setting the Enterprise Custom Pricng CSV via the UI, comment out
-  # the configMapName and location fields below.
+  # To allow for setting the Enterprise Custom Pricing CSV via the UI, leave
+  # the configMapName and location fields commented out (or unset).
   #
   # Use the following command to create a ConfigMap from your pricing spec CSV.
   # You may change the ConfigMap name, or file name, as long as you set the
@@ -284,10 +284,10 @@ enterpriseCustomPricing:
   #
   #  kubectl create configmap -n kubecost kubecost-enterprise-pricing --from-file pricing.csv
   #
-  configMapName: kubecost-enterprise-pricing
+  # configMapName: kubecost-enterprise-pricing
   # The file name (e.g. pricing.csv) needs to match the file name used to make the ConfigMap (above)
-  location:
-    URI: /var/configs/enterprise-pricing/pricing.csv
+  # location:
+  #   URI: /var/configs/enterprise-pricing/pricing.csv
 
 ## Kubecost SAML (enterprise key required)
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-user-management-saml

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -283,11 +283,11 @@ enterpriseCustomPricing:
   # correct configMapName and location.URI, respectively.
   #
   #  kubectl create configmap -n kubecost kubecost-enterprise-pricing --from-file pricing.csv
-  #             
-  configMapName: "" # e.g. kubecost-enterprise-pricing
+  #
+  configMapName: ""  # e.g. kubecost-enterprise-pricing
   # The file name (e.g. pricing.csv) needs to match the file name used to make the ConfigMap (above)
   location:
-    URI: "" # e.g. /var/configs/enterprise-pricing/pricing.csv
+    URI: ""  # e.g. /var/configs/enterprise-pricing/pricing.csv
 
 ## Kubecost SAML (enterprise key required)
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-user-management-saml


### PR DESCRIPTION
## Release Notes Headline
N/A
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
`enterpriseCustomPricing.configMapName` and `enterpriseCustomPricing.location.URI` were pre-populated, which would cause their values to be persisted even if the user only supplied `enterpriseCustomPricing.enabled = true` when intending to configure ECP via the UI.  This would result in mount failures since the user should not need to create a configmap via the k8s API, but the statefulset expects it anyway. This would lead to the aggregator pod to never starting.
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-5776
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
Users will need to do slightly more set up in helm if they want ECP via helm. They will need to provide a configMapName and a location URI. No risks
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Tested on a replicated cluster. Performed a helm upgrade with the new values.yaml, when ECP is enabled aggregator pod spins up as expected, with no mount errors
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
