### PR TITLE
Add free actions key config check

### DIFF
--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -7,6 +7,7 @@
 {{- include "kubecost.clusterId.check" . -}}
 {{- include "kubecost.caCertsSecretConfig.check" . -}}
 {{- include "kubecost.actionsStorageSourceCheck" . -}}
+{{- include "kubecost.freeActionsSigningKeyCheck" . -}}
 {{- include "kubecost.finopsagentCheck" . -}}
 {{- include "kubecost.cloudCost.persistentStorage.check" . -}}
 {{- include "kubecost.aggregator.storageCheck" . -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -257,6 +257,13 @@ Free Actions validation check. Ensures that a signing key is properly configured
     {{- if or (not $rsaEnabled) (not $rsaPrivateKeySecret) -}}
       {{- fail "\nActions is enabled on free-tier. Either provide an RSA signing key pair under kubecostProductConfigs.actions.signing.rsa and clusterController.signing.rsa or configure an enterprise v2 license." -}}
     {{- end -}}
+    {{- if (.Values.clusterController).enabled -}}
+      {{- $clusterControllerRSAEnabled := (((.Values.clusterController).signing).rsa).enabled -}}
+      {{- $clusterControllerRSAPublicKeySecret := (((.Values.clusterController).signing).rsa).publicKeySecret -}}
+      {{- if or (not $clusterControllerRSAEnabled) (not $clusterControllerRSAPublicKeySecret) -}}
+        {{- fail "\nActions is enabled on free-tier and clusterController is enabled. You must configure the cluster controller RSA public key under clusterController.signing.rsa." -}}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -247,6 +247,19 @@ Actions Storage source contents check. Either the Secret must be specified or th
   {{- end -}}
 {{- end -}}
 
+{{/*
+Free Actions validation check. Ensures that a signing key is properly configured.
+*/}}
+{{- define "kubecost.freeActionsSigningKeyCheck" -}}
+  {{- if and (not (.Values.kubecostProductConfigs.productKey).enabled) ((.Values.kubecostProductConfigs.actions).enabled) -}}
+    {{- $rsaEnabled := (((.Values.kubecostProductConfigs.actions).signing).rsa).enabled -}}
+    {{- $rsaPrivateKeySecret := (((.Values.kubecostProductConfigs.actions).signing).rsa).privateKeySecret -}}
+    {{- if or (not $rsaEnabled) (not $rsaPrivateKeySecret) -}}
+      {{- fail "\nActions is enabled on free-tier. Either provide an RSA signing key pair under kubecostProductConfigs.actions.signing.rsa and clusterController.signing.rsa or configure an enterprise v2 license." -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "kubecost.clusterId" }}
   {{- if ((((.Values.prometheus).server).global).external_labels).cluster_id }}
     {{- .Values.prometheus.server.global.external_labels.cluster_id }}


### PR DESCRIPTION
## Release Notes Headline
N/A changes unreleased

## Commentary for Reviewers
Simple check to make sure an RSA key is configured when free actions is enabled, as without it the actions service will fail to start, causing UI issues.

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-5800

## User Impact and Risks
Users should not be able to forget to configure a signing key for at least the aggregator, as again doing so will cause certain pages to not render due to 500 errors.

## Testing
Tested using helm template.

## Documentation Updates
