### PR TITLE
bump agent to 1.0.18

### DIFF
--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
-  version: 1.0.17
-digest: sha256:e80a612c06eb7cde0046d03598cd41a4d5121981b306d2a3ccad041327051f2a
-generated: "2026-05-06T13:01:57.480109-04:00"
+  version: 1.0.18
+digest: sha256:145e2a031af0677c44bdb9ed023ee75fda8b27a0f88b23d74bdf1ce13dd4ad8f
+generated: "2026-05-19T16:22:09.559541-04:00"

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -11,6 +11,6 @@ annotations:
 dependencies:
   - name: finops-agent
     alias: finopsagent
-    version: "v1.0.17"
+    version: "v1.0.18"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finopsagent.enabled


### PR DESCRIPTION
## Release Notes Headline

Update finops agent to 1.0.18
https://github.com/kubecost/ibm-finops-agent/releases/tag/v1.0.18

## Commentary for Reviewers

FIxes certain negative resouce calculations

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

updated agent on two clusters and logs are clean.

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
