### PR TITLE
fix: confusing wording in agent config readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -30,23 +30,9 @@ Consider installing agents first, as the UI will not have value until there is d
 Kubecost 3.x architecture was designed to allow for a single agent configuration to be pushed to all clusters including the primary.
 This is not required, and users can continue to use the same design as previous versions.
 
-When using a global agent configuration, the agent should be installed to a different namespace than is used for the primary cluster.
+When using a global agent configuration, the agent should be installed to a different namespace or Helm release name than is used for the primary cluster.
 
-Agent only configurations:
-
-- [AWS](./agentOnly/helmValues-kubecost-aws.yaml)
-- [Azure](./agentOnly/helmValues-kubecost-azure.yaml)
-- [GCP](./agentOnly/helmValues-kubecost-gcp.yaml)
-
-When you have your customized values, use the `-f` flag to pass them to the helm install command:
-
-```bash
-helm install kubecost-agent \
-  --repo https://kubecost.github.io/kubecost/ kubecost \
-  --namespace kubecost-agent \
-  --create-namespace \
-  -f helmValues-kubecost-agentOnly.yaml
-```
+[Agent configuration guide](agentOnly/README.md)
 
 ### Primary Cluster
 

--- a/examples/agentOnly/README.md
+++ b/examples/agentOnly/README.md
@@ -8,9 +8,9 @@ The multiple examples here are due to the difference in the object-storage confi
 
 ## Agent only configurations
 
-- [AWS](./agentOnly/helmValues-kubecost-aws.yaml)
-- [Azure](./agentOnly/helmValues-kubecost-azure.yaml)
-- [GCP](./agentOnly/helmValues-kubecost-gcp.yaml)
+- [AWS](./helmValues-kubecost-aws.yaml)
+- [Azure](./helmValues-kubecost-azure.yaml)
+- [GCP](./helmValues-kubecost-gcp.yaml)
 
 After customizing the values, use the `-f` flag to pass them to the helm install command:
 

--- a/examples/agentOnly/README.md
+++ b/examples/agentOnly/README.md
@@ -1,0 +1,23 @@
+# Agent Only Configuration
+
+This configuration is for running the finops-agent only. To install a Primary, follow [this guide](../README.md#primary-cluster)
+
+With the exception of the `clusterId`, the agent configuration can be identical for all clusters, even in multi-cluster environments.
+
+The multiple examples here are due to the difference in the object-storage configuration.
+
+## Agent only configurations
+
+- [AWS](./agentOnly/helmValues-kubecost-aws.yaml)
+- [Azure](./agentOnly/helmValues-kubecost-azure.yaml)
+- [GCP](./agentOnly/helmValues-kubecost-gcp.yaml)
+
+After customizing the values, use the `-f` flag to pass them to the helm install command:
+
+```bash
+helm install kubecost-agent \
+  --repo https://kubecost.github.io/kubecost/ kubecost \
+  --namespace kubecost-agent \
+  --create-namespace \
+  -f helmValues-kubecost-agentOnly.yaml
+```

--- a/examples/agentOnly/helmValues-kubecost-aws.yaml
+++ b/examples/agentOnly/helmValues-kubecost-aws.yaml
@@ -3,8 +3,9 @@ global:
   ## when using the same cluster names in different regions, we suggest appending the region to the clusterId
   clusterId: globally-unique-cluster-id
   federatedStorage:
-    # A federated storage config can be provided via an existingSecret or via a string in helm values.
-    # If both are provided, the string in helm values take precedence.
+    ## Use the existingSecret when a access key and secret is used to access the federated storage.
+    ## the 'config' can be used when using assumed roles.
+    ## when using the 'existingSecret' the 'config' should be commented out
     existingSecret: ""
     config: |-
       type: S3

--- a/examples/agentOnly/helmValues-kubecost-azure.yaml
+++ b/examples/agentOnly/helmValues-kubecost-azure.yaml
@@ -5,6 +5,7 @@ global:
   federatedStorage:
     ## Use the existingSecret when a access key and secret is used to access the federated storage.
     ## the 'config' can be used when using assumed roles.
+    ## when using the 'existingSecret' the 'config' should be commented out    
     existingSecret: ""
     config: |-
       type: AZURE

--- a/examples/agentOnly/helmValues-kubecost-gcp.yaml
+++ b/examples/agentOnly/helmValues-kubecost-gcp.yaml
@@ -5,13 +5,14 @@ global:
   federatedStorage:
     ## Use the existingSecret when a access key and secret is used to access the federated storage.
     ## the 'config' can be used when using assumed roles.
+    ## when using the 'existingSecret' the 'config' should be commented out    
     existingSecret: ""
     config: |-
       type: GCS
       config:
         bucket: kubecost-federated-storage
   cspPricingApiKey:
-    ## When using GCP, an API key to access on-demand pricing is required.
+    ## When using GCP, an API key is used to access on-demand pricing. It is not required- default pricing will be used until GCP billing is available.
     ## use the apiKey OR the secret.
     ## A secret is recommended- though the apiKey is can be a read only service account exclusively for downloading public pricing data.
     apiKey: ""


### PR DESCRIPTION
## fix confusing wording in agent config readme

Updated due to feedback on the different configurations needed for using multiple providers.