### PR TITLE
Define cluster/turndown endpoint with 404

### DIFF
--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -205,6 +205,10 @@ data:
             {{- end }}
         }
 
+        location ~ ^/(turndown|cluster)/ {
+          return 404;
+        }
+
     {{- if .Values.oidc.enabled }}
         location /oidc/ {
             proxy_connect_timeout       180;


### PR DESCRIPTION
## Release Notes Headline
N/A - fixes a bug that only exists in a release candidate.

## Commentary for Reviewers
In previous pull request #4701, I cleaned up unused references to cluster-controller "legacy" mode in the helm chart, and made a mistake.

In [this block](https://github.com/kubecost/kubecost/pull/4701/changes#diff-a0c125c6b1c193673efb233a23532f720fb378a53a7ac5144a7548cc7ba2e5b7L222-L251), all non-legacy-mode paths lead to the endpoints returning 404, which I thought would be the same as simply not defining the endpoints. That is not the case! Endpoints which are undefined fall back to serving `index.html`. So, the UI was expecting a 404 to know that we were not operating in legacy mode, but instead it was getting a "200 OK" with html content.

This change re-defines the endpoint, and it simply always returns a 404 Not Found.

## Links to Issues or Tickets

N/A

## User Impact and Risks

N/A

## Testing

Deployed these changes against an Actions environment set up by @LastJedionEarth and saw the Actions page return to life.

## Documentation Updates

N/A
