### PR TITLE
Bump cluster controller image version to 0.16.36

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1331,7 +1331,7 @@ clusterController:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/cluster-controller
-    tag: v0.16.35
+    tag: v0.16.36
   imagePullPolicy: IfNotPresent
   logLevel: info
   extraEnv: []


### PR DESCRIPTION
## Release Notes Headline

Bump cluster controller image version to 0.16.36

## Commentary for Reviewers

Bump cluster controller image version to 0.16.36

## Links to Issues or Tickets

N/A

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A
