### PR TITLE
KCM-5021: Add service account annotation documentation for cluster controller

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1314,11 +1314,11 @@ cloudCost:
 ##
 clusterController:
   enabled: true
-  
+
   serviceAccount:
     ## @param clusterController.serviceAccount.create Whether to create a service account for cluster controller
     create: true
-    
+
     ## @param clusterController.serviceAccount.annotations Annotations for the cluster controller service account
     ## Configure cloud provider authentication for federated storage access:
     ##   AWS:   eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
@@ -1427,7 +1427,7 @@ reporting:
 serviceAccount:
   create: true  # Set this to false if you're bringing your own service account.
   ## @param serviceAccount.annotations Annotations for the service account
-  ## 
+  ##
   ## Configure cloud provider authentication for accessing federated object storage.
   ## These annotations are applied to all service accounts unless overridden by
   ## component-specific annotations (e.g., clusterController.serviceAccount.annotations).

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1314,8 +1314,17 @@ cloudCost:
 ##
 clusterController:
   enabled: true
+  
   serviceAccount:
+    ## @param clusterController.serviceAccount.create Whether to create a service account for cluster controller
     create: true
+    
+    ## @param clusterController.serviceAccount.annotations Annotations for the cluster controller service account
+    ## Configure cloud provider authentication for federated storage access:
+    ##   AWS:   eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
+    ##   GCP:   iam.gke.io/gcp-service-account: SA_NAME@PROJECT_ID.iam.gserviceaccount.com
+    ##   Azure: azure.workload.identity/client-id: CLIENT_ID
+    ## Falls back to global serviceAccount.annotations if not set.
     annotations: {}
 
   ## Enables legacy mode for cluster controller actions (v1)
@@ -1417,6 +1426,24 @@ reporting:
 
 serviceAccount:
   create: true  # Set this to false if you're bringing your own service account.
+  ## @param serviceAccount.annotations Annotations for the service account
+  ## 
+  ## Configure cloud provider authentication for accessing federated object storage.
+  ## These annotations are applied to all service accounts unless overridden by
+  ## component-specific annotations (e.g., clusterController.serviceAccount.annotations).
+  ##
+  ## AWS (IAM Roles for Service Accounts):
+  ##   annotations:
+  ##     eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
+  ##
+  ## GCP (Workload Identity):
+  ##   annotations:
+  ##     iam.gke.io/gcp-service-account: SA_NAME@PROJECT_ID.iam.gserviceaccount.com
+  ##
+  ## Azure (Workload Identity):
+  ##   annotations:
+  ##     azure.workload.identity/client-id: CLIENT_ID
+  ##
   annotations: {}
 
 ## Kubecost Admission Controller (beta feature)


### PR DESCRIPTION
## Release Notes Headline

Add inline documentation for configuring cloud provider authentication on cluster controller service account.

## Commentary for Reviewers

This PR adds documentation for service account annotations used to configure cloud provider authentication (AWS IRSA, GCP Workload Identity, Azure Workload Identity) for the cluster controller's access to federated storage.

Key changes:
- Added comprehensive cloud auth examples to parent `.Values.serviceAccount.annotations` (~15 lines)
- Added compact reference in `.Values.clusterController.serviceAccount.annotations` (4 lines)
- Removed verbose README section in favor of inline values.yaml documentation
- Architecture: parent provides detailed examples, component-specific uses compact format

## Links to Issues or Tickets

https://apptio.atlassian.net/browse/KCM-5021

## User Impact and Risks

**Impact:** Documentation-only change. Users can now discover how to configure cloud authentication directly in values.yaml.

**Risks:** None. No code changes, no template changes, no default behavior changes.

## Testing

Validated with helm template tests:
```bash
helm template kubecost ./kubecost \
  --set clusterController.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::123456789012:role/test"
```

Confirmed annotations properly applied to cluster controller service account.

## Documentation Updates

N/A - This PR is the documentation update.