### PR TITLE
Configurable ECP Retroactive Pricing

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -661,7 +661,7 @@ spec:
               value: {{ (quote .Values.enterpriseCustomPricing.location.URI) }}
             {{- end }}
             - name: ENTERPRISE_CUSTOM_PRICING_APPLY_RETROACTIVELY
-              value: "true"
+              value: {{ .Values.enterpriseCustomPricing.applyRetroactively | quote }}
             {{- end }}
             {{- if ((.Values.kubecostProductConfigs).actions).enabled }}
             - name: ACTIONS_ENABLED

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -288,6 +288,9 @@ enterpriseCustomPricing:
   # The file name (e.g. pricing.csv) needs to match the file name used to make the ConfigMap (above)
   location:
     URI: ""  # e.g. /var/configs/enterprise-pricing/pricing.csv
+  # When true (default), custom pricing is applied retroactively to historical
+  # data. Set to false to apply custom pricing only going forward.
+  applyRetroactively: true
 
 ## Kubecost SAML (enterprise key required)
 ## Ref: https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-user-management-saml


### PR DESCRIPTION
## Release Notes Headline
* Retroactive pricing in Enterprise Custom Pricing can now be toggled via Helm.

## Commentary for Reviewers
* Simply replaces a hardcoded "true" with a configurable value.

## Links to Issues or Tickets
* N/A.

## User Impact and Risks
* No risks, default behavior is the same.

## Testing
* TBD.

## Documentation Updates
* We'll need doc updates to include this new value.
